### PR TITLE
Add support for underglow on Huntsman Elite

### DIFF
--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -705,7 +705,7 @@ class RazerHuntsmanElite(_RippleKeyboard):
     USB_PID = 0x0226
     HAS_MATRIX = True
     WAVE_DIRS = (0, 1)
-    MATRIX_DIMS = [6, 22]
+    MATRIX_DIMS = [9, 22]
     METHODS = ['get_device_type_keyboard', 'set_wave_effect', 'set_static_effect', 'set_spectrum_effect',
                'set_reactive_effect', 'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect', 'set_breath_dual_effect',
                'set_custom_effect', 'set_key_row', 'get_game_mode', 'set_game_mode', 'get_macro_mode', 'set_macro_mode',


### PR DESCRIPTION
Modified MATRIX_DIMS for the Huntsman Elite to add underglow support. Currently only the rows for the keys on the keyboard are supported. There are 3 additional rows for the underglow lighting, resulting in there actually being 9 rows total.

Tested using the `custom_zones.py` script from examples.

Edit: Forgot to note that this is for custom lighting. The out-of-the-box options (ex. static, wave, etc.) already have underglow working properly