### PR TITLE
[WIP] udev location change to /usr/lib/udev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ ubuntu_udev_uninstall:
 	rm -f $(DESTDIR)/lib/udev/rules.d/99-razer.rules $(DESTDIR)/lib/udev/razer_mount
 
 # Install for Ubuntu
-ubuntu_install: setup_dkms udev_install daemon_install python_library_install
+ubuntu_install: setup_dkms ubuntu_udev_install daemon_install python_library_install
 	@echo -e "\n::\033[34m Installing for Ubuntu\033[0m"
 	@echo "====================================================="
 

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,17 @@ udev_uninstall:
 	@echo "====================================================="
 	rm -f $(DESTDIR)/usr/lib/udev/rules.d/99-razer.rules $(DESTDIR)/usr/lib/udev/razer_mount
 
+ubuntu_udev_install:
+	@echo -e "\n::\033[34m Installing Razer udev rules\033[0m"
+	@echo "====================================================="
+	install -m 644 -v -D install_files/udev/99-razer.rules $(DESTDIR)/lib/udev/rules.d/99-razer.rules
+	install -m 755 -v -D install_files/udev/razer_mount $(DESTDIR)/lib/udev/razer_mount
+
+ubuntu_udev_uninstall:
+	@echo -e "\n::\033[34m Uninstalling Razer udev rules\033[0m"
+	@echo "====================================================="
+	rm -f $(DESTDIR)/lib/udev/rules.d/99-razer.rules $(DESTDIR)/lib/udev/razer_mount
+
 # Install for Ubuntu
 ubuntu_install: setup_dkms udev_install daemon_install python_library_install
 	@echo -e "\n::\033[34m Installing for Ubuntu\033[0m"

--- a/Makefile
+++ b/Makefile
@@ -122,13 +122,13 @@ remove_dkms:
 udev_install:
 	@echo -e "\n::\033[34m Installing Razer udev rules\033[0m"
 	@echo "====================================================="
-	install -m 644 -v -D install_files/udev/99-razer.rules $(DESTDIR)/lib/udev/rules.d/99-razer.rules
-	install -m 755 -v -D install_files/udev/razer_mount $(DESTDIR)/lib/udev/razer_mount
+	install -m 644 -v -D install_files/udev/99-razer.rules $(DESTDIR)/usr/lib/udev/rules.d/99-razer.rules
+	install -m 755 -v -D install_files/udev/razer_mount $(DESTDIR)/usr/lib/udev/razer_mount
 
 udev_uninstall:
 	@echo -e "\n::\033[34m Uninstalling Razer udev rules\033[0m"
 	@echo "====================================================="
-	rm -f $(DESTDIR)/lib/udev/rules.d/99-razer.rules $(DESTDIR)/lib/udev/razer_mount
+	rm -f $(DESTDIR)/usr/lib/udev/rules.d/99-razer.rules $(DESTDIR)/usr/lib/udev/razer_mount
 
 # Install for Ubuntu
 ubuntu_install: setup_dkms udev_install daemon_install python_library_install


### PR DESCRIPTION
- [x] Makefile: Change udev `/lib` to `/usr/lib` as udev wants the files there (most distros have it symlinked, only Ubuntu wants it in `/lib`)
- [x] Makefile: Add an additional target for Ubuntu udev (change `/usr/lib` -> `/lib`)
- [x] Makefile: Modify `ubuntu_install` target to use new udev target

Still has to be tested.