### PR TITLE
RFC: bind to the system bus, not the session bus

### DIFF
--- a/daemon/openrazer_daemon/screensaver-monitor.py
+++ b/daemon/openrazer_daemon/screensaver-monitor.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+#
+# This program monitors the screensaver DBus interfaces and toggles the
+# respective methods on the openrazer daemon
+
+
+import logging
+import sys
+import argparse
+
+from gi.repository import GObject, GLib, Gio
+from enum import Enum
+
+DBUS_SCREENSAVER_INTERFACES = ('org.freedesktop.ScreenSaver',
+                               'org.gnome.ScreenSaver',
+                               'org.mate.ScreenSaver')
+
+
+class ScreensaverState(Enum):
+    SCREENSAVER_OFF = 0
+    SCREENSAVER_ON = 1
+
+
+class ScreensaverMonitorDBusError(Exception):
+    pass
+
+
+class ScreensaverMonitor(object):
+    # The openrazer bus type
+    BUS_TYPE = Gio.BusType.SYSTEM
+
+    def __init__(self, verbose=False):
+        if verbose:
+            logging.basicConfig(level=logging.DEBUG)
+        else:
+            logging.basicConfig(level=logging.INFO)
+
+        self._logger = logging.getLogger('razer.screensaver')
+        self._logger.info("Initialising DBus Screensaver Monitor")
+
+        # DBus proxy to org.razer.devices
+        self._proxy = None
+        self._init_subscriptions()
+        self._watch_openrazer()
+
+    def _watch_openrazer(self):
+        """
+        Set up a watch for the openrazer daemon DBus name.
+        """
+        try:
+            self._watch_id = Gio.bus_watch_name(self.BUS_TYPE,
+                                                "org.razer",
+                                                Gio.BusNameWatcherFlags.AUTO_START,
+                                                self._connect_openrazer,
+                                                self._disconnect_openrazer)
+        except GLib.Error as e:
+            self._logger.critical("Failed to set up watch for openrazer-daemon")
+            raise ScreensaverMonitorDBusError(e.message)
+
+    def _connect_openrazer(self, connection, name, name_owner):
+        """
+        Connect to the openrazer daemon DBus name.
+        """
+        try:
+            p = Gio.DBusProxy.new_for_bus_sync(self.BUS_TYPE,
+                                               Gio.DBusProxyFlags.NONE, None,
+                                               "org.razer",
+                                               "/org/razer",
+                                               "razer.daemon",
+                                               None)
+            version = p.call_sync("version", None, Gio.DBusCallFlags.NO_AUTO_START,
+                                  500, None).unpack()[0]
+            self._logger.info("Connected to openrazer-daemon v{}".format(version))
+
+            self._proxy = Gio.DBusProxy.new_for_bus_sync(self.BUS_TYPE,
+                                                         Gio.DBusProxyFlags.NONE,
+                                                         None,
+                                                         "org.razer",
+                                                         "/org/razer",
+                                                         "razer.devices",
+                                                         None)
+            # We throw away the result, this is just to test-connect so we
+            # fail early.
+            self._proxy.call_sync("getDevices", None,
+                                  Gio.DBusCallFlags.NO_AUTO_START,
+                                  500, None).unpack()[0]
+        except GLib.Error as e:
+            self._logger.critical("Failed to connect to openrazer-daemon")
+            raise ScreensaverMonitorDBusError(e.message)
+
+    def _disconnect_openrazer(self, connection, name):
+        """
+        Disconnect from the openrazer daemon DBus name.
+        """
+        self._logger.info("openrazer-daemon bus disappeared")
+        self._proxy = None
+
+    def _init_subscriptions(self):
+        """
+        Set up signal subscriptions to the various screensaver DBus
+        interfaces on the session bus.
+        """
+        self._subscriptions = []
+        self._session_bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        # This should be synced from the interfaces
+        self._state = ScreensaverState.SCREENSAVER_OFF
+
+        for screensaver_interface in DBUS_SCREENSAVER_INTERFACES:
+            self._logger.debug("Subscribing to '{}'".format(screensaver_interface))
+            s = self._session_bus.signal_subscribe(None, screensaver_interface,
+                                                   'ActiveChanged',
+                                                   None, None, 0,
+                                                   self._signal_callback,
+                                                   None)
+            self._subscriptions.append(s)
+
+    def shutdown(self):
+        for s in self._subscriptions:
+            self._session_bus.signal_unsubscribe(s)
+        Gio.bus_unwatch_name(self._watch_id)
+
+    def _signal_callback(self, connection, name_owner, object_path, interface, signal, val, data):
+        """
+        Callback for DBus signal notifications
+        """
+        self._logger.debug("Received DBus signal {} {} {}".format(interface, signal, val))
+        active = bool(val[0])
+        self.set_screensaver_state(active)
+
+    def set_screensaver_state(self, active):
+        """
+        Change the screensaver state to be active or inactive
+        """
+        if active:
+            state = ScreensaverState.SCREENSAVER_ON
+            if state == self._state:
+                return
+        else:
+            state = ScreensaverState.SCREENSAVER_OFF
+            if state == self._state:
+                return
+
+        self._set_device_state(active)
+
+    def _set_device_state(self, state):
+        if state == ScreensaverState.SCREENSAVER_ON:
+            what = "Suspending"
+            method = "suspendDevice"
+        else:
+            what = "Resuming"
+            method = "resumeDevice"
+
+        try:
+            devices = self._proxy.call_sync("getDevices", None,
+                                            Gio.DBusCallFlags.NO_AUTO_START,
+                                            500, None).unpack()[0]
+            for d in devices:
+                self._logger.debug("{} device {}".format(what, d))
+                p = Gio.DBusProxy.new_for_bus_sync(self.BUS_TYPE,
+                                                   Gio.DBusProxyFlags.NONE,
+                                                   None,
+                                                   "org.razer",
+                                                   "/org/razer/device/{}".format(d),
+                                                   "razer.device.misc",
+                                                   None)
+
+                p.call_sync(method, None, Gio.DBusCallFlags.NO_AUTO_START, 500, None)
+
+            self._state = state
+        except GLib.Error as e:
+            self._logger.critical("Failed to suspend/resume devices")
+            raise ScreensaverMonitorDBusError(e.message)
+
+    def monitor(self):
+        """
+        Monitor the screensaver interfaces and update our device state
+        accordingly.
+        """
+        GObject.MainLoop().run()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='''
+        This tool monitors the screensaver DBus interfaces for screensaver
+        activation and toggles device suspend/resume on the openrazer-daemon
+        as the screensaver toggles.''')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose logging', default=False)
+    args = parser.parse_args()
+
+    try:
+        sm = ScreensaverMonitor(verbose=args.verbose)
+        sm.monitor()
+    except KeyboardInterrupt:
+        sm.shutdown()
+    except ScreensaverMonitorDBusError:
+        sys.exit(1)

