### PR TITLE
razermousemat_driver: remove redundant check on retval

### DIFF
--- a/driver/razermousemat_driver.c
+++ b/driver/razermousemat_driver.c
@@ -662,9 +662,6 @@ static int razer_mousemat_probe(struct hid_device *hdev, const struct hid_device
 
     }
 
-    if (retval)
-        goto exit_free;
-
     hid_set_drvdata(hdev, dev);
 
 


### PR DESCRIPTION
The check on retval is redundant as retval was initialized to zero
earlier and has not changed at the point where the check is being
made. Remove it.  Detected by static analysis with Coverity.

Addresses-Coverity: ("Logically dead code")
Signed-off-by: Colin Ian King <colin.king@canonical.com>