### PR TITLE
Allow partial row updates in Blackwidow Ultimate 2014

### DIFF
--- a/driver/razerchromacommon.c
+++ b/driver/razerchromacommon.c
@@ -485,6 +485,34 @@ struct razer_report razer_chroma_standard_matrix_set_custom_frame(unsigned char 
 }
 
 
+/**
+ * Set the RGB or a row
+ *
+ * All arguments are similar to razer_chroma_standard_matrix_set_custom_frame()
+ *
+ * Main difference is that the arguments holding color data are themselves NOT
+ * offset by +start_col+, but are placed directly after stop_color. This leads
+ * to positive results on a "Razer Blackwidow Ultimate 2014", which identifies
+ * as a "Razer Blackwidow Chroma" (0x0203)
+ */
+struct razer_report razer_chroma_standard_matrix_set_custom_frame_without_offset(unsigned char row_index, unsigned char start_col, unsigned char stop_col, unsigned char *rgb_data)
+{
+    size_t row_length = (size_t) (((stop_col + 1) - start_col) * 3);
+    struct razer_report report = get_razer_report(0x03, 0x0B, 0x46); // In theory should be able to leave data size at max as we have start/stop
+
+    // printk(KERN_ALERT "razerkbd: Row ID: %d, Start: %d, Stop: %d, row length: %d\n", row_index, start_col, stop_col, (unsigned char)row_length);
+
+    report.arguments[0] = 0xFF; // Frame ID
+    report.arguments[1] = row_index;
+    report.arguments[2] = start_col;
+    report.arguments[3] = stop_col;
+    memcpy(&report.arguments[4], rgb_data, row_length);
+
+    return report;
+}
+
+
+
 /*
  * Extended Matrix Effects
  */

--- a/driver/razerchromacommon.h
+++ b/driver/razerchromacommon.h
@@ -48,6 +48,7 @@ struct razer_report razer_chroma_standard_matrix_effect_breathing_single(unsigne
 struct razer_report razer_chroma_standard_matrix_effect_breathing_dual(unsigned char variable_storage, unsigned char led_id, struct razer_rgb *rgb1, struct razer_rgb *rgb2);
 struct razer_report razer_chroma_standard_matrix_effect_custom_frame(unsigned char variable_storage);
 struct razer_report razer_chroma_standard_matrix_set_custom_frame(unsigned char row_index, unsigned char start_col, unsigned char stop_col, unsigned char *rgb_data);
+struct razer_report razer_chroma_standard_matrix_set_custom_frame_without_offset(unsigned char row_index, unsigned char start_col, unsigned char stop_col, unsigned char *rgb_data);
 
 
 /*

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -1607,6 +1607,10 @@ static ssize_t razer_attr_write_matrix_custom_frame(struct device *dev, struct d
             report = razer_chroma_misc_one_row_set_custom_frame(start_col, stop_col, (unsigned char*)&buf[offset]);
             break;
 
+        case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+            report = razer_chroma_standard_matrix_set_custom_frame_without_offset(row_id, start_col, stop_col, (unsigned char*)&buf[offset]);
+            break;
+
         case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
         case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
             report = razer_chroma_standard_matrix_set_custom_frame(row_id, start_col, stop_col, (unsigned char*)&buf[offset]);


### PR DESCRIPTION
It identifies as Blackwidow Chroma (USB id: 0x0203).
This allows to set partial rows not beginning at index 0 by removing the
offset for color arguments in report for partial row updates.

The following line sets only WASD to white,red,green,blue respectively:

`echo -n -e "\x2\x3\x3\xff\xff\xff\x3\x2\x4\xff\x11\x11\x22\xff\x22\x33\x33\xff" > matrix_custom_frame && echo -n 1 > matrix_effect_custom && echo done`

Without this, the submitted colors are offset by `start_col`, with the first `start_col` keys staying off.