### PR TITLE
Added note for the universe repository requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,6 +291,7 @@
                     <pre><code><span class="fa fa-dollar"></span> sudo add-apt-repository ppa:terrz/razerutils</code>
 <code><span class="fa fa-dollar"></span> sudo apt update</code>
 <code><span class="fa fa-dollar"></span> sudo apt install python3-razer razer-kernel-modules-dkms razer-daemon razer-doc</code></pre>
+		    <p><strong>NOTE:</strong> If you get dependency errors when trying to install the driver packages please make sure that you have enabled the "universe" repository in <strong>Software & Updates</strong></p>
 
                     <p>After installing the driver, you should <u>restart the computer</u> or probe it from the terminal:</p>
                     <pre><code><span class="fa fa-dollar"></span> sudo modprobe razerkbd</code></pre>


### PR DESCRIPTION
I have added a note at the installation instructions for Ubuntu/Linux
Mint that you need to enable "universe" repository for the package
installation to be succesfull.