### PR TITLE
Add examples of Python client usage

### DIFF
--- a/examples/advanced_effect.py
+++ b/examples/advanced_effect.py
@@ -1,0 +1,81 @@
+import colorsys
+import random
+
+from razer.client import DeviceManager
+from razer.client import constants as razer_constants
+
+# Create a DeviceManager. This is used to get specific devices
+device_manager = DeviceManager()
+
+
+print("Found {} Razer devices".format(len(device_manager.devices)))
+print()
+
+# Disable daemon effect syncing.
+# Without this, the daemon will try to set the lighting effect to every device.
+device_manager.sync_effects = False
+
+# List of effect I've chosen to make an example for
+effects = [
+    'breath_random',
+    'breath_single',
+    'breath_dual',
+    'breath_triple',
+    'reactive',
+    'spectrum',
+    'static',
+    'wave',
+]
+
+# Helper funciton to generate interesting colors
+def random_color():
+    rgb = colorsys.hsv_to_rgb(random.uniform(0, 1), random.uniform(0.5, 1), 1)
+    return tuple(map(lambda x: int(256 * x), rgb))
+
+# Iterate over each device and set a random effect that it supports.
+for device in device_manager.devices:
+    # Check which effect this device supports.
+    device_effects = [effect for effect in effects if device.fx.has(effect)]
+    # print("{} supports {}".format(device.name, device_effects))
+
+    effect = random.choice(device_effects)
+    print("Setting {} to effect {}".format(device.name, effect))
+
+    # Ad an example for each effect
+    if effect == 'breath_random':
+        device.fx.breath_random()
+
+    elif effect == 'breath_single':
+        color = random_color()
+        device.fx.breath_single(color[0], color[1], color[2])
+
+    elif effect == 'breath_dual':
+        color = random_color()
+        color2 = random_color()
+        device.fx.breath_dual(color[0], color[1], color[2],
+                              color2[0], color2[1], color2[2])
+
+    elif effect == 'breath_triple':
+        color = random_color()
+        color2 = random_color()
+        color3 = random_color()
+        device.fx.breath_triple(color[0], color[1], color[2],
+                                color2[0], color2[1], color2[2],
+                                color3[0], color3[1], color3[2])
+
+    elif effect == 'reactive':
+        color = random_color()
+        times = [razer_constants.REACTIVE_500MS, razer_constants.REACTIVE_1000MS,
+                 razer_constants.REACTIVE_1500MS, razer_constants.REACTIVE_2000MS]
+        device.fx.reactive(color[0], color[1], color[2], random.choice(times))
+
+    elif effect == 'spectrum':
+        device.fx.spectrum()
+
+    elif effect == 'static':
+        color = random_color()
+        device.fx.static(*color)
+
+    elif effect == 'wave':
+        directions = [razer_constants.WAVE_LEFT, razer_constants.WAVE_RIGHT]
+        device.fx.wave(random.choice(directions))

--- a/examples/basic_effect.py
+++ b/examples/basic_effect.py
@@ -1,0 +1,22 @@
+from razer.client import DeviceManager
+from razer.client import constants as razer_constants
+
+# Create a DeviceManager. This is used to get specific devices
+device_manager = DeviceManager()
+
+
+print("Found {} Razer devices".format(len(device_manager.devices)))
+print()
+
+# Disable daemon effect syncing.
+# Without this, the daemon will try to set the lighting effect to every device.
+device_manager.sync_effects = False
+
+# Iterate over each device and set the wave effect
+for device in device_manager.devices:
+    print("Setting {} to wave".format(device.name))
+
+    # Set the effect to wave.
+    # wave requires a direction, but different effect have different arguments.
+    device.fx.wave(razer_constants.WAVE_LEFT)
+

