### PR TITLE
Get Blade Stealth serial number from DMI table

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -26,6 +26,7 @@
 #include <linux/init.h>
 #include <linux/usb/input.h>
 #include <linux/hid.h>
+#include <linux/dmi.h>
 
 #include "razerkbd_driver.h"
 #include "razercommon.h"
@@ -110,10 +111,8 @@ void razer_get_serial(struct usb_device *usb_dev, unsigned char* serial_string)
     
     if(usb_dev->descriptor.idProduct == USB_DEVICE_ID_RAZER_BLADE_STEALTH)
     {
-        // Stealth does not have serial
-        for(i = 0; i < 15; ++i) {
-            serial_string[i] = 'X';
-        }
+        // Stealth does not have serial via USB, so get it from DMI table
+        strcpy(serial_string, dmi_get_system_info(DMI_PRODUCT_SERIAL));
     } else
     {
         // Get serial


### PR DESCRIPTION
I noticed there's a good alternate way to get a serial number for the Stealth, via DMI. I don't know if there are drawbacks to a dependency on DMI, or if there's any other reason not to do it this way?

Tested and works on 4.4.0-17-generic / Ubuntu 16.04.
