### PR TITLE
razerkbd: fix fn key on some devices

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -1975,7 +1975,7 @@ static int razer_raw_event(struct hid_device *hdev, struct hid_report *report, u
     }
 
     // The event were looking for is 16 bytes long and starts with 0x04
-    if(intf->cur_altsetting->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_KEYBOARD && size == 16 && data[0] == 0x04) {
+    if(intf->cur_altsetting->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_KEYBOARD && data[0] == 0x04) {
         // Convert 04... to 0100...
         int index = size-1; // This way we start at 2nd last value, does subtract 1 from the 15key rollover though (not an issue cmon)
         u8 cur_value = 0x00;


### PR DESCRIPTION
The size check is unneccessary because only the events we're looking for
have 0x04 as the first byte.

Fixes #872
Closes #873

