### PR TITLE
[WIP] Fix debian revision

### DIFF
--- a/scripts/build_debs.sh
+++ b/scripts/build_debs.sh
@@ -19,8 +19,8 @@ cd ${ROOT}
 VERSION=$(cat ${ROOT}/debian/changelog | grep -m 1 -oP '(?<=openrazer \()[^\-\)]+')
 ORIG_TAR="openrazer_${VERSION}.orig.tar.gz"
 
-# Add a -1 revision to changelog for building
-sed -i 's|'$VERSION')|'$VERSION'-1)|' ${ROOT}/debian/changelog
+# Add a -0 revision to changelog for building
+sed -i 's|'$VERSION')|'$VERSION'-0)|' ${ROOT}/debian/changelog
 
 #git archive ${CURRENT_BRANCH} | gzip > ${TEMP_DIR}/${ORIG_TAR}
 tar --exclude-vcs --exclude-vcs-ignores -zcf ${TEMP_DIR}/${ORIG_TAR} -C ${ROOT} .
@@ -45,6 +45,6 @@ else
     echo -e "${RED}Failed to generate deb files. Check ${TEMP_DIR}/build.log for more details${NC}"
 fi
 
-# Add a -1 revision to changelog for building
-sed -i 's|'$VERSION'-1)|'$VERSION')|' ${ROOT}/debian/changelog
+# Add a -0 revision to changelog for building
+sed -i 's|'$VERSION'-0)|'$VERSION')|' ${ROOT}/debian/changelog
 


### PR DESCRIPTION
Don't merge this yet, it could break your workflow for PPA daily.

Currently, your packages from OBS sid, OBS 9, PPA stable and PPA daily have those versions:
```
- OBS sid: 2.3.1-1
- OBS 9: 2.3.1-1
- PPA stable: 2.3.1~ubuntu18.10.1
- PPA daily: 2.3.1-1~378~ubuntu18.04.1
```

It would be great to switch to 2.3.1-0 (debian revision to -0), because those packages don't come from debian repositories. This could lead to some troubles for updating when 'official' packages will be available. I am not sure if this PR is enough to fix this because I don't know your workflow for publishing in these different repositories. BTW, packages from PPA stable don't have any revision so they seems to use another workflow. This PR should wait until the next release (or just before) because it will break the daily packages (we will get a lower version than the current one).