### PR TITLE
Fix ripple effect on non-standard keyboards

### DIFF
--- a/daemon/openrazer_daemon/misc/ripple_effect.py
+++ b/daemon/openrazer_daemon/misc/ripple_effect.py
@@ -30,7 +30,9 @@ class RippleEffectThread(threading.Thread):
         self._shutdown = False
         self._active = False
 
-        self._kerboard_grid = KeyboardColour()
+        self._rows, self._cols = self._parent._parent.MATRIX_DIMS
+
+        self._keyboard_grid = KeyboardColour(self._rows, self._cols)
 
     @property
     def shutdown(self):
@@ -100,11 +102,20 @@ class RippleEffectThread(threading.Thread):
         # pylint: disable=too-many-nested-blocks,too-many-branches
         expire_diff = datetime.timedelta(seconds=2)
 
+        # self._parent: RippleManager
+        # self._parent._parent: The device class (e.g. RazerBlackWidowUltimate2013)
+        if self._rows == 6 and self._cols == 22:
+            needslogohandling = True
+            # a virtual 7th row for logo handling
+            self._rows += 1
+        else:
+            needslogohandling = False
+
         # TODO time execution and then sleep for _refresh_rate - time_taken
         while not self._shutdown:
             if self._active:
                 # Clear keyboard
-                self._kerboard_grid.reset_rows()
+                self._keyboard_grid.reset_rows()
 
                 now = datetime.datetime.now()
 
@@ -120,32 +131,40 @@ class RippleEffectThread(threading.Thread):
                         colour = self._colour
                     radiuses.append((key_row, key_col, now_diff.total_seconds() * 12, colour))
 
-                for row in range(0, 7):
-                    for col in range(0, 22):
-                        if row == 0 and col == 20:
+                # Iterate through the rows
+                for row in range(0, self._rows):
+                    # Iterate through the columns
+                    for col in range(0, self._cols):
+                        # The logo location is physically at (6, 11), logically at (0, 20)
+                        # Skip when we come across the logo location, as the ripple would look wrong
+                        if needslogohandling and row == 0 and col == 20:
                             continue
-                        if row == 6:
+
+                        if needslogohandling and row == 6:
                             if col != 11:
                                 continue
-                            else:
-                                # To account for logo placement
-                                for cirlce_centre_row, circle_centre_col, rad, colour in radiuses:
-                                    radius = math.sqrt(math.pow(cirlce_centre_row - row, 2) + math.pow(circle_centre_col - col, 2))
-                                    if rad >= radius >= rad - 1:
-                                        self._kerboard_grid.set_key_colour(0, 20, colour)
-                                        break
+
+                            # To account for logo placement
+                            for cirlce_centre_row, circle_centre_col, rad, colour in radiuses:
+                                radius = math.sqrt(math.pow(cirlce_centre_row - row, 2) + math.pow(circle_centre_col - col, 2))
+                                if rad >= radius >= rad - 1:
+                                    # Again, (0, 20) is the logical location of the logo led
+                                    self._keyboard_grid.set_key_colour(0, 20, colour)
+                                    break
                         else:
                             for cirlce_centre_row, circle_centre_col, rad, colour in radiuses:
                                 radius = math.sqrt(math.pow(cirlce_centre_row - row, 2) + math.pow(circle_centre_col - col, 2))
                                 if rad >= radius >= rad - 1:
-                                    self._kerboard_grid.set_key_colour(row, col, colour)
+                                    self._keyboard_grid.set_key_colour(row, col, colour)
                                     break
 
-                payload = self._kerboard_grid.get_total_binary()
+                # Set the colors on the device
+                payload = self._keyboard_grid.get_total_binary()
 
                 self._parent.set_rgb_matrix(payload)
                 self._parent.refresh_keyboard()
 
+            # Sleep until the next ripple refresh
             time.sleep(self._refresh_rate)
 
 


### PR DESCRIPTION
Until now, ripple only worked on keyboards with a (6, 22) matrix.
Blade keyboards have different sizes (e.g. (6, 16) or (6, 25)) and they
should be supported.

~~This is not tested yet but it could work.~~

Fixes #166 and fixes #353