### PR TITLE
Update list of inverted LED state on Blade laptops

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -1037,7 +1037,7 @@ static int has_inverted_led_state(struct device *dev)
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
     case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
     case USB_DEVICE_ID_RAZER_BLADE_QHD:
-    /* case USB_DEVICE_ID_RAZER_BLADE_LATE_2016: */
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
         return 1;
     default:
@@ -2217,5 +2217,3 @@ static struct hid_driver razer_kbd_driver = {
 };
 
 module_hid_driver(razer_kbd_driver);
-
-

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -1033,7 +1033,7 @@ static int has_inverted_led_state(struct device *dev)
     struct usb_device *usb_dev = interface_to_usbdev(intf);
 
     switch(usb_dev->descriptor.idProduct) {
-    case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
+    /* case USB_DEVICE_ID_RAZER_BLADE_STEALTH: */
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
     case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
     case USB_DEVICE_ID_RAZER_BLADE_QHD:

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -1033,12 +1033,10 @@ static int has_inverted_led_state(struct device *dev)
     struct usb_device *usb_dev = interface_to_usbdev(intf);
 
     switch(usb_dev->descriptor.idProduct) {
-    /* case USB_DEVICE_ID_RAZER_BLADE_STEALTH: */
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
     case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
     case USB_DEVICE_ID_RAZER_BLADE_QHD:
     case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
-    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
         return 1;
     default:
         return 0;


### PR DESCRIPTION
* Invert logo state for Razer Blade Stealth Late 2016
* Uninvert Razer Blade Stealth
* Uninvert Razer Blade Stealth Mid 2017

This relates to #479.