--- a/daemon/org.razer.conf
+++ b/daemon/org.razer.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0"?> <!--*-nxml-*-->
+<!DOCTYPE busconfig PUBLIC
+        "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<busconfig>
+        <policy user="root">
+                <allow own="org.razer"/>
+                <allow send_destination="org.razer"/>
+                <allow receive_sender="org.razer"/>
+        </policy>
+
+	<!-- allow everyone to talk to the daemon -->
+        <policy context="default">
+                <allow send_destination="org.razer"/>
+                <allow receive_sender="org.razer"/>
+        </policy>
+</busconfig>

--- a/daemon/run_openrazer_daemon.py
+++ b/daemon/run_openrazer_daemon.py
@@ -39,6 +39,7 @@ def parse_args():
 
     parser.add_argument('-r', '--respawn', action='store_true', help='Stop any existing daemon first, if one is running.')
     parser.add_argument('-s', '--stop', action='store_true', help='Gracefully stop the existing daemon.')
+    parser.add_argument('--use-system-bus', action='store_true', help='Run on the system bus', default=False)
 
     parser.add_argument('--config', type=str, help='Location of the config file', default=CONF_FILE)
     parser.add_argument('--run-dir', type=str, help='Location of the run directory', default=RAZER_RUNTIME_DIR)
@@ -114,11 +115,18 @@ def install_example_config_file():
 
 def run_daemon():
     global args
+
+    if args.use_system_bus:
+        bustype = 'system'
+    else:
+        bustype = 'session'
+
     daemon = RazerDaemon(verbose=args.verbose,
                          log_dir=args.log_dir,
                          console_log=args.foreground,
                          config_file=args.config,
-                         test_dir=args.test_dir)
+                         test_dir=args.test_dir,
+                         bustype=bustype)
     try:
         daemon.run()
     except KeyboardInterrupt:


### PR DESCRIPTION
**This is an RFC, DO NOT MERGE**

I'm trying to hook up the openrazer drivers to [libratbag](http://github.com/libratbag/libratbag) and the first issue I ran into is that the bus is run as session bus. libratbag's ratbagd runs on the system bus and thus cannot connect to a session bus.

This is the minimal patchset to make it possible for openrazer's daemon to run on the system bus but it's missing the required commandline toggles. I'm submitting this here for comments. Is this something you're interested in?