### PR TITLE
Adjusting keyboard brightness using smaller steps

### DIFF
--- a/daemon/openrazer_daemon/misc/key_event_management.py
+++ b/daemon/openrazer_daemon/misc/key_event_management.py
@@ -462,7 +462,7 @@ class KeyboardKeyManager(object):
                         current_brightness = self._parent.getBrightness()
 
                     if current_brightness > 0:
-                        current_brightness -= 20
+                        current_brightness -= 10
                         if current_brightness < 0:
                             current_brightness = 0
 
@@ -475,7 +475,7 @@ class KeyboardKeyManager(object):
                         current_brightness = self._parent.getBrightness()
 
                     if current_brightness < 100:
-                        current_brightness += 20
+                        current_brightness += 10
                         if current_brightness > 100:
                             current_brightness = 100
 


### PR DESCRIPTION
This allows people to benefit from the driver out of the box, without having to write their own custom python script if they want to get to a lower keyboard brightness.

NB: I've actually been tempted to go even lower and use a step of 5 instead of 10.