### PR TITLE
RFC: Implement openrazer without dkms through hidraw

### DIFF
--- a/daemon/openrazer_daemon/daemon.py
+++ b/daemon/openrazer_daemon/daemon.py
@@ -389,7 +389,7 @@ class RazerDaemon(DBusService):
                 if sys_name in self._razer_devices:
                     continue
 
-                if device_class.match(sys_name, sys_path):  # Check it matches sys/ ID format and has device_type file
+                if device_class.match(sys_name, sys_path):  # Check it matches sys/ ID format and is supported
                     self.logger.info('Found device.%d: %s', device_number, sys_name)
 
                     # TODO add testdir support
@@ -401,14 +401,15 @@ class RazerDaemon(DBusService):
                             if device_match in alt_device.sys_name and alt_device.sys_name != sys_name:
                                 additional_interfaces.append(alt_device.sys_path)
 
-                    # Checking permissions
-                    test_file = os.path.join(sys_path, 'device_type')
-                    file_group_id = os.stat(test_file).st_gid
-                    file_group_name = grp.getgrgid(file_group_id)[0]
+                    if not device_class.USE_HIDRAW:
+                        # Checking permissions
+                        test_file = os.path.join(sys_path, 'device_type')
+                        file_group_id = os.stat(test_file).st_gid
+                        file_group_name = grp.getgrgid(file_group_id)[0]
 
-                    if os.getgid() != file_group_id and file_group_name != 'plugdev':
-                        self.logger.critical("Could not access {0}/device_type, file is not owned by plugdev".format(sys_path))
-                        break
+                        if os.getgid() != file_group_id and file_group_name != 'plugdev':
+                            self.logger.critical("Could not access {0}/device_type, file is not owned by plugdev".format(sys_path))
+                            break
 
                     razer_device = device_class(sys_path, device_number, self._config, testing=self._test_dir is not None, additional_interfaces=sorted(additional_interfaces))
 
@@ -444,7 +445,7 @@ class RazerDaemon(DBusService):
             if sys_name in self._razer_devices:
                 continue
 
-            if device_class.match(sys_name, sys_path):  # Check it matches sys/ ID format and has device_type file
+            if device_class.match(sys_name, sys_path):  # Check it matches sys/ ID format and is supported
                 self.logger.info('Found valid device.%d: %s', device_number, sys_name)
                 razer_device = device_class(sys_path, device_number, self._config, testing=self._test_dir is not None)
 

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/all.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/all.py
@@ -42,6 +42,9 @@ def get_firmware(self):
     """
     self.logger.debug("DBus call get_firmware")
 
+    if self.USE_HIDRAW:
+        return self.get_firmware_version()
+
     driver_path = self.get_driver_path('firmware_version')
 
     with open(driver_path, 'r') as driver_file:
@@ -57,6 +60,9 @@ def get_device_name(self):
     :rtype: str
     """
     self.logger.debug("DBus call get_device_name")
+
+    if self.USE_HIDRAW:
+        return self.DEVICE_NAME
 
     driver_path = self.get_driver_path('device_type')
 

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/deathadder_chroma.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/deathadder_chroma.py
@@ -106,6 +106,9 @@ def get_logo_brightness(self):
     """
     self.logger.debug("DBus call get_logo_brightness")
 
+    if self.USE_HIDRAW:
+        return self.get_logo_brightness()
+
     driver_path = self.get_driver_path('logo_led_brightness')
 
     with open(driver_path, 'r') as driver_file:
@@ -123,6 +126,9 @@ def set_logo_brightness(self, brightness):
     :type brightness: int
     """
     self.logger.debug("DBus call set_logo_brightness")
+
+    if self.USE_HIDRAW:
+        return self.set_logo_brightness(brightness)
 
     driver_path = self.get_driver_path('logo_led_brightness')
 
@@ -322,6 +328,9 @@ def get_scroll_brightness(self):
     """
     self.logger.debug("DBus call get_scroll_brightness")
 
+    if self.USE_HIDRAW:
+        return self.get_scroll_brightness()
+
     driver_path = self.get_driver_path('scroll_led_brightness')
 
     with open(driver_path, 'r') as driver_file:
@@ -339,6 +348,9 @@ def set_scroll_brightness(self, brightness):
     :type brightness: int
     """
     self.logger.debug("DBus call set_scroll_brightness")
