### PR TITLE
Fix starlight single and dual effects

### DIFF
--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/chroma_keyboard.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/chroma_keyboard.py
@@ -545,7 +545,7 @@ def set_starlight_random_effect(self, speed):
 
 
 @endpoint('razer.device.lighting.chroma', 'setStarlightSingle', in_sig='yyyy')
-def set_starlight_single_effect(self, speed, red, green, blue):
+def set_starlight_single_effect(self, red, green, blue, speed):
     """
     Set starlight mode
     """
@@ -557,11 +557,11 @@ def set_starlight_single_effect(self, speed, red, green, blue):
         driver_file.write(bytes([speed, red, green, blue]))
 
     # Notify others
-    self.send_effect_event('setStarlightSingle', speed, red, green, blue)
+    self.send_effect_event('setStarlightSingle', red, green, blue, speed)
 
 
 @endpoint('razer.device.lighting.chroma', 'setStarlightDual', in_sig='yyyyyyy')
-def set_starlight_dual_effect(self, speed, red1, green1, blue1, red2, green2, blue2):
+def set_starlight_dual_effect(self, red1, green1, blue1, red2, green2, blue2, speed):
     """
     Set starlight dual mode
     """
@@ -573,4 +573,4 @@ def set_starlight_dual_effect(self, speed, red1, green1, blue1, red2, green2, bl
         driver_file.write(bytes([speed, red1, green1, blue1, red2, green2, blue2]))
 
     # Notify others
-    self.send_effect_event('setStarlightDual', speed, red1, green1, blue1)
+    self.send_effect_event('setStarlightDual', red1, green1, blue1, red2, green2, blue2, speed)

--- a/driver/razerchromacommon.c
+++ b/driver/razerchromacommon.c
@@ -335,7 +335,6 @@ struct razer_report razer_chroma_standard_matrix_effect_starlight_dual(unsigned 
     report.arguments[4] = rgb1->g; // Green 1
     report.arguments[5] = rgb1->b; // Blue 1
 
-    // For now haven't seen any chroma using this, seen the extended version
     report.arguments[6] = rgb2->r; // Red 2
     report.arguments[7] = rgb2->g; // Green 2
     report.arguments[8] = rgb2->b; // Blue 2

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -2190,7 +2190,7 @@ static int razer_kbd_probe(struct hid_device *hdev, const struct hid_device_id *
 
         case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_wave);            // Wave effect
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_starlight);       // Starlight effect           ???????????????
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_starlight);       // Starlight effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_spectrum);        // Spectrum effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_none);            // No effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_reactive);        // Reactive effect
@@ -2521,7 +2521,7 @@ static void razer_kbd_disconnect(struct hid_device *hdev)
 
         case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_wave);            // Wave effect
-            device_remove_file(&hdev->dev, &dev_attr_matrix_effect_starlight);       // Starlight effect           ???????????????
+            device_remove_file(&hdev->dev, &dev_attr_matrix_effect_starlight);       // Starlight effect
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_spectrum);        // Spectrum effect
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_none);            // No effect
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_reactive);        // Reactive effect

--- a/pylib/openrazer/client/fx.py
+++ b/pylib/openrazer/client/fx.py
@@ -464,7 +464,7 @@ class RazerFX(BaseRazerFX):
             green = clamp_ubyte(green)
             blue = clamp_ubyte(blue)
 
-            self._lighting_dbus.setStarlightSingle(time, red, green, blue)
+            self._lighting_dbus.setStarlightSingle(red, green, blue, time)
 
             return True
         return False
@@ -522,7 +522,7 @@ class RazerFX(BaseRazerFX):
             green2 = clamp_ubyte(green2)
             blue2 = clamp_ubyte(blue2)
 
-            self._lighting_dbus.setStarlightDual(time, red, green, blue, red2, green2, blue2)
+            self._lighting_dbus.setStarlightDual(red, green, blue, red2, green2, blue2, time)
 
             return True
         return False


### PR DESCRIPTION
I noticed starlight single and dual effects didn't function properly on my keyboard (Razer Blackwidow Chroma V2) a while [back](https://github.com/openrazer/openrazer/pull/813#issuecomment-496720208), but hadn't gotten around to submitting the PR.  This should fix #902.

This PR fixes the starlight single and dual effects for the Razer Blackwidow Chroma V2 (and other starlight capable devices).

Prior to this PR:

Starlight single and dual effects only rendered monochrome lights (red in my case).

With these changes:

Starlight single and dual effects render lights with the proper selected colors.

Summary of changes:

- Fixed speed/time parameter ordering for starlight single and dual effects
- Added missing parameters for second set of RGB values for starlight dual effect
- Cleaned up an extra comment

Note:  I have successfully tested this with RazerGenie.  I had to enable starlight with a test branch because RazerGenie currently has it disabled.  I could submit a PR for enabling starlight in RazerGenie if desired.

I also cross-tested these daemon changes with the current version of Polychromatic
to verify the fix works with both frontends.