### PR TITLE
Fix the ripple

### DIFF
--- a/daemon/openrazer_daemon/misc/key_event_management.py
+++ b/daemon/openrazer_daemon/misc/key_event_management.py
@@ -164,9 +164,9 @@ class KeyWatcher(threading.Thread):
                     key_data = event_file_map[event_fd].read(EVENT_SIZE)
                     if not key_data:
                         break
-                    
+
                     date, key_action, key_code = self.parse_event_record(key_data)
-                    
+
                     # Skip if date, key_action and key_code is none as that's a spacer record
                     if date is None:
                         continue
@@ -176,7 +176,7 @@ class KeyWatcher(threading.Thread):
 
     def _poll_read(self):
         for event_file in self.open_event_files:
-            
+
             key_data = event_file.read(EVENT_SIZE)
 
             if key_data is None:

--- a/daemon/openrazer_daemon/misc/key_event_management.py
+++ b/daemon/openrazer_daemon/misc/key_event_management.py
@@ -115,10 +115,9 @@ class KeyWatcher(threading.Thread):
 
         self.open_event_files = [open(event_file, 'rb') for event_file in self._event_files]
         # Set open files to non blocking mode
-        if not use_epoll:
-            for event_file in self.open_event_files:
-                flags = fcntl.fcntl(event_file.fileno(), fcntl.F_GETFL)
-                fcntl.fcntl(event_file.fileno(), fcntl.F_SETFL, flags | os.O_NONBLOCK)
+        for event_file in self.open_event_files:
+            flags = fcntl.fcntl(event_file.fileno(), fcntl.F_GETFL)
+            fcntl.fcntl(event_file.fileno(), fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
     def run(self):
         """
@@ -161,19 +160,23 @@ class KeyWatcher(threading.Thread):
         if len(events) != 0:
             # pylint: disable=unused-variable
             for event_fd, mask in events:
-                key_data = event_file_map[event_fd].read(EVENT_SIZE)
+                while True:
+                    key_data = event_file_map[event_fd].read(EVENT_SIZE)
+                    if not key_data:
+                        break
+                    
+                    date, key_action, key_code = self.parse_event_record(key_data)
+                    
+                    # Skip if date, key_action and key_code is none as that's a spacer record
+                    if date is None:
+                        continue
 
-                date, key_action, key_code = self.parse_event_record(key_data)
-
-                # Skip if date, key_action and key_code is none as that's a spacer record
-                if date is None:
-                    continue
-
-                # Now if key is pressed then we record
-                self._parent.key_action(date, key_code, key_action)
+                    # Now if key is pressed then we record
+                    self._parent.key_action(date, key_code, key_action)
 
     def _poll_read(self):
         for event_file in self.open_event_files:
+            
             key_data = event_file.read(EVENT_SIZE)
 
             if key_data is None:

--- a/daemon/openrazer_daemon/misc/ripple_effect.py
+++ b/daemon/openrazer_daemon/misc/ripple_effect.py
@@ -25,7 +25,7 @@ class RippleEffectThread(threading.Thread):
         self._parent = parent
 
         self._colour = (0, 255, 0)
-        self._refresh_rate = 0.100
+        self._refresh_rate = 0.040
 
         self._shutdown = False
         self._active = False
@@ -129,7 +129,7 @@ class RippleEffectThread(threading.Thread):
                     # Current radius is based off a time metric
                     if self._colour is not None:
                         colour = self._colour
-                    radiuses.append((key_row, key_col, now_diff.total_seconds() * 12, colour))
+                    radiuses.append((key_row, key_col, now_diff.total_seconds() * 24, colour))
 
                 # Iterate through the rows
                 for row in range(0, self._rows):
@@ -147,14 +147,14 @@ class RippleEffectThread(threading.Thread):
                             # To account for logo placement
                             for cirlce_centre_row, circle_centre_col, rad, colour in radiuses:
                                 radius = math.sqrt(math.pow(cirlce_centre_row - row, 2) + math.pow(circle_centre_col - col, 2))
-                                if rad >= radius >= rad - 1:
+                                if rad >= radius >= rad - 2:
                                     # Again, (0, 20) is the logical location of the logo led
                                     self._keyboard_grid.set_key_colour(0, 20, colour)
                                     break
                         else:
                             for cirlce_centre_row, circle_centre_col, rad, colour in radiuses:
                                 radius = math.sqrt(math.pow(cirlce_centre_row - row, 2) + math.pow(circle_centre_col - col, 2))
-                                if rad >= radius >= rad - 1:
+                                if rad >= radius >= rad - 2:
                                     self._keyboard_grid.set_key_colour(row, col, colour)
                                     break
 


### PR DESCRIPTION
OK, so I'll be honest here.
The ripple effect was too slow and buggy for me to tolerate.
So I decided to step on Python land and attempt to check what's wrong, and this is what I found.

Whenever the input watcher observes an incoming event, the sad thing is that it only reads **one** event from the keyboard, effectively delaying input by 1 event. This made the ripple not react in time, and/or sometimes just look wrong (by this I mean sometimes I would press a key, and a ripple wouldn't come, and then after a second key press (on a different key) the ripple comes out on the previous key!).

As of now the input thread reads *all* events available before getting out of the incoming event function, which makes everything work as it should.

And about the ripple, it was just too slow. I sped it up and slightly increased the radius (1-key-radius ripple doesn't look that good...).

(P.S.: the effect looks fluid at a refresh rate of 25 FPS/0.04s)