+
+    if self.USE_HIDRAW:
+        return self.set_scroll_brightness(brightness)
 
     driver_path = self.get_driver_path('scroll_led_brightness')
 

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/deathadder_chroma.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/deathadder_chroma.py
@@ -47,6 +47,9 @@ def get_logo_active(self):
     """
     self.logger.debug("DBus call get_logo_active")
 
+    if self.USE_HIDRAW:
+        return self.get_logo_active()
+
     driver_path = self.get_driver_path('logo_led_state')
 
     with open(driver_path, 'r') as driver_file:
@@ -63,6 +66,9 @@ def set_logo_active(self, active):
     :type active: bool
     """
     self.logger.debug("DBus call set_logo_active")
+
+    if self.USE_HIDRAW:
+        return self.set_logo_active(active)
 
     driver_path = self.get_driver_path('logo_led_state')
 
@@ -257,6 +263,9 @@ def get_scroll_active(self):
     """
     self.logger.debug("DBus call get_scroll_active")
 
+    if self.USE_HIDRAW:
+        return self.get_scroll_active()
+
     driver_path = self.get_driver_path('scroll_led_state')
 
     with open(driver_path, 'r') as driver_file:
@@ -273,6 +282,9 @@ def set_scroll_active(self, active):
     :type active: bool
     """
     self.logger.debug("DBus call set_scroll_active")
+
+    if self.USE_HIDRAW:
+        return self.set_scroll_active(active)
 
     driver_path = self.get_driver_path('scroll_led_state')
 

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/mamba.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/mamba.py
@@ -127,6 +127,9 @@ def set_dpi_xy(self, dpi_x, dpi_y):
     """
     self.logger.debug("DBus call set_dpi_both")
 
+    if self.USE_HIDRAW:
+        return self.set_dpi_xy(dpi_x, dpi_y)
+
     driver_path = self.get_driver_path('dpi')
 
     dpi_bytes = struct.pack('>HH', dpi_x, dpi_y)
@@ -144,6 +147,9 @@ def get_dpi_xy(self):
     :rtype: list of int
     """
     self.logger.debug("DBus call get_dpi_both")
+
+    if self.USE_HIDRAW:
+        return self.get_dpi_xy()
 
     driver_path = self.get_driver_path('dpi')
 
@@ -177,6 +183,9 @@ def set_poll_rate(self, rate):
     self.logger.debug("DBus call set_poll_rate")
 
     if rate in (1000, 500, 125):
+        if self.USE_HIDRAW:
+            return self.set_poll_rate(rate)
+
         driver_path = self.get_driver_path('poll_rate')
 
         with open(driver_path, 'w') as driver_file:
