### PR TITLE
Fix Matrix Size Razer Blade Pro 2017

### DIFF
--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -1037,7 +1037,7 @@ class RazerBladePro2017(_MacroKeyboard):
     USB_PID = 0x0225
     HAS_MATRIX = True
     DEDICATED_MACRO_KEYS = False
-    MATRIX_DIMS = [6, 22]  # 6 Rows, 22 Cols
+    MATRIX_DIMS = [6, 25]  # 6 Rows, 25 Cols
     METHODS = ['get_firmware', 'get_matrix_dims', 'has_matrix', 'get_device_name', 'get_device_type_keyboard', 'get_brightness', 'set_brightness', 'set_wave_effect', 'set_static_effect', 'set_spectrum_effect',
                'set_reactive_effect', 'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect', 'set_breath_dual_effect',
                'set_custom_effect', 'set_key_row', 'set_starlight_random_effect',


### PR DESCRIPTION
Update the matrix effect size to reflect the true keyboard size of 6x25.

***Ripple Fixing Series:***

- [x] Fix matrix size for RBP 2017 (#412)
- [ ] Fix ripple effect not spanning entire keyboard
- [ ] Add keyboard mapping for RBP 2017