### PR TITLE
Rework razer-service man page

### DIFF
--- a/daemon/resources/man/razer-service.8
+++ b/daemon/resources/man/razer-service.8
@@ -1,32 +1,31 @@
-.TH "RAZER-SERVICE" 8 "2016-05-26" "Razer Service" "razer-service"
+.TH "RAZER-SERVICE" 8 "2017-02-10" "Razer Service" "razer-service"
 
-.SH "NAME"
+.SH NAME
 razer-service \- Razer Service to manage razer devices in userspace
 
-.SH "SYNOPSIS"
-.PP
-\fBrazer-service\fR [ \fB-v\fR | \fB--Bverbose\fR ] [ \fB-F\fR | \fB--foreground\fR ] [\fB--config\fR=\fIconfig_file\fR ] [ \fB--run-dir\fR=\fIrun_directory\fR ] [ \fB--log-dir\fR=\fIlog_directory\fR ] [ \fB--pid-file\fR=\fIpid_file\fR ]
+.SH SYNOPSIS
+.B razer-service
+[\fI\,OPTION\/\fR]...
 
-.SH "SUMMARY"
+.SH DESCRIPTION
+.B razer-service
+is a userspace service which is designed to be an intermediary between userspace programs and the razer drivers. It will provide some higher level functions to allow similar operation to the Windows Razer Synapse program. This service is designed to be started by xdg-autostart as a session service.
 .PP
-razer-service is a userspace service which is designed to be an intermediary between userspace programs and the razer drivers. It will provide some higher level functions to allow similar operation to the windows Razer Synapse program. This service is designed to be started by xdg-autostart as a session service.
-.PP
-The service has the functionality to sync effects between multiple devices, perform on-the-fly macro recording and playback and reimplements the
-FN+Keys logic so they work when \fBmacro_keys\fB are enabled. The service can also perform various ripple effects, it can turn off the devices when the
-screensaver is active and also optionally store key metrics to provide usage heatmaps
+The service has the functionality to sync effects between multiple devices, perform on-the-fly macro recording and playback and reimplements the FN+Keys logic so they work when \fBmacro_keys\fR are enabled. The service can also perform various ripple effects, it can turn off the devices when the screensaver is active and also optionally store key metrics to provide usage heatmaps.
 
-.SH "DOCUMENTATION"
-.PP
-The full and most up-to-date documentation can be found on our GitHub repository here
-https://github.com/terrycain/razer_drivers .
-
-.SH "OPTIONS"
+.SH OPTIONS
 .TP
 \fB-v\fR, \fB--verbose\fR
 Enable logging of DEBUG messages to the log file and screen if running in foreground mode.
 .TP
 \fB-F\fR, \fB--foreground\fR
 Run the dameon in the foreground and don't fork. This also enables sending the logging output to the screen as well as the log file.
+.TP
+\fB-r\fR, \fB--respawn\fR
+Stop any existing daemon first, if one is running.
+.TP
+\fB-s\fR, \fB--stop\fR
+Gracefully stop the existing daemon.
 .TP
 \fB--config\fR=\fIconfig_file\fR
 Specifies the location of the config file. If this is not provided it will default to \fB$HOME\fR/.razer-service/razer.conf and create it if needed from the example config.
@@ -39,11 +38,23 @@ This argument decides where the log directory will be, the daemon itself will ha
 .TP
 \fB--pid-file\fR=\fIpid_file\fR
 If provided the daemon will store its PID file in the location provided in this argument. Its not needed when used with Upstart as that will track its PID even when double forked.
+.TP
+\fB--test-dir\fR=\fItest_dir\fR
+If provided the daemon will operate in test-driver mode in which it exposes devices that aren't physically connected. Use
+.I scripts/create_fake_device.py
+or
+.I scripts/setup_fake_devices.sh
+to create the directory structure.
 
-.SH "BUGS"
+.SH DOCUMENTATION
+.PP
+The full and most up-to-date documentation can be found on our GitHub repository here
+https://github.com/terrycain/razer-drivers .
+
+.SH BUGS
 .PP
 This daemon makes use of the EVIOCGRAB ioctl which will get exclusive access of the keyboard's event files in /dev/input. Whilst the service has exclusive access to the event files other programs will not receive any key presses, this is required to make FN act like a modifier. Using \fBmacro_keys\fR is considered experimental as whilst it works it is still largely untested. If FN is held the service will grab the file and then release it when FN is released, there is a race condition where if FN is held and another key presses immediatly after the keypress event will leak to the system and programs will see its being held and not released (and spam the key).
 
 .SH "SEE ALSO"
 .BR razer.conf (5),
-.BR https://github.com/terrycain/razer_drivers
+.BR https://github.com/terrycain/razer-drivers


### PR DESCRIPTION
Fix some formatting errors and add new commandline options
One problem that's left (the same problem is also with new stuff):
![image_2017-02-10_13-30-28](https://cloud.githubusercontent.com/assets/3768500/22827002/d6b88b5e-ef95-11e6-8a3e-fe4e6b31fd2d.png)
And I don't manage to tell troff/groff not to break in the middle of "words".  The same problem is seen in the razer.conf.5 man page with the `--config` parameter.