### PR TITLE
Systemd dbus activation

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -4,16 +4,15 @@ PREFIX?=/usr
 purge_pycache:
 	@find -name '__pycache__' | xargs rm -rf
 
-install: purge_pycache manpages
+install-resources:
+	@install -m 644 -D -v resources/razer.conf $(DESTDIR)$(PREFIX)/share/razer-daemon/razer.conf.example
+	@install -m 755 -D -v run_razer_daemon.py $(DESTDIR)$(PREFIX)/bin/razer-daemon
+
+install: purge_pycache manpages install-resources
 	python3 setup.py install --prefix=$(PREFIX) --root=$(DESTDIR)
-	@install -m 644 -D -v resources/razer.conf $(DESTDIR)$(PREFIX)/share/razer-daemon/razer.conf.example
-	@install -m 755 -D -v run_razer_daemon.py $(DESTDIR)$(PREFIX)/bin/razer-daemon
 
-ubuntu_install: purge_pycache manpages
+ubuntu_install: purge_pycache manpages install-resources
 	python3 setup.py install --prefix=$(PREFIX) --root=$(DESTDIR) --no-compile
-	@install -m 644 -D -v resources/razer.conf $(DESTDIR)$(PREFIX)/share/razer-daemon/razer.conf.example
-	@install -m 755 -D -v run_razer_daemon.py $(DESTDIR)$(PREFIX)/bin/razer-daemon
-
 
 manpages:
 	@install -m 644 -D -v resources/man/razer.conf.5 $(DESTDIR)$(PREFIX)/share/man/man5/razer.conf.5

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -4,9 +4,15 @@ PREFIX?=/usr
 purge_pycache:
 	@find -name '__pycache__' | xargs rm -rf
 
-install-resources:
+service:
+	@sed "s|##PREFIX##|$(PREFIX)|" resources/org.razer.service.in > org.razer.service
+	@sed "s|##PREFIX##|$(PREFIX)|" resources/razer-daemon.systemd.service.in > razer-daemon.service
+
+install-resources: service
 	@install -m 644 -D -v resources/razer.conf $(DESTDIR)$(PREFIX)/share/razer-daemon/razer.conf.example
 	@install -m 755 -D -v run_razer_daemon.py $(DESTDIR)$(PREFIX)/bin/razer-daemon
+	@install -m 644 -D -v org.razer.service $(DESTDIR)$(PREFIX)/share/dbus-1/services/org.razer.service
+	@install -m 644 -D -v razer-daemon.service $(DESTDIR)$(PREFIX)/lib/systemd/user/razer-daemon.service
 
 install: purge_pycache manpages install-resources
 	python3 setup.py install --prefix=$(PREFIX) --root=$(DESTDIR)

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,33 +1,34 @@
 DESTDIR?=/
+PREFIX?=/usr
 
 purge_pycache:
 	@find -name '__pycache__' | xargs rm -rf
 
 install: purge_pycache manpages
-	python3 setup.py install --prefix=/usr --root=$(DESTDIR)
-	@install -m 644 -D -v resources/razer.conf $(DESTDIR)/usr/share/razer-daemon/razer.conf.example
-	@install -m 755 -D -v run_razer_daemon.py $(DESTDIR)/usr/bin/razer-daemon
+	python3 setup.py install --prefix=$(PREFIX) --root=$(DESTDIR)
+	@install -m 644 -D -v resources/razer.conf $(DESTDIR)$(PREFIX)/share/razer-daemon/razer.conf.example
+	@install -m 755 -D -v run_razer_daemon.py $(DESTDIR)$(PREFIX)/bin/razer-daemon
 
 ubuntu_install: purge_pycache manpages
-	python3 setup.py install --prefix=/usr --root=$(DESTDIR) --no-compile
-	@install -m 644 -D -v resources/razer.conf $(DESTDIR)/usr/share/razer-daemon/razer.conf.example
-	@install -m 755 -D -v run_razer_daemon.py $(DESTDIR)/usr/bin/razer-daemon
+	python3 setup.py install --prefix=$(PREFIX) --root=$(DESTDIR) --no-compile
+	@install -m 644 -D -v resources/razer.conf $(DESTDIR)$(PREFIX)/share/razer-daemon/razer.conf.example
+	@install -m 755 -D -v run_razer_daemon.py $(DESTDIR)$(PREFIX)/bin/razer-daemon
 
 
 manpages:
-	@install -m 644 -D -v resources/man/razer.conf.5 $(DESTDIR)/usr/share/man/man5/razer.conf.5
-	@gzip $(DESTDIR)/usr/share/man/man5/razer.conf.5
-	@install -m 644 -D -v resources/man/razer-daemon.8 $(DESTDIR)/usr/share/man/man8/razer-daemon.8
-	@gzip $(DESTDIR)/usr/share/man/man8/razer-daemon.8
+	@install -m 644 -D -v resources/man/razer.conf.5 $(DESTDIR)$(PREFIX)/share/man/man5/razer.conf.5
+	@gzip $(DESTDIR)$(PREFIX)/share/man/man5/razer.conf.5
+	@install -m 644 -D -v resources/man/razer-daemon.8 $(DESTDIR)$(PREFIX)/share/man/man8/razer-daemon.8
+	@gzip $(DESTDIR)$(PREFIX)/share/man/man8/razer-daemon.8
 
 manpages_uninstall:
-	@rm -f $(DESTDIR)/usr/share/man/man5/razer.conf.5.gz
-	@rm -f $(DESTDIR)/usr/share/man/man8/razer-daemon.8.gz
+	@rm -f $(DESTDIR)$(PREFIX)/share/man/man5/razer.conf.5.gz
+	@rm -f $(DESTDIR)$(PREFIX)/share/man/man8/razer-daemon.8.gz
 
 uninstall: manpages_uninstall
-	$(eval DAEMONPATH := $(shell find $(DESTDIR)/usr/lib/python3* -maxdepth 2 -name "razer_daemon"))
+	$(eval DAEMONPATH := $(shell find $(DESTDIR)$(PREFIX)/lib/python3* -maxdepth 2 -name "razer_daemon"))
 	$(eval EGGPATH := $(shell readlink -f $(DAEMONPATH)-*.egg-info/)) # shows an error when it's not already installed (maybe use some if condition)
 	@rm -rf -v $(DAEMONPATH)
 	@rm -rf -v $(EGGPATH)
-	@rm -rf -v $(DESTDIR)/usr/share/razer-daemon
-	@rm -f -v $(DESTDIR)/usr/bin/razer-daemon
+	@rm -rf -v $(DESTDIR)$(PREFIX)/share/razer-daemon
+	@rm -f -v $(DESTDIR)$(PREFIX)/bin/razer-daemon

--- a/daemon/resources/org.razer.service.in
+++ b/daemon/resources/org.razer.service.in
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.razer
+Exec=##PREFIX##/bin/razer-daemon
+SystemdService=razer-daemon.service

--- a/daemon/resources/razer-daemon.systemd.service.in
+++ b/daemon/resources/razer-daemon.systemd.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daemon to manage razer devices in userspace
+Documentation=man:razer-daemon(8)
+
+[Service]
+Type=dbus
+BusName=org.razer
+ExecStart=##PREFIX##/bin/razer-daemon -Fv
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This allows for the daemon to be auto-started via `systemd--user` whenever an application attempts to communicate to the dbus endpoints exposed by the daemon.

It also allows end-users to auto-start the daemon by simply running `systemctl --user enable --now razer-daemon`.