--- a/examples/custom_starlight.py
+++ b/examples/custom_starlight.py
@@ -1,0 +1,83 @@
+from collections import defaultdict
+import colorsys
+import random
+import time
+import threading
+
+from razer.client import DeviceManager
+from razer.client import constants as razer_constants
+
+# Create a DeviceManager. This is used to get specific devices
+device_manager = DeviceManager()
+
+
+print("Found {} Razer devices".format(len(device_manager.devices)))
+print()
+
+# Disable daemon effect syncing.
+# Without this, the daemon will try to set the lighting effect to every device.
+device_manager.sync_effects = False
+
+# Helper funciton to generate interesting colors
+def random_color():
+    rgb = colorsys.hsv_to_rgb(random.uniform(0, 1), random.uniform(0.5, 1), 1)
+    return tuple(map(lambda x: int(256 * x), rgb))
+
+
+# Handle the startlight effect for a single key
+def starlight_key(device, row, col, active):
+    color = random_color()
+
+    hue = random.uniform(0, 1)
+    start_time = time.time()
+
+    fade_time = 2
+
+    elapsed = 0
+    while elapsed < fade_time:
+        elapsed = time.time() - start_time
+        value = 1 - elapsed / fade_time
+        rgb = colorsys.hsv_to_rgb(hue, 1, value)
+        color = tuple(map(lambda x: int(256 * x), rgb))
+
+        device.fx.advanced.matrix[row, col] = color
+
+        value -= 0.01
+        # print(device, color)
+        time.sleep(1 / 60)
+
+    device.fx.advanced.matrix[row, col] = (0, 0, 0)
+    active[(row, col)] = False
+
+
+# Handle the startlight effect for an entire device
+def starlight_effect(device):
+    rows, cols = device.fx.advanced.rows, device.fx.advanced.cols
+    active = defaultdict(bool)
+
+    device.fx.advanced.matrix.reset()
+    device.fx.advanced.draw()
+
+    while True:
+        row, col = random.randrange(rows), random.randrange(cols)
+
+        if not active[(row, col)]:
+            active[(row, col)] = True
+            threading.Thread(target=starlight_key, args=(device, row, col, active)).start()
+
+        time.sleep(0.1)
+
+
+# Spawn a manager thread for each device and wait on all of them.
+threads = []
+for device in device_manager.devices:
+    t = threading.Thread(target=starlight_effect, args=(device,), daemon=True)
+    t.start()
+    threads.append(t)
+
+
+# If there are still threads, update each device.
+while any(t.isAlive() for t in threads):
+    for device in device_manager.devices:
+        device.fx.advanced.draw()
+    time.sleep(1 / 60)

--- a/examples/custom_zones.py
+++ b/examples/custom_zones.py
@@ -1,0 +1,31 @@
+import colorsys
+import random
+
+from razer.client import DeviceManager
+from razer.client import constants as razer_constants
+
+# Create a DeviceManager. This is used to get specific devices
+device_manager = DeviceManager()
+
+
+print("Found {} Razer devices".format(len(device_manager.devices)))
+print()
+
+# Disable daemon effect syncing.
+# Without this, the daemon will try to set the lighting effect to every device.
+device_manager.sync_effects = False
+
+# Helper funciton to generate interesting colors
+def random_color():
+    rgb = colorsys.hsv_to_rgb(random.uniform(0, 1), random.uniform(0.5, 1), 1)
+    return tuple(map(lambda x: int(256 * x), rgb))
+
+# Set random colors for each zone of each device
+for device in device_manager.devices:
+    rows, cols = device.fx.advanced.rows, device.fx.advanced.cols
+
+    for row in range(rows):
+        for col in range(cols):
+            device.fx.advanced.matrix[row, col] = random_color()
+
+    device.fx.advanced.draw()

--- a/examples/list_devices.py
+++ b/examples/list_devices.py
@@ -1,0 +1,13 @@
+from razer.client import DeviceManager
+
+# Create a DeviceManager. This is used to get specific devices
+device_manager = DeviceManager()
+
+
+print("Found {} Razer devices".format(len(device_manager.devices)))
+print()
+
+
+# Iterate over each device and pretty out some standard information about each
+for device in device_manager.devices:
+    print("{}: type \"{}\"".format(device.name, device.type))

--- a/examples/list_devices.py
+++ b/examples/list_devices.py
@@ -10,4 +10,9 @@ print()
 
 # Iterate over each device and pretty out some standard information about each
 for device in device_manager.devices:
-    print("{}: type \"{}\"".format(device.name, device.type))
+    print("{}:".format(device.name))
+    print("   type: {}".format(device.type))
+    print("   serial: {}".format(device.serial))
+    print("   firmware version: {}".format(device.firmware_version))
+    print("   driver version: {}".format(device.driver_version))
+    print()


### PR DESCRIPTION
This has 5 examples of Python client usage:

- Getting basic info about a device
- Setting an effect
- Checking for effect support
- Basic custom matrix settings
- Starlight effect (done in software)