@@ -194,6 +203,9 @@ def get_poll_rate(self):
     :rtype: int
     """
     self.logger.debug("DBus call get_poll_rate")
+
+    if self.USE_HIDRAW:
+        return self.get_poll_rate()
 
     driver_path = self.get_driver_path('poll_rate')
 

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/mamba.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/mamba.py
@@ -156,7 +156,7 @@ def get_dpi_xy(self):
 
 @endpoint('razer.device.dpi', 'maxDPI', out_sig='i')
 def max_dpi(self):
-    self.logger.debug("DBus call get_dpi_both")
+    self.logger.debug("DBus call get_dpi_max")
 
     if hasattr(self, 'DPI_MAX'):
         return self.DPI_MAX

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -496,17 +496,42 @@ class RazerDevice(DBusService):
         request.transaction_id = 0x3F
         self.razer_send_payload(request)
 
+    def get_led_brightness(self, led):
+        request = self.razer_get_report(0x03, 0x83, 0x03)
+        request.arguments = [RazerReport.VARSTORE, led]
+        response = self.razer_send_payload(request)
+        return response.arguments[2]
+
+    def set_led_brightness(self, led, brightness):
+        # Python has a double but we need an integer
+        brightness = int(brightness)
+        request = self.razer_get_report(0x03, 0x03, 0x03)
+        request.arguments = [RazerReport.VARSTORE, led, brightness]
+        self.razer_send_payload(request)
+
     def get_logo_active(self):
         return self.get_led_active(RazerReport.LOGO_LED) == 1
 
     def set_logo_active(self, enabled):
         return self.set_led_active(RazerReport.LOGO_LED, enabled)
 
+    def get_logo_brightness(self):
+        return self.get_led_brightness(RazerReport.LOGO_LED)
+
+    def set_logo_brightness(self, brightness):
+        return self.set_led_brightness(RazerReport.LOGO_LED, brightness)
+
     def get_scroll_active(self):
         return self.get_led_active(RazerReport.SCROLL_WHEEL_LED) == 1
 
     def set_scroll_active(self, enabled):
         self.set_led_active(RazerReport.SCROLL_WHEEL_LED, enabled)
+
+    def get_scroll_brightness(self):
+        return self.get_led_brightness(RazerReport.SCROLL_WHEEL_LED)
+
+    def set_scroll_brightness(self, brightness):
+        return self.set_led_brightness(RazerReport.SCROLL_WHEEL_LED, brightness)
 
     def set_dpi_xy(self, dpi_x, dpi_y):
         return self.set_misc_dpi_xy(RazerReport.NOSTORE, dpi_x, dpi_y)

--- a/daemon/openrazer_daemon/hardware/headsets.py
+++ b/daemon/openrazer_daemon/hardware/headsets.py
@@ -34,6 +34,10 @@ class RazerKrakenClassic(__RazerDevice):
     def _close(self):
         super(RazerKrakenClassic, self)._close()
 
+    @property
+    def hid_request_index(self):
+        return None
+
     @staticmethod
     def decode_bitfield(bitfield):
         return {
@@ -108,6 +112,10 @@ class RazerKraken(__RazerDevice):
 
     def _close(self):
         super(RazerKraken, self)._close()
+
+    @property
+    def hid_request_index(self):
+        return None
 
     @staticmethod
     def decode_bitfield(bitfield):
@@ -192,6 +200,10 @@ class RazerKrakenV2(__RazerDevice):
 
     def _close(self):
         super(RazerKrakenV2, self)._close()
+
+    @property
+    def hid_request_index(self):
+        return None
 
     @staticmethod
     def decode_bitfield(bitfield):

--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -8,7 +8,17 @@ from openrazer_daemon.misc.key_event_management import KeyboardKeyManager as _Ke
 from openrazer_daemon.misc.ripple_effect import RippleManager as _RippleManager
 
 
-class _MacroKeyboard(_RazerDeviceBrightnessSuspend):
+class _RazerKeyboard(_RazerDeviceBrightnessSuspend):
+    @property
+    def hid_response_index(self):
+        return 0x01
+
+    @property
+    def hid_request_index(self):
+        return 0x01
+
+
+class _MacroKeyboard(_RazerKeyboard):
     """
     Keyboard class
 
@@ -39,7 +49,7 @@ class _MacroKeyboard(_RazerDeviceBrightnessSuspend):
         self.key_manager.close()
 
 
-class RazerNostromo(_RazerDeviceBrightnessSuspend):
+class RazerNostromo(_RazerKeyboard):
     """
     Class for the Razer Nostromo
     """
@@ -80,7 +90,7 @@ class RazerNostromo(_RazerDeviceBrightnessSuspend):
         self.key_manager.close()
 
 
-class RazerTartarus(_RazerDeviceBrightnessSuspend):
+class RazerTartarus(_RazerKeyboard):
     """
     Class for the Razer Tartarus
     """
@@ -118,7 +128,7 @@ class RazerTartarus(_RazerDeviceBrightnessSuspend):
         self.key_manager.close()
 
 
-class RazerTartarusChroma(_RazerDeviceBrightnessSuspend):
+class RazerTartarusChroma(_RazerKeyboard):
     """
     Class for the Razer Tartarus Chroma
     """
