### PR TITLE
Expand effects in event sync

### DIFF
--- a/daemon/openrazer_daemon/misc/effect_sync.py
+++ b/daemon/openrazer_daemon/misc/effect_sync.py
@@ -74,17 +74,85 @@ class EffectSync(object):
                             effect_func(0x0, 0xFF, 0x00)  # Green
 
             else:
+                # setNone sets active to false and needs to be reenabled for effects to show - maybe a bit inefficient
+                if not effect_name == 'setNone':
+                    effect_func = getattr(self._parent, 'setScrollActive', None)
+                    if effect_func is not None:
+                        effect_func(True)
+                    effect_func = getattr(self._parent, 'setLogoActive', None)
+                    if effect_func is not None:
+                        effect_func(True)
+                    effect_func = getattr(self._parent, 'setBacklightActive', None)
+                    if effect_func is not None:
+                        effect_func(True)
+
                 # We dont have method
                 if effect_name == 'setPulsate':
                     # BW -> Chroma?
                     effect_func = getattr(self._parent, 'setBreathSingle', None)
                     if effect_func is not None:
-                        effect_func(0x00, 0xFF, 0x00)  # Green
-                if effect_name in ('setBreathSingle', 'setBreathRandom', 'setBreathDual'):
-                    # Chroma -> BW?
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setScrollPulsate', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setLogoPulsate', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setBacklightPulsate', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+
+                elif effect_name in ('setBreathSingle', 'setBreathRandom', 'setBreathDual'):
+                    if effect_name == 'setBreathRandom':
+                        pargs = (0x00, 0xFF, 0x00)  # Green
+                    else:
+                        pargs = args[0:4]  # limit args to first 3, as setBreathDual gives 6 args
                     effect_func = getattr(self._parent, 'setPulsate', None)
                     if effect_func is not None:
-                        effect_func()  # Pulsate
+                        effect_func(*pargs)
+                    effect_func = getattr(self._parent, 'setScrollPulsate', None)
+                    if effect_func is not None:
+                        effect_func(*pargs)
+                    effect_func = getattr(self._parent, 'setLogoPulsate', None)
+                    if effect_func is not None:
+                        effect_func(*pargs)
+                    effect_func = getattr(self._parent, 'setBacklightPulsate', None)
+                    if effect_func is not None:
+                        effect_func(*pargs)
+
+                elif effect_name == 'setNone':
+                    #print("setNone stub")
+                    effect_func = getattr(self._parent, 'setScrollActive', None)
+                    if effect_func is not None:
+                        effect_func(False)
+                    effect_func = getattr(self._parent, 'setLogoActive', None)
+                    if effect_func is not None:
+                        effect_func(False)
+                    effect_func = getattr(self._parent, 'setBacklightActive', None)
+                    if effect_func is not None:
+                        effect_func(False)
+
+                elif effect_name == 'setSpectrum':
+                    effect_func = getattr(self._parent, 'setScrollSpectrum', None)
+                    if effect_func is not None:
+                        effect_func()
+                    effect_func = getattr(self._parent, 'setLogoSpectrum', None)
+                    if effect_func is not None:
+                        effect_func()
+                    effect_func = getattr(self._parent, 'setBacklightSpectrum', None)
+                    if effect_func is not None:
+                        effect_func()
+
+                elif effect_name == 'setStatic':
+                    effect_func = getattr(self._parent, 'setScrollStatic', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setLogoStatic', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setBacklightStatic', None)
+                    if effect_func is not None:
+                        effect_func(*args)
 
         except Exception as err:
             self._logger.exception("Caught exception trying to sync effects.", exc_info=err)


### PR DESCRIPTION
Some methods (e.g. setBacklightSpectrum) are not implemented yet but are
theoretically possible and it doesn't hurt having it in there.

Tested with my DeathAdder Chroma and Kraken V1 and the effects sync properly.