### PR TITLE
Added static color setting for Naga Trinity

### DIFF
--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -437,29 +437,31 @@ static ssize_t razer_attr_write_mode_static(struct device *dev, struct device_at
         case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
             report = razer_chroma_mouse_extended_matrix_effect_static(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0]);
             break;
-
+	
         case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
             report = razer_chroma_mouse_extended_matrix_effect_static(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0]);
             report.transaction_id.id = 0xff;
             break;
-
+            
         case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
-            struct razer_report report = get_razer_report(0x0f, 0x03, 0x0e);
+			;
+			struct razer_rgb *rgb = (struct razer_rgb*)&buf[0];
+			razer_report report = get_razer_report(0x0f, 0x03, 0x0e);
 
-            report.arguments[0] = 0x00; // Variable storage
-            report.arguments[1] = 0x00; // LED ID
-            report.arguments[2] = 0x00; // Unknown
-            report.arguments[3] = 0x00; // Unknown
-            report.arguments[4] = 0x02; // Effect ID
-            report.arguments[5] = rgb->r; // RGB 3x
-            report.arguments[6] = rgb->g;
-            report.arguments[7] = rgb->b;
-            report.arguments[8] = rgb->r;
-            report.arguments[9] = rgb->g;
-            report.arguments[10] = rgb->b;
-            report.arguments[11] = rgb->r;
-            report.arguments[12] = rgb->g;
-            report.arguments[13] = rgb->b;
+			report.arguments[0] = 0x00; // Variable storage
+			report.arguments[1] = 0x00; // LED ID
+			report.arguments[2] = 0x00; // Unknown
+			report.arguments[3] = 0x00; // Unknown
+			report.arguments[4] = 0x02; // Effect ID
+			report.arguments[5] = rgb->r; // RGB 3x
+			report.arguments[6] = rgb->g;
+			report.arguments[7] = rgb->b;
+			report.arguments[8] = rgb->r;
+			report.arguments[9] = rgb->g;
+			report.arguments[10] = rgb->b;
+			report.arguments[11] = rgb->r;
+			report.arguments[12] = rgb->g;
+			report.arguments[13] = rgb->b;
             report.transaction_id.id = 0x1f;
             break;
 

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -443,6 +443,26 @@ static ssize_t razer_attr_write_mode_static(struct device *dev, struct device_at
             report.transaction_id.id = 0xff;
             break;
 
+        case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
+			struct razer_report report = get_razer_report(0x0f, 0x03, 0x0e);
+
+			report.arguments[0] = 0x00; // Variable storage
+			report.arguments[1] = 0x00; // LED ID
+			report.arguments[2] = 0x00; // Unknown
+			report.arguments[3] = 0x00; // Unknown
+			report.arguments[4] = 0x02; // Effect ID
+			report.arguments[5] = rgb->r; // RGB 3x
+			report.arguments[6] = rgb->g;
+			report.arguments[7] = rgb->b;
+			report.arguments[8] = rgb->r;
+			report.arguments[9] = rgb->g;
+			report.arguments[10] = rgb->b;
+			report.arguments[11] = rgb->r;
+			report.arguments[12] = rgb->g;
+			report.arguments[13] = rgb->b;
+            report.transaction_id.id = 0x1f;
+            break;
+
         default:
             report = razer_chroma_standard_matrix_effect_static(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0]);
             break;
@@ -2940,6 +2960,7 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_brightness);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_static);
             break;
         }
 
@@ -3251,6 +3272,7 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
             device_remove_file(&hdev->dev, &dev_attr_dpi);
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
             device_remove_file(&hdev->dev, &dev_attr_matrix_brightness);