@@ -156,7 +166,7 @@ class RazerTartarusChroma(_RazerDeviceBrightnessSuspend):
         self.key_manager.close()
 
 
-class RazerOrbweaver(_RazerDeviceBrightnessSuspend):
+class RazerOrbweaver(_RazerKeyboard):
     """
     Class for the Razer Orbweaver
     """
@@ -196,7 +206,7 @@ class RazerOrbweaver(_RazerDeviceBrightnessSuspend):
         self.key_manager.close()
 
 
-class RazerOrbweaverChroma(_RazerDeviceBrightnessSuspend):
+class RazerOrbweaverChroma(_RazerKeyboard):
     """
     Class for the Razer Orbweaver Chroma
     """
@@ -555,6 +565,10 @@ class RazerBladeStealth(_MacroKeyboard):
 
         self.ripple_manager.close()
 
+    @property
+    def hid_request_index(self):
+        return None
+
 
 class RazerBladeStealthLate2016(_MacroKeyboard):
     """
@@ -593,6 +607,10 @@ class RazerBladeStealthLate2016(_MacroKeyboard):
 
         self.ripple_manager.close()
 
+    @property
+    def hid_request_index(self):
+        return None
+
 
 class RazerBladeProLate2016(_MacroKeyboard):
     """
@@ -630,6 +648,10 @@ class RazerBladeProLate2016(_MacroKeyboard):
 
         self.ripple_manager.close()
 
+    @property
+    def hid_request_index(self):
+        return None
+
 
 class RazerBladeLate2016(_MacroKeyboard):
     """
@@ -666,6 +688,10 @@ class RazerBladeLate2016(_MacroKeyboard):
         super(RazerBladeLate2016, self)._close()
 
         self.ripple_manager.close()
+
+    @property
+    def hid_request_index(self):
+        return None
 
 
 class RazerBladeQHD(_MacroKeyboard):
@@ -705,6 +731,10 @@ class RazerBladeQHD(_MacroKeyboard):
         super(RazerBladeQHD, self)._close()
 
         self.ripple_manager.close()
+
+    @property
+    def hid_request_index(self):
+        return None
 
 
 class RazerBlackWidow2016(_MacroKeyboard):
@@ -893,6 +923,14 @@ class RazerAnansi(_MacroKeyboard):
     def _close(self):
         super(RazerAnansi, self)._close()
 
+    @property
+    def hid_response_index(self):
+        return 0x02
+
+    @property
+    def hid_request_index(self):
+        return 0x02
+
 
 class RazerDeathStalkerExpert(_MacroKeyboard):
     """
@@ -1062,4 +1100,8 @@ class RazerBladePro2017(_MacroKeyboard):
         super(RazerBladePro2017, self)._close()
 
         self.ripple_manager.close()
+
+    @property
+    def hid_request_index(self):
+        return None
 

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -143,11 +143,14 @@ class RazerImperator(__RazerDevice):
 
     DPI_MAX = 6400
 
+    USE_HIDRAW = True
+
     def _resume_device(self):
         self.logger.debug("Imperator doesnt have suspend/resume")
 
     def _suspend_device(self):
         self.logger.debug("Imperator doesnt have suspend/resume")
+
 
 
 class RazerOuroboros(__RazerDevice):
@@ -343,6 +346,10 @@ class RazerNagaHexV2(__RazerDeviceBrightnessSuspend):
     }
 
     DPI_MAX = 16000
+
+    @property
+    def hid_transaction_id(self):
+        return 0x3f
 
     def __init__(self, *args, **kwargs):
         super(RazerNagaHexV2, self).__init__(*args, **kwargs)
@@ -627,6 +634,10 @@ class RazerDeathadderElite(__RazerDeviceBrightnessSuspend):
 
     DPI_MAX = 16000
 
+    @property
+    def hid_transaction_id(self):
+        return 0x3f
+
     def _suspend_device(self):
         """
         Suspend the device
@@ -715,6 +726,9 @@ class RazerMamba2012Wireless(__RazerDeviceBrightnessSuspend):
 
         self._battery_manager.close()
 
+    def get_hidraw_serial(self):
+        return ''
+
 
 class RazerMamba2012Wired(__RazerDeviceBrightnessSuspend):
     """
