### PR TITLE
daemon: follow the xdg basedir spec

### DIFF
--- a/daemon/razer_daemon/daemon.py
+++ b/daemon/razer_daemon/daemon.py
@@ -93,21 +93,21 @@ def daemonize(foreground=False, verbose=False, log_dir=None, console_log=False, 
         os.dup2(stdout.fileno(), sys.stdout.fileno())
         os.dup2(stdout.fileno(), sys.stderr.fileno())
 
-    pid_file = os.path.join(run_dir, "daemon.pid")
-
     # Change working directory
     if run_dir is not None and os.path.exists(run_dir) and os.path.isdir(run_dir):
         os.chdir(run_dir)
-        # Write PID file
-        try:
-            with open(pid_file, 'w') as pid_file_obj:
-                pid_file_obj.write(str(os.getpid()))
-        except (OSError, IOError) as err:
-            print("Error: {0}".format(err))
+        pid_file = os.path.join(run_dir, "razer-daemon.pid")
     else:
         run_dir = tempfile.mkdtemp(prefix='tmp_', suffix='_razer_daemon')
-        pid_file = os.path.join(run_dir, "daemon.pid")
+        pid_file = os.path.join(run_dir, "razer-daemon.pid")
         os.chdir(run_dir)
+
+    # Write PID file
+    try:
+        with open(pid_file, 'w') as pid_file_obj:
+            pid_file_obj.write(str(os.getpid()))
+    except (OSError, IOError) as err:
+        print("Error: {0}".format(err))
 
     # Create daemon and run
     daemon = RazerDaemon(verbose, log_dir, console_log, run_dir, config_file, test_dir=test_dir)

--- a/daemon/resources/man/razer-daemon.8
+++ b/daemon/resources/man/razer-daemon.8
@@ -12,6 +12,8 @@ razer-daemon \- Razer Service to manage razer devices in userspace
 is a userspace service which is designed to be an intermediary between userspace programs and the razer drivers. It will provide some higher level functions to allow similar operation to the Windows Razer Synapse program. This service is designed to be started by xdg-autostart as a session service.
 .PP
 The service has the functionality to sync effects between multiple devices, perform on-the-fly macro recording and playback and reimplements the FN+Keys logic so they work when \fBmacro_keys\fR are enabled. The service can also perform various ripple effects, it can turn off the devices when the screensaver is active and also optionally store key metrics to provide usage heatmaps.
+.PP
+Note, that all paths shown as defaults, eg \fB$HOME\fR/.local/share/ or \fB$HOME\fR/.config/ can be changed with the XDG Base Directory specification variables: \fB$XDG_CONFIG_HOME\fR, \fB$XDG_DATA_HOME\fR and \fB$XDG_RUNTIME_DIR\fR.
 
 .SH OPTIONS
 .TP
@@ -28,16 +30,13 @@ Stop any existing daemon first, if one is running.
 Gracefully stop the existing daemon.
 .TP
 \fB--config\fR=\fIconfig_file\fR
-Specifies the location of the config file. If this is not provided it will default to \fB$HOME\fR/.razer-service/razer.conf and create it if needed from the example config.
+Specifies the location of the config file. If this is not provided it will default to \fB$HOME\fR/.config/razer-service/razer.conf and create it if needed from the example config.
 .TP
 \fB--run-dir\fR=\fIrun_directory\fR
-Tells the daemon what directory is its run directory, the directory it will change to once started. It will default to \fB$HOME\fR/.razer-service/
+Tells the daemon what directory is its run directory, the directory it will change to once started. It will default to \fB$XDG_RUNTIME_DIR\fR, if not set it falls back to \fB$HOME\fR/.local/share/razer-service/.
 .TP
 \fB--log-dir\fR=\fIlog_directory\fR
-This argument decides where the log directory will be, the daemon itself will handle log rotation as it's a user session service. The daemon will default to \fB$HOME\fR/.razer-service/logs for its log directory.
-.TP
-\fB--pid-file\fR=\fIpid_file\fR
-If provided the daemon will store its PID file in the location provided in this argument. Its not needed when used with Upstart as that will track its PID even when double forked.
+This argument decides where the log directory will be, the daemon itself will handle log rotation as it's a user session service. The daemon will default to \fB$HOME\fR/.local/share/razer-service/logs/ for its log directory.
 .TP
 \fB--test-dir\fR=\fItest_dir\fR
 If provided the daemon will operate in test-driver mode in which it exposes devices that aren't physically connected. Use

--- a/daemon/resources/man/razer.conf.5
+++ b/daemon/resources/man/razer.conf.5
@@ -5,7 +5,7 @@ razer.conf \- configuration file for the Razer Service
 
 .SH "DESCRIPTION"
 .PP
-\fB$HOME\fI/.razer-service/razer.conf\fR configures some startup and runtime options of the \fBrazer-daemon\fR(8). \fBrazer-daemon\fR(8) is able to use configuration files specified in non-standard locations by providing the \fI--config\fR argument.
+\fB$HOME\fI/.config/razer-service/razer.conf\fR, overrideable with \fB$XDG_CONFIG_HOME\fR, configures some startup and runtime options of the \fBrazer-service\fR(8). \fBrazer-service\fR(8) is able to use configuration files specified in non-standard locations by providing the \fI--config\fR argument.
 .PP
 The configuration file is formatted like a .INI file and is parsed by Python's ConfigParser so as long as that module can read the file all is good.
 

--- a/daemon/run_razer_daemon.py
+++ b/daemon/run_razer_daemon.py
@@ -18,7 +18,7 @@ XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME", os.path.join(HOME, ".config"
 RAZER_DATA_HOME = os.path.join(XDG_DATA_HOME, "razer-daemon")
 XDG_RUNTIME_DIR = os.environ.get("XDG_RUNTIME_DIR", RAZER_DATA_HOME)
 RAZER_CONFIG_HOME = os.path.join(XDG_CONFIG_HOME, "razer-daemon")
-RAZER_RUNTIME_DIR = os.path.join(XDG_RUNTIME_DIR, "razer-daemon")
+RAZER_RUNTIME_DIR = XDG_RUNTIME_DIR
 
 EXAMPLE_CONF_FILE = '/usr/share/razer-daemon/razer.conf.example'
 

--- a/daemon/run_razer_daemon.py
+++ b/daemon/run_razer_daemon.py
@@ -15,10 +15,10 @@ HOME = os.path.expanduser("~")
 XDG_DATA_HOME = os.environ.get("XDG_DATA_HOME", os.path.join(HOME, ".local", "share"))
 XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME", os.path.join(HOME, ".config"))
 
-RAZER_DATA_HOME = os.path.join(XDG_DATA_HOME, "razer-service")
+RAZER_DATA_HOME = os.path.join(XDG_DATA_HOME, "razer-daemon")
 XDG_RUNTIME_DIR = os.environ.get("XDG_RUNTIME_DIR", RAZER_DATA_HOME)
-RAZER_CONFIG_HOME = os.path.join(XDG_CONFIG_HOME, "razer-service")
-RAZER_RUNTIME_DIR = os.path.join(XDG_RUNTIME_DIR, "razer-service")
+RAZER_CONFIG_HOME = os.path.join(XDG_CONFIG_HOME, "razer-daemon")
+RAZER_RUNTIME_DIR = os.path.join(XDG_RUNTIME_DIR, "razer-daemon")
 
 EXAMPLE_CONF_FILE = '/usr/share/razer-daemon/razer.conf.example'
 
@@ -67,11 +67,11 @@ def run():
 
     # TODO Fix up run_dir (especially in macros branch as things will break)
     if not os.path.exists(RAZER_CONFIG_HOME):
-        os.mkdir(RAZER_CONFIG_HOME)
+        os.makedirs(RAZER_CONFIG_HOME, exist_ok=True)
     if not os.path.exists(RAZER_DATA_HOME):
-        os.mkdir(RAZER_DATA_HOME)
+        os.makedirs(RAZER_DATA_HOME, exist_ok=True)
     if not os.path.exists(LOG_PATH):
-        os.mkdir(LOG_PATH)
+        os.makedirs(LOG_PATH, exist_ok=True)
     if not os.path.exists(CONF_FILE):
         if os.path.exists(EXAMPLE_CONF_FILE):
             shutil.copy(EXAMPLE_CONF_FILE, CONF_FILE)

--- a/daemon/run_razer_daemon.py
+++ b/daemon/run_razer_daemon.py
@@ -10,12 +10,20 @@ from razer_daemon.daemon import daemonize
 from subprocess import check_output
 from time import sleep
 
-SHARE_DIR = '/usr/share/razer-daemon'
-EXAMPLE_CONF = os.path.join(SHARE_DIR, 'razer.conf.example')
+# Basically copied from https://github.com/jleclanche/python-xdg/blob/master/xdg/basedir.py
+HOME = os.path.expanduser("~")
+XDG_DATA_HOME = os.environ.get("XDG_DATA_HOME", os.path.join(HOME, ".local", "share"))
+XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME", os.path.join(HOME, ".config"))
 
-BASE_PATH = os.path.join(os.path.abspath(os.environ['HOME']), '.razer-service')
-CONF_PATH = os.path.join(BASE_PATH, 'razer.conf')
-LOG_PATH = os.path.join(BASE_PATH, 'logs')
+RAZER_DATA_HOME = os.path.join(XDG_DATA_HOME, "razer-service")
+XDG_RUNTIME_DIR = os.environ.get("XDG_RUNTIME_DIR", RAZER_DATA_HOME)
+RAZER_CONFIG_HOME = os.path.join(XDG_CONFIG_HOME, "razer-service")
+RAZER_RUNTIME_DIR = os.path.join(XDG_RUNTIME_DIR, "razer-service")
+
+EXAMPLE_CONF_FILE = '/usr/share/razer-daemon/razer.conf.example'
+
+CONF_FILE = os.path.join(RAZER_CONFIG_HOME, 'razer.conf')
+LOG_PATH = os.path.join(RAZER_DATA_HOME, 'logs')
 
 
 def parse_args():
@@ -28,10 +36,9 @@ def parse_args():
     parser.add_argument('-r', '--respawn', action='store_true', help='Stop any existing daemon first, if one is running.')
     parser.add_argument('-s', '--stop', action='store_true', help='Gracefully stop the existing daemon.')
 
-    parser.add_argument('--config', type=str, help='Location of the config file', default=CONF_PATH)
-    parser.add_argument('--run-dir', type=str, help='Location of the data directory', default=BASE_PATH)
+    parser.add_argument('--config', type=str, help='Location of the config file', default=CONF_FILE)
+    parser.add_argument('--run-dir', type=str, help='Location of the run directory', default=RAZER_RUNTIME_DIR)
     parser.add_argument('--log-dir', type=str, help='Location of the log directory', default=LOG_PATH)
-    parser.add_argument('--pid-file', type=str, help='Location of the pid file')
 
     parser.add_argument('--test-dir', type=str, help='Directory containing test driver structure')
 
@@ -58,14 +65,18 @@ def stop_daemon():
 def run():
     args = parse_args()
 
-    if not os.path.exists(BASE_PATH):
-        os.mkdir(BASE_PATH)
+    # TODO Fix up run_dir (especially in macros branch as things will break)
+    if not os.path.exists(RAZER_CONFIG_HOME):
+        os.mkdir(RAZER_CONFIG_HOME)
+    if not os.path.exists(RAZER_DATA_HOME):
+        os.mkdir(RAZER_DATA_HOME)
+    if not os.path.exists(LOG_PATH):
         os.mkdir(LOG_PATH)
-        os.mkdir(os.path.join(BASE_PATH, 'data'))
-        if os.path.exists(EXAMPLE_CONF):
-            shutil.copy(EXAMPLE_CONF, CONF_PATH)
+    if not os.path.exists(CONF_FILE):
+        if os.path.exists(EXAMPLE_CONF_FILE):
+            shutil.copy(EXAMPLE_CONF_FILE, CONF_FILE)
         else:
-            print('Cant find "{0}"'.format(EXAMPLE_CONF), file=sys.stderr)
+            print('Cant find "{0}"'.format(EXAMPLE_CONF_FILE), file=sys.stderr)
 
     if args.stop:
         stop_daemon()
@@ -89,9 +100,6 @@ def run():
 
     if args.run_dir:
         daemon_args['run_dir'] = args.run_dir
-
-    if args.pid_file:
-        daemon_args['pid_file'] = args.pid_file
 
     daemonize(**daemon_args)
 

--- a/pylib/tests/integration_tests/test_device_manager.py
+++ b/pylib/tests/integration_tests/test_device_manager.py
@@ -15,7 +15,7 @@ import coverage
 
 def run_daemon(daemon_dir, driver_dir):
     # TODO console_log false
-    razer_daemon.daemon.daemonize(foreground=True, verbose=True, console_log=False, run_dir=daemon_dir, pid_file=os.path.join(daemon_dir, 'daemon.pid'), test_dir=driver_dir)
+    razer_daemon.daemon.daemonize(foreground=True, verbose=True, console_log=False, run_dir=daemon_dir, pid_file=os.path.join(daemon_dir, 'razer-daemon.pid'), test_dir=driver_dir)
 
 class DeviceManagerTest(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
config files (eg razer.conf) -> `$XDG_CONFIG_HOME/razer-service/` **OR** `~/.config/razer-service/`
data files -> `$XDG_DATA_HOME/razer-service/` **OR** `~/.local/share/razer-service/`
daemon pid -> `$XDG_RUNTIME_DIR/razer-service` (eg `/run/user/1000`) - if not set, fall back to the data files location


**TODO:**
~~Update the manpages to reflect new locations and removed options~~
Potentially change commandline options because some directories are not setable except the xdg variables

**REMINDER** After #285 is merged, apply https://github.com/z3ntu/razer-drivers/commit/79ad45a991c4844d4ffd529fb714281534bf21f9 and https://github.com/z3ntu/razer-drivers/commit/68a6ba68bcd6d233e949222215e31bd07b338473 and https://github.com/z3ntu/razer-drivers/commit/9d8ce93f2b7107ebe57b1e4ebceed0c528acda28!
And then change razer-daemon.service to openrazer.service probably.