### PR TITLE
Added missing effects to Razer Blade Advanced 2019

### DIFF
--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -1080,7 +1080,7 @@ class RazerBlade2019Adv(_RippleKeyboard):
     USB_VID = 0x1532
     USB_PID = 0x023a
     HAS_MATRIX = True
-    MATRIX_DIMS = [6, 16]
+    MATRIX_DIMS = [6, 15]
     METHODS = ['get_device_type_keyboard', 'set_wave_effect', 'set_static_effect', 'set_spectrum_effect',
                'set_reactive_effect', 'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect',
                'set_breath_dual_effect', 'set_custom_effect', 'set_key_row', 'set_starlight_random_effect',

--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -1081,8 +1081,10 @@ class RazerBlade2019Adv(_RippleKeyboard):
     USB_PID = 0x023a
     HAS_MATRIX = True
     MATRIX_DIMS = [6, 16]
-    METHODS = ['get_device_type_keyboard', 'set_static_effect', 'set_spectrum_effect',
-               'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect']
+    METHODS = ['get_device_type_keyboard', 'set_wave_effect', 'set_static_effect', 'set_spectrum_effect',
+               'set_reactive_effect', 'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect',
+               'set_breath_dual_effect', 'set_custom_effect', 'set_key_row', 'set_starlight_random_effect',
+               'set_ripple_effect', 'set_ripple_effect_random_colour']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1482/blade15.png"
 

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -1881,12 +1881,15 @@ static int razer_kbd_probe(struct hid_device *hdev, const struct hid_device_id *
             break;
 
         case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_wave);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_wave);            // Wave effect
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_starlight);       // Starlight effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_spectrum);        // Spectrum effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_none);            // No effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_reactive);        // Reactive effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_breath);          // Breathing effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_static);          // Static effect
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_custom);          // Custom effect
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_custom_frame);           // Set LED matrix
             break;
 
         case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -2187,11 +2187,15 @@ static void razer_kbd_disconnect(struct hid_device *hdev)
             break;
 
         case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+            device_remove_file(&hdev->dev, &dev_attr_matrix_effect_wave);            // Wave effect
+            device_remove_file(&hdev->dev, &dev_attr_matrix_effect_starlight);       // Starlight effect
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_spectrum);        // Spectrum effect
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_none);            // No effect
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_reactive);        // Reactive effect
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_breath);          // Breathing effect
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_static);          // Static effect
+            device_remove_file(&hdev->dev, &dev_attr_matrix_effect_custom);          // Custom effect
+            device_remove_file(&hdev->dev, &dev_attr_matrix_custom_frame);           // Set LED matrix
             break;
 
         case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -1881,6 +1881,7 @@ static int razer_kbd_probe(struct hid_device *hdev, const struct hid_device_id *
             break;
 
         case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_wave);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_spectrum);        // Spectrum effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_none);            // No effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_reactive);        // Reactive effect


### PR DESCRIPTION
Support for missing effects on the Blade Advanced 2019: wave, starlight, ripple, and custom led matrix.
- Fixed MATRIX_DIMS to actual matrix size [6,15].
- Added correct effects to METHODS list. Same as Blade 2018 (non-base model).
- Added device file creation for respective effects to the keyboard driver.

This allows users of the Blade 2019 Advanced to use such effects and set the color for each individual key.
**PS**: the current drivers for the Blade 2019 Advanced do not support the aforementioned effects nor individual key lighting.