@@ -737,6 +751,9 @@ class RazerMamba2012Wired(__RazerDeviceBrightnessSuspend):
     }
 
     DPI_MAX = 6400
+
+    def get_hidraw_serial(self):
+        return ''
 
 
 class RazerNaga2014(__RazerDevice):
@@ -816,6 +833,9 @@ class RazerOrochi2011(__RazerDeviceBrightnessSuspend):
     }
 
     MAX_DPI = 4000
+
+    def get_hidraw_serial(self):
+        return ''
 
     def _suspend_device(self):
         """

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -260,7 +260,7 @@ class RazerOrochiWired(__RazerDeviceBrightnessSuspend):
     DPI_MAX = 8200
 
 
-class RazerDeathadderChroma(__RazerDeviceBrightnessSuspend):
+class RazerDeathAdderChroma(__RazerDeviceBrightnessSuspend):
     """
     Class for the Razer DeathAdder Chroma
     """
@@ -282,8 +282,12 @@ class RazerDeathadderChroma(__RazerDeviceBrightnessSuspend):
 
     DPI_MAX = 10000
 
+    USE_HIDRAW = True
+
+    DEVICE_NAME = "Razer DeathAdder Chroma"
+
     def __init__(self, *args, **kwargs):
-        super(RazerDeathadderChroma, self).__init__(*args, **kwargs)
+        super(RazerDeathAdderChroma, self).__init__(*args, **kwargs)
 
         # Set brightness to max and LEDs to on, on startup
         _da_set_logo_brightness(self, 100)

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -2,7 +2,7 @@
 Mouse class
 """
 import re
-from openrazer_daemon.hardware.device_base import RazerDeviceBrightnessSuspend as __RazerDeviceBrightnessSuspend, RazerDevice as __RazerDevice
+from openrazer_daemon.hardware.device_base import RazerDeviceBrightnessSuspend as __RazerDeviceBrightnessSuspend, RazerDevice as __RazerDevice, RazerReport as _RazerReport
 from openrazer_daemon.misc.battery_notifier import BatteryManager as _BatteryManager
 # TODO replace with plain import
 from openrazer_daemon.dbus_services.dbus_methods.deathadder_chroma import get_logo_brightness as _da_get_logo_brightness, set_logo_brightness as _da_set_logo_brightness, \
@@ -145,12 +145,19 @@ class RazerImperator(__RazerDevice):
 
     USE_HIDRAW = True
 
+    DEVICE_NAME = "Razer Imperator 2012"
+
     def _resume_device(self):
         self.logger.debug("Imperator doesnt have suspend/resume")
 
     def _suspend_device(self):
         self.logger.debug("Imperator doesnt have suspend/resume")
 
+    def get_dpi_xy(self):
+        return self.get_misc_dpi_xy(_RazerReport.VARSTORE)
+
+    def set_dpi_xy(self, dpi_x, dpi_y):
+        return self.set_misc_dpi_xy(_RazerReport.VARSTORE, dpi_x, dpi_y)
 
 
 class RazerOuroboros(__RazerDevice):
@@ -836,6 +843,12 @@ class RazerOrochi2011(__RazerDeviceBrightnessSuspend):
 
     def get_hidraw_serial(self):
         return ''
