### PR TITLE
razermouse: Remove unnecessary 0x3f transaction ID

### DIFF
--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -277,10 +277,6 @@ static ssize_t razer_attr_write_mode_none(struct device *dev, struct device_attr
 
     switch (usb_dev->descriptor.idProduct) {
     case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
-        report = razer_chroma_mouse_extended_matrix_effect_none(VARSTORE, BACKLIGHT_LED);
-        report.transaction_id.id = 0x3f;
-        break;
-
     case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
         report = razer_chroma_mouse_extended_matrix_effect_none(VARSTORE, BACKLIGHT_LED);
         break;
@@ -314,7 +310,6 @@ static ssize_t razer_attr_write_mode_custom(struct device *dev, struct device_at
     case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
     case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
         report = razer_chroma_extended_matrix_effect_custom_frame();
-        report.transaction_id.id = 0x3f;
         break;
 
     case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
@@ -343,7 +338,6 @@ static ssize_t razer_attr_write_mode_static(struct device *dev, struct device_at
         switch (usb_dev->descriptor.idProduct) {
         case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
             report = razer_chroma_mouse_extended_matrix_effect_static(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0]);
-            report.transaction_id.id = 0x3f;
             break;
 
         case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
@@ -394,10 +388,6 @@ static ssize_t razer_attr_write_mode_spectrum(struct device *dev, struct device_
 
     switch (usb_dev->descriptor.idProduct) {
     case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
-        report = razer_chroma_mouse_extended_matrix_effect_spectrum(VARSTORE, BACKLIGHT_LED);
-        report.transaction_id.id = 0x3f;
-        break;
-
     case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
         report = razer_chroma_mouse_extended_matrix_effect_spectrum(VARSTORE, BACKLIGHT_LED);
         break;
@@ -428,10 +418,6 @@ static ssize_t razer_attr_write_mode_reactive(struct device *dev, struct device_
 
         switch (usb_dev->descriptor.idProduct) {
         case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
-            report = razer_chroma_mouse_extended_matrix_effect_reactive(VARSTORE, BACKLIGHT_LED, speed, (struct razer_rgb*)&buf[1]);
-            report.transaction_id.id = 0x3f;
-            break;
-
         case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
             report = razer_chroma_mouse_extended_matrix_effect_reactive(VARSTORE, BACKLIGHT_LED, speed, (struct razer_rgb*)&buf[1]);
             break;
@@ -475,10 +461,6 @@ static ssize_t razer_attr_write_mode_breath(struct device *dev, struct device_at
         default: // "Random" colour mode
             report = razer_chroma_mouse_extended_matrix_effect_breathing_random(VARSTORE, BACKLIGHT_LED);
             break;
-        }
-
-        if(usb_dev->descriptor.idProduct != USB_DEVICE_ID_RAZER_NAGA_CHROMA) { // Chroma uses ff
-            report.transaction_id.id = 0x3f;
         }
         break;
 
@@ -1001,13 +983,8 @@ static ssize_t razer_attr_write_set_key_row(struct device *dev, struct device_at
             break;
 
         case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
-            report = razer_chroma_extended_matrix_set_custom_frame(row_id, start_col, stop_col, (unsigned char*)&buf[offset]);
-            report.transaction_id.id = 0x3f;
-            break;
-
         case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
             report = razer_chroma_extended_matrix_set_custom_frame(row_id, start_col, stop_col, (unsigned char*)&buf[offset]);
-            report.transaction_id.id = 0x3f;
             break;
 
         case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
@@ -1107,7 +1084,6 @@ static ssize_t razer_attr_read_scroll_led_brightness(struct device *dev, struct 
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
         report = razer_chroma_extended_matrix_get_brightness(VARSTORE, SCROLL_WHEEL_LED);
-        report.transaction_id.id = 0x3F;
         break;
 
     default:
@@ -1138,7 +1114,6 @@ static ssize_t razer_attr_write_scroll_led_brightness(struct device *dev, struct
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
         report = razer_chroma_extended_matrix_brightness(VARSTORE, SCROLL_WHEEL_LED, brightness);
-        report.transaction_id.id = 0x3F;
         break;
 
     default:
@@ -1169,7 +1144,6 @@ static ssize_t razer_attr_read_logo_led_brightness(struct device *dev, struct de
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
         report = razer_chroma_extended_matrix_get_brightness(VARSTORE, LOGO_LED);
-        report.transaction_id.id = 0x3F;
         break;
 
     default:
@@ -1200,7 +1174,6 @@ static ssize_t razer_attr_write_logo_led_brightness(struct device *dev, struct d
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
         report = razer_chroma_extended_matrix_brightness(VARSTORE, LOGO_LED, brightness);
-        report.transaction_id.id = 0x3F;
         break;
 
     default:
@@ -1458,17 +1431,12 @@ static ssize_t razer_attr_write_scroll_mode_spectrum(struct device *dev, struct 
 
     switch(usb_dev->descriptor.idProduct) {
     case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
-        report = razer_chroma_mouse_extended_matrix_effect_spectrum(VARSTORE, SCROLL_WHEEL_LED);
-        report.transaction_id.id = 0x3f;
-        break;
-
     case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
         report = razer_chroma_mouse_extended_matrix_effect_spectrum(VARSTORE, SCROLL_WHEEL_LED);
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
         report = razer_chroma_extended_matrix_effect_spectrum(VARSTORE, SCROLL_WHEEL_LED);
-        report.transaction_id.id = 0x3f;
         break;
     }
 
@@ -1493,17 +1461,12 @@ static ssize_t razer_attr_write_scroll_mode_reactive(struct device *dev, struct 
 
         switch(usb_dev->descriptor.idProduct) {
         case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
-            report = razer_chroma_mouse_extended_matrix_effect_reactive(VARSTORE, SCROLL_WHEEL_LED, speed, (struct razer_rgb*)&buf[1]);
-            report.transaction_id.id = 0x3f;
-            break;
-
         case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
             report = razer_chroma_mouse_extended_matrix_effect_reactive(VARSTORE, SCROLL_WHEEL_LED, speed, (struct razer_rgb*)&buf[1]);
             break;
 
         case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
             report = razer_chroma_extended_matrix_effect_reactive(VARSTORE, SCROLL_WHEEL_LED, speed, (struct razer_rgb*)&buf[1]);
-            report.transaction_id.id = 0x3f;
             break;
         }
 
@@ -1583,17 +1546,12 @@ static ssize_t razer_attr_write_scroll_mode_static(struct device *dev, struct de
 
         switch(usb_dev->descriptor.idProduct) {
         case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
-            report = razer_chroma_mouse_extended_matrix_effect_static(VARSTORE, SCROLL_WHEEL_LED, (struct razer_rgb*)&buf[0]);
-            break;
-
         case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
             report = razer_chroma_mouse_extended_matrix_effect_static(VARSTORE, SCROLL_WHEEL_LED, (struct razer_rgb*)&buf[0]);
-            report.transaction_id.id = 0x3f;
             break;
 
         case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
             report = razer_chroma_extended_matrix_effect_static(VARSTORE, SCROLL_WHEEL_LED, (struct razer_rgb*)&buf[0]);
-            report.transaction_id.id = 0x3f;
             break;
         }
 
@@ -1618,17 +1576,12 @@ static ssize_t razer_attr_write_scroll_mode_none(struct device *dev, struct devi
 
     switch(usb_dev->descriptor.idProduct) {
     case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
-        report = razer_chroma_mouse_extended_matrix_effect_none(VARSTORE, SCROLL_WHEEL_LED);
-        break;
-
     case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
         report = razer_chroma_mouse_extended_matrix_effect_none(VARSTORE, SCROLL_WHEEL_LED);
-        report.transaction_id.id = 0x3f;
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
         report = razer_chroma_extended_matrix_effect_none(VARSTORE, SCROLL_WHEEL_LED);
-        report.transaction_id.id = 0x3f;
         break;
     }
 
@@ -1649,17 +1602,12 @@ static ssize_t razer_attr_write_logo_mode_spectrum(struct device *dev, struct de
 
     switch(usb_dev->descriptor.idProduct) {
     case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
-        report = razer_chroma_mouse_extended_matrix_effect_spectrum(VARSTORE, LOGO_LED);
-        break;
-
     case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
         report = razer_chroma_mouse_extended_matrix_effect_spectrum(VARSTORE, LOGO_LED);
-        report.transaction_id.id = 0x3f;
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
         report = razer_chroma_extended_matrix_effect_spectrum(VARSTORE, LOGO_LED);
-        report.transaction_id.id = 0x3f;
         break;
     }
 
@@ -1683,17 +1631,12 @@ static ssize_t razer_attr_write_logo_mode_reactive(struct device *dev, struct de
 
         switch(usb_dev->descriptor.idProduct) {
         case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
-            report = razer_chroma_mouse_extended_matrix_effect_reactive(VARSTORE, LOGO_LED, speed, (struct razer_rgb*)&buf[1]);
-            break;
-
         case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
             report = razer_chroma_mouse_extended_matrix_effect_reactive(VARSTORE, LOGO_LED, speed, (struct razer_rgb*)&buf[1]);
-            report.transaction_id.id = 0x3f;
             break;
 
         case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
             report = razer_chroma_extended_matrix_effect_reactive(VARSTORE, LOGO_LED, speed, (struct razer_rgb*)&buf[1]);
-            report.transaction_id.id = 0x3f;
             break;
         }
 
@@ -1772,17 +1715,12 @@ static ssize_t razer_attr_write_logo_mode_static(struct device *dev, struct devi
     if(count == 3) {
         switch(usb_dev->descriptor.idProduct) {
         case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
-            report = razer_chroma_mouse_extended_matrix_effect_static(VARSTORE, LOGO_LED, (struct razer_rgb*)&buf[0]);
-            break;
-
         case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
             report = razer_chroma_mouse_extended_matrix_effect_static(VARSTORE, LOGO_LED, (struct razer_rgb*)&buf[0]);
-            report.transaction_id.id = 0x3f;
             break;
 
         case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
             report = razer_chroma_extended_matrix_effect_static(VARSTORE, LOGO_LED, (struct razer_rgb*)&buf[0]);
-            report.transaction_id.id = 0x3f;
             break;
         }
 
@@ -1807,17 +1745,12 @@ static ssize_t razer_attr_write_logo_mode_none(struct device *dev, struct device
 
     switch(usb_dev->descriptor.idProduct) {
     case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
-        report = razer_chroma_mouse_extended_matrix_effect_none(VARSTORE, LOGO_LED);
-        break;
-
     case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
         report = razer_chroma_mouse_extended_matrix_effect_none(VARSTORE, LOGO_LED);
-        report.transaction_id.id = 0x3f;
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
         report = razer_chroma_extended_matrix_effect_none(VARSTORE, LOGO_LED);
-        report.transaction_id.id = 0x3f;
         break;
     }
 


### PR DESCRIPTION
* Any extended_matrix type of report already has the transaction ID
  field set to 0x3f by default.
* Group device case statements together where they are duplicated.