### PR TITLE
daemon: if we're running on foreground mode, supply our own logger

### DIFF
--- a/daemon/run_openrazer_daemon.py
+++ b/daemon/run_openrazer_daemon.py
@@ -7,6 +7,7 @@ import signal
 import sys
 import time
 import contextlib
+import logging
 
 from openrazer_daemon.daemon import RazerDaemon
 from subprocess import check_output
@@ -129,7 +130,10 @@ def run_daemon():
 
 def run():
     global args
+
+    logger = None
     args = parse_args()
+
     if args.stop:
         stop_daemon(args)
         sys.exit(0)
@@ -137,6 +141,14 @@ def run():
     if args.respawn:
         stop_daemon(args)
         time.sleep(3)
+
+    # daemonize logs exceptions to its logger (which defaults to the syslog)
+    # and does not make them appear on stdout/stderr. If we're in foreground
+    # mode, override that logger with our own.
+    if not args.foreground:
+        logger = logging.getLogger('run-daemon')
+        if args.verbose:
+            logger.setLevel(logging.DEBUG)
 
     install_example_config_file()
 
@@ -146,7 +158,8 @@ def run():
                        action=run_daemon,
                        foreground=args.foreground,
                        verbose=args.verbose,
-                       chdir=args.run_dir)
+                       chdir=args.run_dir,
+                       logger=logger)
     daemon.start()
 
 if __name__ == "__main__":


### PR DESCRIPTION
daemonize initializes a logger during start(). Any exception in the 'action'
argument will be logged to that logger - which defaults to the syslog.

Inside run_daemon() we set up our own logger for the daemon itself and catch
any exceptions by logging to that. However, if an exception occurs during the
daemon's __init__(), that exception was only caught by daemonize and thus
logged to syslog only.

Avoid this by using another logger in case we're using -F

The proper fix is likely to have a classmethod that returns the logger for the
daemon and re-use that for daemonize too. But that requires moving the log
directory creation etc. into the startup script.

Fixes #431