+
+    def get_hidraw_device_mode(self):
+        return '0:0'
+
+    def set_hidraw_device_mode(self, mode_id, param):
+        pass
 
     def _suspend_device(self):
         """

--- a/daemon/openrazer_daemon/hardware/mug.py
+++ b/daemon/openrazer_daemon/hardware/mug.py
@@ -34,3 +34,6 @@ class RazerChromaMugHolder(_RazerDeviceBrightnessSuspend):
 
     def _close(self):
         super(RazerChromaMugHolder, self)._close()
+
+    def get_hidraw_serial(self):
+        return ''

--- a/daemon/openrazer_daemon/screensaver-monitor.py
+++ b/daemon/openrazer_daemon/screensaver-monitor.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+#
+# This program monitors the screensaver DBus interfaces and toggles the
+# respective methods on the openrazer daemon
+
+
+import logging
+import sys
+import argparse
+
+from gi.repository import GObject, GLib, Gio
+from enum import Enum
+
+DBUS_SCREENSAVER_INTERFACES = ('org.freedesktop.ScreenSaver',
+                               'org.gnome.ScreenSaver',
+                               'org.mate.ScreenSaver')
+
+
+class ScreensaverState(Enum):
+    SCREENSAVER_OFF = 0
+    SCREENSAVER_ON = 1
+
+
+class ScreensaverMonitorDBusError(Exception):
+    pass
+
+
+class ScreensaverMonitor(object):
+    # The openrazer bus type
+    BUS_TYPE = Gio.BusType.SYSTEM
+
+    def __init__(self, verbose=False):
+        if verbose:
+            logging.basicConfig(level=logging.DEBUG)
+        else:
+            logging.basicConfig(level=logging.INFO)
+
+        self._logger = logging.getLogger('razer.screensaver')
+        self._logger.info("Initialising DBus Screensaver Monitor")
+
+        # DBus proxy to org.razer.devices
+        self._proxy = None
+        self._init_subscriptions()
+        self._watch_openrazer()
+
+    def _watch_openrazer(self):
+        """
+        Set up a watch for the openrazer daemon DBus name.
+        """
+        try:
+            self._watch_id = Gio.bus_watch_name(self.BUS_TYPE,
+                                                "org.razer",
+                                                Gio.BusNameWatcherFlags.AUTO_START,
+                                                self._connect_openrazer,
+                                                self._disconnect_openrazer)
+        except GLib.Error as e:
+            self._logger.critical("Failed to set up watch for openrazer-daemon")
+            raise ScreensaverMonitorDBusError(e.message)
+
+    def _connect_openrazer(self, connection, name, name_owner):
+        """
+        Connect to the openrazer daemon DBus name.
+        """
+        try:
+            p = Gio.DBusProxy.new_for_bus_sync(self.BUS_TYPE,
+                                               Gio.DBusProxyFlags.NONE, None,
+                                               "org.razer",
+                                               "/org/razer",
+                                               "razer.daemon",
+                                               None)
+            version = p.call_sync("version", None, Gio.DBusCallFlags.NO_AUTO_START,
+                                  500, None).unpack()[0]
+            self._logger.info("Connected to openrazer-daemon v{}".format(version))
+
+            self._proxy = Gio.DBusProxy.new_for_bus_sync(self.BUS_TYPE,
+                                                         Gio.DBusProxyFlags.NONE,
+                                                         None,
+                                                         "org.razer",
+                                                         "/org/razer",
+                                                         "razer.devices",
+                                                         None)
+            # We throw away the result, this is just to test-connect so we
+            # fail early.
+            self._proxy.call_sync("getDevices", None,
+                                  Gio.DBusCallFlags.NO_AUTO_START,
+                                  500, None).unpack()[0]
+        except GLib.Error as e:
+            self._logger.critical("Failed to connect to openrazer-daemon")
+            raise ScreensaverMonitorDBusError(e.message)
+
+    def _disconnect_openrazer(self, connection, name):
+        """
+        Disconnect from the openrazer daemon DBus name.
+        """
+        self._logger.info("openrazer-daemon bus disappeared")
+        self._proxy = None
+
+    def _init_subscriptions(self):
+        """
+        Set up signal subscriptions to the various screensaver DBus
+        interfaces on the session bus.
+        """
+        self._subscriptions = []
+        self._session_bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        # This should be synced from the interfaces
+        self._state = ScreensaverState.SCREENSAVER_OFF
+
+        for screensaver_interface in DBUS_SCREENSAVER_INTERFACES:
+            self._logger.debug("Subscribing to '{}'".format(screensaver_interface))
+            s = self._session_bus.signal_subscribe(None, screensaver_interface,
+                                                   'ActiveChanged',
+                                                   None, None, 0,
+                                                   self._signal_callback,
+                                                   None)
+            self._subscriptions.append(s)
+
+    def shutdown(self):
+        for s in self._subscriptions:
+            self._session_bus.signal_unsubscribe(s)
+        Gio.bus_unwatch_name(self._watch_id)
+
+    def _signal_callback(self, connection, name_owner, object_path, interface, signal, val, data):
+        """
+        Callback for DBus signal notifications
+        """
+        self._logger.debug("Received DBus signal {} {} {}".format(interface, signal, val))
+        active = bool(val[0])
+        self.set_screensaver_state(active)
+
+    def set_screensaver_state(self, active):
+        """
+        Change the screensaver state to be active or inactive
+        """
+        if active:
+            state = ScreensaverState.SCREENSAVER_ON
+            if state == self._state:
+                return
+        else:
+            state = ScreensaverState.SCREENSAVER_OFF
+            if state == self._state:
+                return
+
+        self._set_device_state(active)
+
+    def _set_device_state(self, state):
+        if state == ScreensaverState.SCREENSAVER_ON:
+            what = "Suspending"
+            method = "suspendDevice"
+        else:
+            what = "Resuming"
+            method = "resumeDevice"
+
+        try:
+            devices = self._proxy.call_sync("getDevices", None,
+                                            Gio.DBusCallFlags.NO_AUTO_START,
+                                            500, None).unpack()[0]
+            for d in devices:
+                self._logger.debug("{} device {}".format(what, d))
+                p = Gio.DBusProxy.new_for_bus_sync(self.BUS_TYPE,
+                                                   Gio.DBusProxyFlags.NONE,
+                                                   None,
+                                                   "org.razer",
+                                                   "/org/razer/device/{}".format(d),
+                                                   "razer.device.misc",
+                                                   None)
+
+                p.call_sync(method, None, Gio.DBusCallFlags.NO_AUTO_START, 500, None)
+
+            self._state = state
+        except GLib.Error as e:
+            self._logger.critical("Failed to suspend/resume devices")
+            raise ScreensaverMonitorDBusError(e.message)
+
+    def monitor(self):
+        """
+        Monitor the screensaver interfaces and update our device state
+        accordingly.
+        """
+        GObject.MainLoop().run()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='''
+        This tool monitors the screensaver DBus interfaces for screensaver
+        activation and toggles device suspend/resume on the openrazer-daemon
+        as the screensaver toggles.''')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose logging', default=False)
+    args = parser.parse_args()
+
+    try:
+        sm = ScreensaverMonitor(verbose=args.verbose)
+        sm.monitor()
+    except KeyboardInterrupt:
+        sm.shutdown()
+    except ScreensaverMonitorDBusError:
+        sys.exit(1)

--- a/daemon/org.razer.conf
+++ b/daemon/org.razer.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0"?> <!--*-nxml-*-->
+<!DOCTYPE busconfig PUBLIC
+        "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<busconfig>
+        <policy user="root">
+                <allow own="org.razer"/>
+                <allow send_destination="org.razer"/>
+                <allow receive_sender="org.razer"/>
+        </policy>
+
+	<!-- allow everyone to talk to the daemon -->
+        <policy context="default">
+                <allow send_destination="org.razer"/>
+                <allow receive_sender="org.razer"/>
+        </policy>
+</busconfig>

--- a/daemon/run_openrazer_daemon.py
+++ b/daemon/run_openrazer_daemon.py
@@ -39,6 +39,7 @@ def parse_args():
 
     parser.add_argument('-r', '--respawn', action='store_true', help='Stop any existing daemon first, if one is running.')
     parser.add_argument('-s', '--stop', action='store_true', help='Gracefully stop the existing daemon.')
+    parser.add_argument('--use-system-bus', action='store_true', help='Run on the system bus', default=False)
 
     parser.add_argument('--config', type=str, help='Location of the config file', default=CONF_FILE)
     parser.add_argument('--run-dir', type=str, help='Location of the run directory', default=RAZER_RUNTIME_DIR)
@@ -114,11 +115,18 @@ def install_example_config_file():
 
 def run_daemon():
     global args
+
+    if args.use_system_bus:
+        bustype = 'system'
+    else:
+        bustype = 'session'
+
     daemon = RazerDaemon(verbose=args.verbose,
                          log_dir=args.log_dir,
                          console_log=args.foreground,
                          config_file=args.config,
-                         test_dir=args.test_dir)
+                         test_dir=args.test_dir,
+                         bustype=bustype)
     try:
         daemon.run()
     except KeyboardInterrupt:

--- a/pylib/openrazer/client/__init__.py
+++ b/pylib/openrazer/client/__init__.py
@@ -16,7 +16,7 @@ class DeviceManager(object):
     """
     def __init__(self):
         # Load up the DBus
