### PR TITLE
Add support rbg starlight for blade kbd and others

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -1176,6 +1176,21 @@ static ssize_t razer_attr_write_mode_starlight(struct device *dev, struct device
         }
         break;
 
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
+        if(count == 7) {
+            report = razer_chroma_standard_matrix_effect_starlight_dual(VARSTORE, BACKLIGHT_LED, buf[0], (struct razer_rgb*)&buf[1], (struct razer_rgb*)&buf[4]);
+            razer_send_payload(usb_dev, &report);
+        } else if(count == 4) {
+            report = razer_chroma_standard_matrix_effect_starlight_single(VARSTORE, BACKLIGHT_LED, buf[0], (struct razer_rgb*)&buf[1]);
+            razer_send_payload(usb_dev, &report);
+        } else if(count == 1) {
+            report = razer_chroma_standard_matrix_effect_starlight_random(VARSTORE, BACKLIGHT_LED, buf[0]);
+            razer_send_payload(usb_dev, &report);
+        } else {
+            printk(KERN_WARNING "razerkbd: Starlight only accepts Speed (1byte). Speed, RGB (4byte). Speed, RGB, RGB (7byte)");
+        }
+        break;
+
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
         if(count == 7) {
             report = razer_chroma_standard_matrix_effect_starlight_dual(VARSTORE, BACKLIGHT_LED, buf[0], (struct razer_rgb*)&buf[1], (struct razer_rgb*)&buf[4]);


### PR DESCRIPTION
Add support for different modes' starlight for blade laptop and some other keyboard

Tested equipment: **Razer Blade Stealth Late 2017**
TODO: test for others

Ref:
`razer_attr_write_mode_static(...)` from `driver/razerkbd_driver.c`

-------------------------------------------separate line-------------------------------------------
Welcome to test these devices below, once fully tested and succeeded, please leave a comment or ping me by email, so I can update this list, thanks!
  
- [x] RAZER BLADE STEALTH LATE 2017
~~RAZER BLACKWIDOW ULTIMATE 2016
RAZER BLACKWIDOW X ULTIMATE
RAZER BLADE STEALTH
RAZER BLADE STEALTH LATE 2016
RAZER BLADE STEALTH MID 2017
RAZER BLADE QHD
RAZER BLADE PRO LATE 2016
RAZER BLADE 2018
RAZER BLADE 2018 MERCURY
RAZER BLADE 2019 ADV
RAZER BLADE MID 2019 MERCURY
RAZER BLADE LATE 2016
RAZER BLADE PRO 2017
RAZER BLADE PRO 2017 FULLHD~~

-------------------------------------------update-------------------------------------------
bladeStealthLate2017 has been fully tested for this feature.
Reset changes for untested devices, whoever want to add this feature to above devices, can reference my earlier changes on this branch.