### PR TITLE
Use consistent device friendly names in daemon.

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -252,7 +252,7 @@ static ssize_t razer_attr_read_device_type(struct device *dev, struct device_att
     switch (usb_dev->descriptor.idProduct)
     {
         case USB_DEVICE_ID_RAZER_BLACKWIDOW_ORIGINAL:
-            device_type = "Razer BlackWidow Original\n";
+            device_type = "Razer BlackWidow Classic\n";
             break;
 
         case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2012:
@@ -272,7 +272,7 @@ static ssize_t razer_attr_read_device_type(struct device *dev, struct device_att
             break;
 
         case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
-            device_type = "New Razer Blade Stealth (Late 2016)\n";
+            device_type = "Razer Blade Stealth (Late 2016)\n";
             break;
         
         case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -125,15 +125,15 @@ static ssize_t razer_attr_read_device_type(struct device *dev, struct device_att
             break;
         
         case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
-            device_type = "Razer Mamba TE\n";
+            device_type = "Razer Mamba Tournament Edition\n";
             break;
 
         case USB_DEVICE_ID_RAZER_ABYSSUS:
-            device_type = "Razer Abyssus\n";
+            device_type = "Razer Abyssus 2014\n";
             break;
         
         case USB_DEVICE_ID_RAZER_IMPERATOR:
-            device_type = "Razer Imperator\n";
+            device_type = "Razer Imperator 2012\n";
             break;
         
         case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
@@ -141,7 +141,7 @@ static ssize_t razer_attr_read_device_type(struct device *dev, struct device_att
             break;
 
         default:
-            device_type = "Unknown\n";
+            device_type = "Unknown Device\n";
     }
 
     return sprintf(buf, device_type);


### PR DESCRIPTION
A simple change where the driver uses the same "friendly device names" from README. This is also to ensure consistency for the front-end apps.