### PR TITLE
Allow setting a custom effect on Mamba TE

### DIFF
--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -876,6 +876,10 @@ static ssize_t razer_attr_write_set_key_row(struct device *dev, struct device_at
 				report = razer_chroma_standard_matrix_set_custom_frame(row_id, start_col, stop_col, (unsigned char*)&buf[offset]);
 				report.transaction_id.id = 0x80;
 				break;
+			
+			case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
+				report = razer_chroma_misc_one_row_set_custom_frame(start_col, stop_col, (unsigned char*)&buf[offset]);
+				break;
 		}
         razer_send_payload(usb_dev, &report);
         


### PR DESCRIPTION
This fixes a small issue introduced in version 1.1.6 - it was not possible to set a custom effect on Mamba Tournament Edition (wired).

At first I have tried copying the Mamba Wireless case - calling `razer_chroma_standard_matrix_set_custom_frame` with `report.transaction_id.id = 0x80`, but it did not work - some error messages appeared in dmesg.

So I used the same call as in the previous version and it works okay.