-        session_bus = _dbus.SessionBus()
+        session_bus = _dbus.SystemBus()
         try:
             self._dbus = session_bus.get_object("org.razer", "/org/razer")
         except _dbus.DBusException:

--- a/pylib/openrazer/client/device.py
+++ b/pylib/openrazer/client/device.py
@@ -43,7 +43,7 @@ class RazerDeviceFactory(__BaseDeviceFactory):
         :rtype: RazerDevice
         """
         if daemon_dbus is None:
-            session_bus = _dbus.SessionBus()
+            session_bus = _dbus.SystemBus()
             daemon_dbus = session_bus.get_object("org.razer", "/org/razer/device/{0}".format(serial))
 
         device_dbus = _dbus.Interface(daemon_dbus, "razer.device.misc")

--- a/pylib/openrazer/client/devices/__init__.py
+++ b/pylib/openrazer/client/devices/__init__.py
@@ -15,7 +15,7 @@ class RazerDevice(object):
     def __init__(self, serial, vid_pid=None, daemon_dbus=None):
         # Load up the DBus
         if daemon_dbus is None:
-            session_bus = _dbus.SessionBus()
+            session_bus = _dbus.SystemBus()
             daemon_dbus = session_bus.get_object("org.razer", "/org/razer/device/{0}".format(serial))
 
         self._dbus = daemon_dbus

--- a/pylib/openrazer/client/fx.py
+++ b/pylib/openrazer/client/fx.py
@@ -28,7 +28,7 @@ class BaseRazerFX(object):
         self._capabilities = capabilities
 
         if daemon_dbus is None:
-            session_bus = _dbus.SessionBus()
+            session_bus = _dbus.SystemBus()
             daemon_dbus = session_bus.get_object("org.razer", "/org/razer/device/{0}".format(serial))
         self._dbus = daemon_dbus
 
@@ -558,7 +558,7 @@ class RazerAdvancedFX(BaseRazerFX):
             raise ValueError("Matrix dimenions cannot contain -1")
 
         if daemon_dbus is None:
-            session_bus = _dbus.SessionBus()
+            session_bus = _dbus.SystemBus()
             daemon_dbus = session_bus.get_object("org.razer", "/org/razer/device/{0}".format(serial))
 
         self._matrix_dims = matrix_dims

--- a/pylib/openrazer/client/macro.py
+++ b/pylib/openrazer/client/macro.py
@@ -9,7 +9,7 @@ from openrazer_daemon import keyboard
 class RazerMacro(object):
     def __init__(self, serial:str, daemon_dbus=None, capabilities=None):
         if daemon_dbus is None:
-            session_bus = _dbus.SessionBus()
+            session_bus = _dbus.SystemBus()
             daemon_dbus = session_bus.get_object("org.razer", "/org/razer/device/{0}".format(serial))
 
         if capabilities is None:


### PR DESCRIPTION
Given that this is based on top of #380:
**This is an RFC, DO NOT MERGE**

The basic communication with the Razer devices relies only on the standard HID SET_REPORT and GET_REPORT. Instead of implementing several kernel drivers, we should better have the dbus daemon directly issue the commands to the device.

This will benefit users as they will just have to install the openrazer daemon, and they can forget about the pain of dkms.

This requires the daemon to be run as a system bus as we do not care about the permission if we are running as root.

I only wrote the functions for the Imperator (which I own and which I was able to test).

With a slight modification of RazerGenie (for it to be using the system bus), the change is transparent from a user perspective.

If #380 gets merged, I can easily rebase this one on top of master.