+            device_remove_file(&hdev->dev, &dev_attr_matrix_effect_static);
             break;
         }
 

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -444,24 +444,24 @@ static ssize_t razer_attr_write_mode_static(struct device *dev, struct device_at
             break;
             
         case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
-			;
-			struct razer_rgb *rgb = (struct razer_rgb*)&buf[0];
-			razer_report report = get_razer_report(0x0f, 0x03, 0x0e);
+            ;
+            struct razer_rgb *rgb = (struct razer_rgb*)&buf[0];
+            razer_report report = get_razer_report(0x0f, 0x03, 0x0e);
 
-			report.arguments[0] = 0x00; // Variable storage
-			report.arguments[1] = 0x00; // LED ID
-			report.arguments[2] = 0x00; // Unknown
-			report.arguments[3] = 0x00; // Unknown
-			report.arguments[4] = 0x02; // Effect ID
-			report.arguments[5] = rgb->r; // RGB 3x
-			report.arguments[6] = rgb->g;
-			report.arguments[7] = rgb->b;
-			report.arguments[8] = rgb->r;
-			report.arguments[9] = rgb->g;
-			report.arguments[10] = rgb->b;
-			report.arguments[11] = rgb->r;
-			report.arguments[12] = rgb->g;
-			report.arguments[13] = rgb->b;
+            report.arguments[0] = 0x00; // Variable storage
+            report.arguments[1] = 0x00; // LED ID
+            report.arguments[2] = 0x00; // Unknown
+            report.arguments[3] = 0x00; // Unknown
+            report.arguments[4] = 0x02; // Effect ID
+            report.arguments[5] = rgb->r; // RGB 3x
+            report.arguments[6] = rgb->g;
+            report.arguments[7] = rgb->b;
+            report.arguments[8] = rgb->r;
+            report.arguments[9] = rgb->g;
+            report.arguments[10] = rgb->b;
+            report.arguments[11] = rgb->r;
+            report.arguments[12] = rgb->g;
+            USB_DEVICE_ID_RAZER_NAGA_TRINITYreport.arguments[13] = rgb->b;
             report.transaction_id.id = 0x1f;
             break;
 

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -444,22 +444,22 @@ static ssize_t razer_attr_write_mode_static(struct device *dev, struct device_at
             break;
 
         case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
-			struct razer_report report = get_razer_report(0x0f, 0x03, 0x0e);
+            struct razer_report report = get_razer_report(0x0f, 0x03, 0x0e);
 
-			report.arguments[0] = 0x00; // Variable storage
-			report.arguments[1] = 0x00; // LED ID
-			report.arguments[2] = 0x00; // Unknown
-			report.arguments[3] = 0x00; // Unknown
-			report.arguments[4] = 0x02; // Effect ID
-			report.arguments[5] = rgb->r; // RGB 3x
-			report.arguments[6] = rgb->g;
-			report.arguments[7] = rgb->b;
-			report.arguments[8] = rgb->r;
-			report.arguments[9] = rgb->g;
-			report.arguments[10] = rgb->b;
-			report.arguments[11] = rgb->r;
-			report.arguments[12] = rgb->g;
-			report.arguments[13] = rgb->b;
+            report.arguments[0] = 0x00; // Variable storage
+            report.arguments[1] = 0x00; // LED ID
+            report.arguments[2] = 0x00; // Unknown
+            report.arguments[3] = 0x00; // Unknown
+            report.arguments[4] = 0x02; // Effect ID
+            report.arguments[5] = rgb->r; // RGB 3x
+            report.arguments[6] = rgb->g;
+            report.arguments[7] = rgb->b;
+            report.arguments[8] = rgb->r;
+            report.arguments[9] = rgb->g;
+            report.arguments[10] = rgb->b;
+            report.arguments[11] = rgb->r;
+            report.arguments[12] = rgb->g;
+            report.arguments[13] = rgb->b;
             report.transaction_id.id = 0x1f;
             break;
 


### PR DESCRIPTION
The USB payload format is very different from everything else so I had to create the report and set the attributes in the Trinity Naga case for razer_attr_write_mode_static().

I was going to wait until I did other lighting modes to merge this but I found out every other lighting mode just uses this static mode and updates it very frequently with software, so there isn't really anything more I can implement here as far as I know. If you think differently, let me know. I may have some more time available to put into this.