### PR TITLE
Implements CMakeLists.txt so CLion can compile and analyze code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,18 @@
 *.x86_64
 *.hex
 
+# kdevelop files
+.kdev4/*
+*.kdev4
+
+# vim temp files
+*.un~
+*~
+*.swp
+
+# clion files
+cmake-build-debug/*
+
 # Cached/Pre-compiled Python files
 *.pyc
 __pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,139 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(razer-drivers)
+
+set(SOURCES
+        driver/razermouse_driver.c
+        driver/razerfirefly_driver.c
+        driver/razerkbd_driver.c
+        driver/razercommon.c
+        driver/razerchromacommon.c
+)
+
+set(HEADERS
+        driver/razermouse_driver.h
+        driver/razerfirefly_driver.h
+        driver/razerkbd_driver.h
+        driver/razercommon.h
+        driver/razerchromacommon.h
+)
+
+set(TARGET_VARS
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+)
+
+execute_process(COMMAND uname -r
+        OUTPUT_VARIABLE INSTALLED_KERNEL
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+set(LINUX_KERNEL_PATH /usr/lib/modules/${INSTALLED_KERNEL})
+include_directories(${LINUX_KERNEL_PATH}/build/include
+    ${LINUX_KERNEL_PATH}/build/arch/x86/include
+)
+
+# Build all target
+add_custom_target(All # all is reserved
+        COMMAND make all
+        ${TARGET_VARS}
+)
+add_custom_target(build-lp-all
+        COMMAND make lp_all
+        ${TARGET_VARS}
+)
+
+# Driver compilation
+add_custom_target(driver
+        COMMAND make driver
+        ${TARGET_VARS}
+)
+add_custom_target(driver-verbose
+        COMMAND make driver_verbose
+        ${TARGET_VARS}
+)
+add_custom_target(driver-clean
+        COMMAND make driver_clean
+        ${TARGET_VARS}
+)
+# Install kernel modules and then update module dependencies
+add_custom_target(driver-install
+        COMMAND make driver_install
+        ${TARGET_VARS}
+)
+# Remove kernel modules
+add_custom_target(driver-uninstall
+        COMMAND make driver_uninstall
+        ${TARGET_VARS}
+)
+
+# Launchpad hacks
+add_custom_target(lp-driver
+        COMMAND make lp_driver
+        ${TARGET_VARS}
+)
+add_custom_target(lp-driver-clean
+        COMMAND make lp_driver_clean
+        ${TARGET_VARS}
+)
+
+# Razer Daemon
+add_custom_target(daemon-install
+        COMMAND make daemon_install
+        ${TARGET_VARS}
+)
+add_custom_target(daemon-uninstall
+        COMMAND make daemon_uninstall
+        ${TARGET_VARS}
+)
+
+# Python Library
+add_custom_target(python-library-install
+        COMMAND make python_library_install
+        ${TARGET_VARS}
+)
+add_custom_target(python-library-uninstall
+        COMMAND make python_library_uninstall
+        ${TARGET_VARS}
+)
+
+# Clean target
+add_custom_target(Clean # clean is reserved
+        COMMAND make clean
+        ${TARGET_VARS}
+)
+
+add_custom_target(setup-dkms
+        COMMAND make setup_dkms
+        ${TARGET_VARS}
+)
+
+add_custom_target(udev-install
+        COMMAND make udev_install
+        ${TARGET_VARS}
+)
+add_custom_target(udev-uninstall
+        COMMAND make udev_uninstall
+        ${TARGET_VARS}
+)
+
+# Install for Ubuntu
+add_custom_target(ubuntu-install
+        COMMAND make ubuntu_install
+        ${TARGET_VARS}
+)
+
+add_custom_target(fedora-install
+        COMMAND make fedora_install
+        ${TARGET_VARS}
+)
+
+add_custom_target(Install # install is reserved
+        COMMAND make install
+        ${TARGET_VARS}
+)
+add_custom_target(Uninstall # uninstall is reserved
+        COMMAND make uninstall
+        ${TARGET_VARS}
+)
+
+add_executable(FakeTarget ${HEADERS} ${SOURCES}) # fake target so kernel includes are found for autocompletion
+
+target_compile_definitions(FakeTarget PUBLIC __KERNEL__=1)

--- a/driver/razerfirefly_driver.c
+++ b/driver/razerfirefly_driver.c
@@ -60,9 +60,9 @@ struct razer_report razer_send_payload(struct usb_device *usb_dev, struct razer_
 	int retval = -1;
     struct razer_report response_report;
     
-    request_report->crc = razer_calculate_crc(request_report);
+	request_report->crc = razer_calculate_crc(request_report);
 
-    retval = razer_get_report(usb_dev, request_report, &response_report);
+	retval = razer_get_report(usb_dev, request_report, &response_report);
 
     if(retval == 0)
     {
@@ -485,8 +485,8 @@ static int razer_firefly_probe(struct hid_device *hdev, const struct hid_device_
         goto exit_free;
 
     hid_set_drvdata(hdev, dev);
-
-
+	
+	
     retval = hid_parse(hdev);
     if(retval)    {
         hid_err(hdev, "parse failed\n");
@@ -497,8 +497,8 @@ static int razer_firefly_probe(struct hid_device *hdev, const struct hid_device_
         hid_err(hdev, "hw start failed\n");
         goto exit_free;
     }
-
-
+	
+	
     usb_disable_autosuspend(usb_dev);
     return 0;
 exit:


### PR DESCRIPTION
CLion currently doesn't directly support make. I have to wrap the make commands in CMake to use the Linux kernel build system. I'm including a FakeTarget, which allows for code completion and analysis, and custom targets that just call the various make build options. I'm mainly doing this since I'm used to programming in CLion and was having some workflow issues with features missing from kdevelop. Overall everything builds correctly with some false positives for unresolved macros when CLion analyzes code.