### PR TITLE
Fixes for building with MSVC compiler

### DIFF
--- a/driver/razeraccessory_driver.c
+++ b/driver/razeraccessory_driver.c
@@ -43,7 +43,7 @@ MODULE_LICENSE(DRIVER_LICENSE);
 /**
  * Send report to the mouse
  */
-int razer_get_report(struct usb_device *usb_dev, struct razer_report *request_report, struct razer_report *response_report)
+static int razer_get_report(struct usb_device *usb_dev, struct razer_report *request_report, struct razer_report *response_report)
 {
     return razer_get_usb_response(usb_dev, 0x00, request_report, 0x00, response_report, 600, 800);
 }
@@ -51,7 +51,7 @@ int razer_get_report(struct usb_device *usb_dev, struct razer_report *request_re
 /**
  * Function to send to device, get response, and actually check the response
  */
-struct razer_report razer_send_payload(struct usb_device *usb_dev, struct razer_report *request_report)
+static struct razer_report razer_send_payload(struct usb_device *usb_dev, struct razer_report *request_report)
 {
     int retval = -1;
     struct razer_report response_report = {0};
@@ -85,7 +85,7 @@ struct razer_report razer_send_payload(struct usb_device *usb_dev, struct razer_
 /**
  * Device mode function
  */
-void razer_set_device_mode(struct usb_device *usb_dev, unsigned char mode, unsigned char param)
+static void razer_set_device_mode(struct usb_device *usb_dev, unsigned char mode, unsigned char param)
 {
     struct razer_report report = razer_chroma_standard_set_device_mode(mode, param);
     report.transaction_id.id = 0x3F;
@@ -738,7 +738,7 @@ static int razer_raw_event(struct hid_device *hdev, struct hid_report *report, u
  */
 static const struct hid_device_id razer_devices[] = {
     { HID_USB_DEVICE(USB_VENDOR_ID_RAZER,USB_DEVICE_ID_RAZER_CHROMA_MUG) },
-    { }
+    { 0 }
 };
 
 MODULE_DEVICE_TABLE(hid, razer_devices);

--- a/driver/razercore_driver.c
+++ b/driver/razercore_driver.c
@@ -44,7 +44,7 @@ MODULE_LICENSE(DRIVER_LICENSE);
 /**
  * Send report to the core
  */
-int razer_get_report(struct usb_device *usb_dev, struct razer_report *request_report, struct razer_report *response_report)
+static int razer_get_report(struct usb_device *usb_dev, struct razer_report *request_report, struct razer_report *response_report)
 {
     return razer_get_usb_response(usb_dev, 0x00, request_report, 0x00, response_report, RAZER_CORE_WAIT_MIN_US, RAZER_CORE_WAIT_MAX_US);
 }
@@ -52,7 +52,7 @@ int razer_get_report(struct usb_device *usb_dev, struct razer_report *request_re
 /**
  * Function to send to device, get response, and actually check the response
  */
-struct razer_report razer_send_payload(struct usb_device *usb_dev, struct razer_report *request_report)
+static struct razer_report razer_send_payload(struct usb_device *usb_dev, struct razer_report *request_report)
 {
     int retval = -1;
     struct razer_report response_report = {0};
@@ -561,7 +561,7 @@ static void razer_core_disconnect(struct hid_device *hdev)
  */
 static const struct hid_device_id razer_devices[] = {
     { HID_USB_DEVICE(USB_VENDOR_ID_RAZER,USB_DEVICE_ID_RAZER_CORE) },
-    { }
+    { 0 }
 };
 
 MODULE_DEVICE_TABLE(hid, razer_devices);

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -73,7 +73,7 @@ static const struct razer_key_translation chroma_keys[] = {
 
     // Custom bind
     { KEY_KPENTER, KEY_CALC },
-    { }
+    { 0 }
 };
 
 static const struct razer_key_translation chroma_keys_2[] = {
@@ -90,7 +90,7 @@ static const struct razer_key_translation chroma_keys_2[] = {
     { KEY_RIGHTALT,    RAZER_MACRO_KEY },
 
     { KEY_PAUSE, KEY_SLEEP },
-    { }
+    { 0 }
 };
 
 /**
@@ -207,7 +207,7 @@ static ssize_t razer_attr_read_kbd_layout(struct device *dev, struct device_attr
 /**
  * Device mode function
  */
-void razer_set_device_mode(struct usb_device *usb_dev, unsigned char mode, unsigned char param)
+static void razer_set_device_mode(struct usb_device *usb_dev, unsigned char mode, unsigned char param)
 {
     struct razer_report report = razer_chroma_standard_set_device_mode(mode, param);
 

--- a/driver/razerkraken_driver.c
+++ b/driver/razerkraken_driver.c
@@ -42,6 +42,7 @@ MODULE_LICENSE(DRIVER_LICENSE);
 /**
  * Print report to syslog
  */
+/*
 static void print_erroneous_kraken_request_report(struct razer_kraken_request_report* report, char* driver_name, char* message)
 {
     printk(KERN_WARNING "%s: %s. Report ID: %02x dest: %02x length: %02x ADDR: %02x%02x Args: %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x .\n",
@@ -56,6 +57,7 @@ static void print_erroneous_kraken_request_report(struct razer_kraken_request_re
            report->arguments[6], report->arguments[7], report->arguments[8], report->arguments[9], report->arguments[10], report->arguments[11],
            report->arguments[12], report->arguments[13], report->arguments[14], report->arguments[15]);
 }
+*/
 
 static int razer_kraken_send_control_msg(struct usb_device *usb_dev,struct razer_kraken_request_report* report, unsigned char skip)
 {

--- a/driver/razerkraken_driver.c
+++ b/driver/razerkraken_driver.c
@@ -42,7 +42,7 @@ MODULE_LICENSE(DRIVER_LICENSE);
 /**
  * Print report to syslog
  */
-void print_erroneous_kraken_request_report(struct razer_kraken_request_report* report, char* driver_name, char* message)
+static void print_erroneous_kraken_request_report(struct razer_kraken_request_report* report, char* driver_name, char* message)
 {
     printk(KERN_WARNING "%s: %s. Report ID: %02x dest: %02x length: %02x ADDR: %02x%02x Args: %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x .\n",
            driver_name,
@@ -57,7 +57,7 @@ void print_erroneous_kraken_request_report(struct razer_kraken_request_report* r
            report->arguments[12], report->arguments[13], report->arguments[14], report->arguments[15]);
 }
 
-int razer_kraken_send_control_msg(struct usb_device *usb_dev,struct razer_kraken_request_report* report, unsigned char skip)
+static int razer_kraken_send_control_msg(struct usb_device *usb_dev,struct razer_kraken_request_report* report, unsigned char skip)
 {
     uint request = HID_REQ_SET_REPORT; // 0x09
     uint request_type = USB_TYPE_CLASS | USB_RECIP_INTERFACE | USB_DIR_OUT; // 0x21
@@ -101,7 +101,7 @@ int razer_kraken_send_control_msg(struct usb_device *usb_dev,struct razer_kraken
  * length - amount of data
  * address - where to write data to
  */
-struct razer_kraken_request_report get_kraken_request_report(unsigned char report_id, unsigned char destination, unsigned char length, unsigned short address)
+static struct razer_kraken_request_report get_kraken_request_report(unsigned char report_id, unsigned char destination, unsigned char length, unsigned short address)
 {
     struct razer_kraken_request_report report;
     memset(&report, 0, sizeof(struct razer_kraken_request_report));
@@ -118,7 +118,7 @@ struct razer_kraken_request_report get_kraken_request_report(unsigned char repor
 /**
  * Get a union containing the effect bitfield
  */
-union razer_kraken_effect_byte get_kraken_effect_byte(void)
+static union razer_kraken_effect_byte get_kraken_effect_byte(void)
 {
     union razer_kraken_effect_byte effect_byte;
     memset(&effect_byte, 0, sizeof(union razer_kraken_effect_byte));
@@ -129,7 +129,7 @@ union razer_kraken_effect_byte get_kraken_effect_byte(void)
 /**
  * Get the current effect
  */
-unsigned char get_current_effect(struct device *dev)
+static unsigned char get_current_effect(struct device *dev)
 {
     struct razer_kraken_device *device = dev_get_drvdata(dev);
     struct razer_kraken_request_report report = get_kraken_request_report(0x04, 0x00, 0x01, device->led_mode_address);
@@ -160,7 +160,7 @@ unsigned char get_current_effect(struct device *dev)
     return result;
 }
 
-unsigned int get_rgb_from_addr(struct device *dev, unsigned short address, unsigned char len, char* buf)
+static unsigned int get_rgb_from_addr(struct device *dev, unsigned short address, unsigned char len, char* buf)
 {
     struct razer_kraken_device *device = dev_get_drvdata(dev);
     struct razer_kraken_request_report report = get_kraken_request_report(0x04, 0x00, len, address);
@@ -526,8 +526,10 @@ static ssize_t razer_attr_write_mode_breath(struct device *dev, struct device_at
 static ssize_t razer_attr_read_mode_breath(struct device *dev, struct device_attribute *attr, char *buf)
 {
     struct razer_kraken_device *device = dev_get_drvdata(dev);
-    union razer_kraken_effect_byte effect_byte = (union razer_kraken_effect_byte)get_current_effect(dev);
+    union razer_kraken_effect_byte effect_byte;
     unsigned char num_colours = 1;
+
+    effect_byte.value = get_current_effect(dev);
 
     if(effect_byte.bits.two_colour_breathing == 1) {
         num_colours = 2;
@@ -686,7 +688,7 @@ static DEVICE_ATTR(matrix_effect_static,    0660, razer_attr_read_mode_static,  
 static DEVICE_ATTR(matrix_effect_custom,    0660, razer_attr_read_mode_custom,                razer_attr_write_mode_custom);
 static DEVICE_ATTR(matrix_effect_breath,    0660, razer_attr_read_mode_breath,                razer_attr_write_mode_breath);
 
-void razer_kraken_init(struct razer_kraken_device *dev, struct usb_interface *intf)
+static void razer_kraken_init(struct razer_kraken_device *dev, struct usb_interface *intf)
 {
     struct usb_device *usb_dev = interface_to_usbdev(intf);
     unsigned int rand_serial = 0;
@@ -857,7 +859,7 @@ static const struct hid_device_id razer_devices[] = {
     { HID_USB_DEVICE(USB_VENDOR_ID_RAZER,USB_DEVICE_ID_RAZER_KRAKEN_CLASSIC_ALT) },
     { HID_USB_DEVICE(USB_VENDOR_ID_RAZER,USB_DEVICE_ID_RAZER_KRAKEN) },
     { HID_USB_DEVICE(USB_VENDOR_ID_RAZER,USB_DEVICE_ID_RAZER_KRAKEN_V2) },
-    { }
+    { 0 }
 };
 
 MODULE_DEVICE_TABLE(hid, razer_devices);

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -44,7 +44,7 @@ MODULE_LICENSE(DRIVER_LICENSE);
 /**
  * Send report to the mouse
  */
-int razer_get_report(struct usb_device *usb_dev, struct razer_report *request_report, struct razer_report *response_report)
+static int razer_get_report(struct usb_device *usb_dev, struct razer_report *request_report, struct razer_report *response_report)
 {
     return razer_get_usb_response(usb_dev, 0x00, request_report, 0x00, response_report, RAZER_MOUSE_WAIT_MIN_US, RAZER_MOUSE_WAIT_MAX_US);
 }
@@ -52,7 +52,7 @@ int razer_get_report(struct usb_device *usb_dev, struct razer_report *request_re
 /**
  * Function to send to device, get response, and actually check the response
  */
-struct razer_report razer_send_payload(struct usb_device *usb_dev, struct razer_report *request_report)
+static struct razer_report razer_send_payload(struct usb_device *usb_dev, struct razer_report *request_report)
 {
     int retval = -1;
     struct razer_report response_report = {0};
@@ -87,7 +87,7 @@ struct razer_report razer_send_payload(struct usb_device *usb_dev, struct razer_
  * Specific functions for ancient devices
  *
  */
-void deathadder3_5g_set_scroll_led_state(struct razer_mouse_device *device, unsigned int enabled)
+static void deathadder3_5g_set_scroll_led_state(struct razer_mouse_device *device, unsigned int enabled)
 {
     if (enabled == 1) {
         device->da3_5g.leds |= 0x02;
@@ -100,7 +100,7 @@ void deathadder3_5g_set_scroll_led_state(struct razer_mouse_device *device, unsi
     mutex_unlock(&device->lock);
 }
 
-void deathadder3_5g_set_logo_led_state(struct razer_mouse_device *device, unsigned int enabled)
+static void deathadder3_5g_set_logo_led_state(struct razer_mouse_device *device, unsigned int enabled)
 {
     if (enabled == 1) {
         device->da3_5g.leds |= 0x01;
@@ -113,7 +113,7 @@ void deathadder3_5g_set_logo_led_state(struct razer_mouse_device *device, unsign
     mutex_unlock(&device->lock);
 }
 
-void deathadder3_5g_set_poll_rate(struct razer_mouse_device *device, unsigned short poll_rate)
+static void deathadder3_5g_set_poll_rate(struct razer_mouse_device *device, unsigned short poll_rate)
 {
     switch(poll_rate) {
     case 1000:
@@ -135,7 +135,7 @@ void deathadder3_5g_set_poll_rate(struct razer_mouse_device *device, unsigned sh
     mutex_unlock(&device->lock);
 }
 
-void deathadder3_5g_set_dpi(struct razer_mouse_device *device, unsigned short dpi)
+static void deathadder3_5g_set_dpi(struct razer_mouse_device *device, unsigned short dpi)
 {
     switch(dpi) {
     case 450:
@@ -2642,7 +2642,7 @@ static int razer_raw_event(struct hid_device *hdev, struct hid_report *report, u
 /**
  * Mouse init function
  */
-void razer_mouse_init(struct razer_mouse_device *dev, struct usb_interface *intf, struct hid_device *hdev)
+static void razer_mouse_init(struct razer_mouse_device *dev, struct usb_interface *intf, struct hid_device *hdev)
 {
     struct usb_device *usb_dev = interface_to_usbdev(intf);
     unsigned int rand_serial = 0;
@@ -3336,7 +3336,7 @@ static const struct hid_device_id razer_devices[] = {
     { HID_USB_DEVICE(USB_VENDOR_ID_RAZER,USB_DEVICE_ID_RAZER_NAGA_TRINITY) },
     { HID_USB_DEVICE(USB_VENDOR_ID_RAZER,USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL) },
     { HID_USB_DEVICE(USB_VENDOR_ID_RAZER,USB_DEVICE_ID_RAZER_DEATHADDER_1800) },
-    { }
+    { 0 }
 };
 
 MODULE_DEVICE_TABLE(hid, razer_devices);

--- a/driver/razermousemat_driver.c
+++ b/driver/razermousemat_driver.c
@@ -45,7 +45,7 @@ static unsigned char saved_brightness = 0;
 /**
  * Send report to the mousemat
  */
-int razer_get_report(struct usb_device *usb_dev, struct razer_report *request_report, struct razer_report *response_report)
+static int razer_get_report(struct usb_device *usb_dev, struct razer_report *request_report, struct razer_report *response_report)
 {
     return razer_get_usb_response(usb_dev, 0x00, request_report, 0x00, response_report, RAZER_MOUSEMAT_WAIT_MIN_US, RAZER_MOUSEMAT_WAIT_MAX_US);
 }
@@ -53,7 +53,7 @@ int razer_get_report(struct usb_device *usb_dev, struct razer_report *request_re
 /**
  * Function to send to device, get response, and actually check the response
  */
-struct razer_report razer_send_payload(struct usb_device *usb_dev, struct razer_report *request_report)
+static struct razer_report razer_send_payload(struct usb_device *usb_dev, struct razer_report *request_report)
 {
     int retval = -1;
     struct razer_report response_report = {0};
@@ -781,7 +781,7 @@ static const struct hid_device_id razer_devices[] = {
     { HID_USB_DEVICE(USB_VENDOR_ID_RAZER,USB_DEVICE_ID_RAZER_FIREFLY_HYPERFLUX) },
     { HID_USB_DEVICE(USB_VENDOR_ID_RAZER,USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA) },
     { HID_USB_DEVICE(USB_VENDOR_ID_RAZER,USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA_EXTENDED) },
-    { }
+    { 0 }
 };
 
 MODULE_DEVICE_TABLE(hid, razer_devices);


### PR DESCRIPTION
This replaces PR #1002.

I cleaned up the Linux compile error as directed.  This doesn't add the WIN32 declarations, it just makes all the driver-specific functions static and uses { 0 } instead of { } for list termination.  These changes allow the driver to build using rsandoz's wrapper on Windows.