### PR TITLE
Add Custom Effect support for Chroma Mug Holder

### DIFF
--- a/install_files/udev/99-razer.rules
+++ b/install_files/udev/99-razer.rules
@@ -20,7 +20,8 @@ ATTRS{idProduct}=="0c00", \
 ATTRS{idProduct}=="0504|0510", \
     ENV{ID_RAZER_CHROMA}="1", ENV{RAZER_DRIVER}="razerkraken"
 
-ATTRS{idProduct}=="0F07", \
+# Razer Mug
+ATTRS{idProduct}=="0f07", \
     ENV{ID_RAZER_CHROMA}="1", ENV{RAZER_DRIVER}="razermug"
 
 # Get out if no match


### PR DESCRIPTION
Chroma Mug Holder works just like Firefly in its custom effect support.  If you use CreateMousepadEffect in the Chroma SDK, that will drive both Firefly and Mug Holder.  That means it has 15 LED zones and responds to the same custom effect code that Firefly does.  I've copied the firefly code for custom effects and pasted it into the mug holder driver.

I also fixed the capital letter in the udev rule.  It wasn't auto-detecting the mug.  Eventually found out it's installing to /usr/lib/udev/rules.d rather than /lib/udev/rules.d and Ubuntu 16.10 seems not to like this.  I have not changed anything with this path but it's something to keep in mind.  I manually copied the files from /usr/lib/udev to /lib/udev and it works.