### PR TITLE
Remove redundant listing

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,14 +232,6 @@
                     <h5>Nostromo</h5>
                   </a>
                 </div>
-                <div class="col-md-3 col-sm-4 device-icon">
-                  <a href="https://www.razerzone.com/licensed-and-team-peripherals/overwatch-razer-blackwidow-chroma/" target="_blank">
-                    <br>
-                    <img src="https://assets.razerzone.com/eeimages/products/23326/overwatch-razer-gallery-3.png">
-                    <br><br>
-                    <h5>Overwatch</h5>
-                  </a>
-                </div>
               </div>
             </div>
 


### PR DESCRIPTION
The razer overwatch keyboard is a blackwidow chroma with an overwatch logo stamped on, there is no need to list it separately.