### PR TITLE
Add NixOS to list of supported distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Packages are available for these distributions:
 * [Fedora](https://openrazer.github.io/#fedora)
 * [openSUSE](https://openrazer.github.io/#opensuse)
 * [Gentoo](https://openrazer.github.io/#gentoo)
+* [NixOS](https://openrazer.github.io/#nixos)
 * [Solus](https://openrazer.github.io/#solus)
 * [Void Linux](https://openrazer.github.io/#voidlinux)
 * [Red Hat / CentOS](https://openrazer.github.io/#redhat) (unofficial)


### PR DESCRIPTION
Forgot to add NixOS to this list when I made https://github.com/openrazer/openrazer.github.io/pull/9.
Uncertain about order or whether it's "official" (as the list on the actual [page](https://openrazer.github.io/) is different than the README.