### PR TITLE
Add custom effect for Kraken Chroma v1 and v2

### DIFF
--- a/driver/razerkraken_driver.c
+++ b/driver/razerkraken_driver.c
@@ -308,15 +308,18 @@ static ssize_t razer_attr_write_mode_none(struct device *dev, struct device_attr
 static ssize_t razer_attr_write_mode_static(struct device *dev, struct device_attribute *attr, const char *buf, size_t count)
 {
     struct razer_kraken_device *device = dev_get_drvdata(dev);
-    struct razer_kraken_request_report rgb_report = get_kraken_request_report(0x04, 0x40, 0x03, device->breathing_address[0]);
+    struct razer_kraken_request_report rgb_report = get_kraken_request_report(0x04, 0x40, count, device->breathing_address[0]);
     struct razer_kraken_request_report effect_report = get_kraken_request_report(0x04, 0x40, 0x01, device->led_mode_address);
     union razer_kraken_effect_byte effect_byte = get_kraken_effect_byte();
     
-    if(count == 3) {
-		
+    if(count == 3 || count == 4) {
+
 		rgb_report.arguments[0] = buf[0];
 		rgb_report.arguments[1] = buf[1];
 		rgb_report.arguments[2] = buf[2];
+        if(count == 4) {
+            rgb_report.arguments[3] = buf[3];
+        }
 		
 		// ON/Static
 		effect_byte.bits.on_off_static = 1;
@@ -329,8 +332,49 @@ static ssize_t razer_attr_write_mode_static(struct device *dev, struct device_at
 		razer_kraken_send_control_msg(device->usb_dev, &effect_report, 0);
 		mutex_unlock(&device->lock);
 	
-    } else {
-		printk(KERN_WARNING "razerkraken: Static mode only accepts RGB (3byte)\n");
+    }
+    else {
+		printk(KERN_WARNING "razerkraken: Static mode only accepts RGB (3byte) or RGB with intensity (4byte)\n");
+	}
+
+    return count;
+}
+
+/**
+ * Write device file "mode_custom"
+ *
+ * Custom effect mode is activated whenever the file is written to with 3 bytes
+ */
+static ssize_t razer_attr_write_mode_custom(struct device *dev, struct device_attribute *attr, const char *buf, size_t count)
+{
+    struct razer_kraken_device *device = dev_get_drvdata(dev);
+    struct razer_kraken_request_report rgb_report = get_kraken_request_report(0x04, 0x40, count, device->custom_address);
+    struct razer_kraken_request_report effect_report = get_kraken_request_report(0x04, 0x40, 0x01, device->led_mode_address);
+    union razer_kraken_effect_byte effect_byte = get_kraken_effect_byte();
+    
+    if(count == 3 || count == 4) {
+
+		rgb_report.arguments[0] = buf[0];
+		rgb_report.arguments[1] = buf[1];
+		rgb_report.arguments[2] = buf[2];
+        if(count == 4) {
+            rgb_report.arguments[3] = buf[3];
+        }
+		
+		// ON/Static
+		effect_byte.bits.on_off_static = 1;
+		effect_report.arguments[0] = 1;//effect_byte.value;
+		
+		// Lock sending of the 2 commands
+		mutex_lock(&device->lock);
+		razer_kraken_send_control_msg(device->usb_dev, &rgb_report, 1);
+		
+		razer_kraken_send_control_msg(device->usb_dev, &effect_report, 1);
+		mutex_unlock(&device->lock);
+	
+    }
+    else {
+		printk(KERN_WARNING "razerkraken: Static mode only accepts RGB (3byte) or RGB with intensity (4byte)\n");
 	}
 
     return count;
@@ -345,6 +389,17 @@ static ssize_t razer_attr_read_mode_static(struct device *dev, struct device_att
 {
 	struct razer_kraken_device *device = dev_get_drvdata(dev);
     return get_rgb_from_addr(dev, device->breathing_address[0], 0x04, buf);
+}
+
+/**
+ * Read device file "mode_custom"
+ *
+ * Returns 4 bytes for config
+ */
+static ssize_t razer_attr_read_mode_custom(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct razer_kraken_device *device = dev_get_drvdata(dev);
+    return get_rgb_from_addr(dev, device->custom_address, 0x04, buf);
 }
 
 /**
@@ -613,6 +668,7 @@ static DEVICE_ATTR(matrix_current_effect,	0440, razer_attr_read_matrix_current_e
 static DEVICE_ATTR(matrix_effect_none,      0220, NULL,                                       razer_attr_write_mode_none);
 static DEVICE_ATTR(matrix_effect_spectrum,  0220, NULL,                                       razer_attr_write_mode_spectrum);
 static DEVICE_ATTR(matrix_effect_static,    0660, razer_attr_read_mode_static,                razer_attr_write_mode_static);
+static DEVICE_ATTR(matrix_effect_custom,    0660, razer_attr_read_mode_custom,                razer_attr_write_mode_custom);
 static DEVICE_ATTR(matrix_effect_breath,    0660, razer_attr_read_mode_breath,                razer_attr_write_mode_breath);
 
 void razer_kraken_init(struct razer_kraken_device *dev, struct usb_interface *intf) {
@@ -630,12 +686,14 @@ void razer_kraken_init(struct razer_kraken_device *dev, struct usb_interface *in
     switch(dev->usb_pid) {
 		case USB_DEVICE_ID_RAZER_KRAKEN_V2:
 			dev->led_mode_address = KYLIE_SET_LED_ADDRESS;
+            dev->custom_address = KYLIE_CUSTOM_ADDRESS_START;
 			dev->breathing_address[0] = KYLIE_BREATHING1_ADDRESS_START;
 			dev->breathing_address[1] = KYLIE_BREATHING2_ADDRESS_START;
 			dev->breathing_address[2] = KYLIE_BREATHING3_ADDRESS_START;
 			break;
 		case USB_DEVICE_ID_RAZER_KRAKEN:
 			dev->led_mode_address = RAINIE_SET_LED_ADDRESS;
+            dev->custom_address = RAINIE_CUSTOM_ADDRESS_START;
 			dev->breathing_address[0] = RAINIE_BREATHING1_ADDRESS_START;
 			
 			// Get a "random" integer
@@ -679,6 +737,7 @@ static int razer_kraken_probe(struct hid_device *hdev, const struct hid_device_i
 				CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_none);            // No effect
 				CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_spectrum);        // Spectrum effect
 				CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_static);          // Static effect
+                CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_custom);          // Custom effect
 				CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_breath);          // Brething effect
 				CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_current_effect);         // Get current effect
 			    break;
@@ -731,6 +790,7 @@ static void razer_kraken_disconnect(struct hid_device *hdev)
 				device_remove_file(&hdev->dev, &dev_attr_matrix_effect_none);            // No effect
 				device_remove_file(&hdev->dev, &dev_attr_matrix_effect_spectrum);        // Spectrum effect
 				device_remove_file(&hdev->dev, &dev_attr_matrix_effect_static);          // Static effect
+                device_remove_file(&hdev->dev, &dev_attr_matrix_effect_custom);          // Custom effect
 				device_remove_file(&hdev->dev, &dev_attr_matrix_effect_breath);          // Brething effect
 				device_remove_file(&hdev->dev, &dev_attr_matrix_current_effect);         // Get current effect
 			    

--- a/driver/razerkraken_driver.h
+++ b/driver/razerkraken_driver.h
@@ -37,6 +37,7 @@ struct razer_kraken_device {
     
     // Will be set with the correct address for setting LED mode for each device
     unsigned short led_mode_address;
+    unsigned short custom_address;
     unsigned short breathing_address[3];
     
     char serial[23];
@@ -137,6 +138,9 @@ union razer_kraken_effect_byte {
 
 #define KYLIE_SET_LED_ADDRESS 0x172D
 #define RAINIE_SET_LED_ADDRESS 0x1008
+
+#define KYLIE_CUSTOM_ADDRESS_START 0x1189
+#define RAINIE_CUSTOM_ADDRESS_START 0x1189
 
 #define KYLIE_BREATHING1_ADDRESS_START 0x1741
 #define RAINIE_BREATHING1_ADDRESS_START 0x15DE


### PR DESCRIPTION
The custom effect updates the color instantaneously whereas the static effect slow-fades from the current color to the new color.  The custom effect is preferable if you're generating your own fades or patterns in a custom application and want a fast response, such as in my Keyboard Visualizer app.

This PR adds a matrix_effect_custom option that works the same way as the matrix_effect_static option does except that this time it writes to the custom color memory locations rather than the breathing/static memory locations.  In addition, I added the ability to write an optional 4th byte to these effects to control the intensity (as the format in the USB protocol is R/G/B/I for 4 bytes of data).  You can remove this change if you don't like it, I added it in because I screwed up my v2 by writing the wrong values to the register and setting the intensity to zero and I needed a way to undo it.  I figured it could be useful in general though.

Interestingly enough, this custom effect works on both the V1 and V2, despite custom effects not working with the V1 on the official SDK and Razer's official statement being that the V1 did not support custom effects due to firmware limitations.  With this code the custom effects work fine...