### PR TITLE
Use different profile LED IDs for some keypads

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -652,8 +652,20 @@ static ssize_t razer_attr_read_tartarus_profile_led_red(struct device *dev, stru
 {
     struct usb_interface *intf = to_usb_interface(dev->parent);
     struct usb_device *usb_dev = interface_to_usbdev(intf);
-    struct razer_report report = razer_chroma_standard_get_led_state(VARSTORE, RED_PROFILE_LED);
-    struct razer_report response = razer_send_payload(usb_dev, &report);
+    struct razer_report report = {0};
+    struct razer_report response = {0};
+
+    switch(usb_dev->descriptor.idProduct) {
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
+        report = razer_chroma_standard_get_led_state(VARSTORE, BLUE_PROFILE_LED);
+        break;
+    default:
+        report = razer_chroma_standard_get_led_state(VARSTORE, RED_PROFILE_LED);
+        break;
+    }
+
+    response = razer_send_payload(usb_dev, &report);
 
     return sprintf(buf, "%d\n", response.arguments[2]);
 }
@@ -667,8 +679,20 @@ static ssize_t razer_attr_read_tartarus_profile_led_green(struct device *dev, st
 {
     struct usb_interface *intf = to_usb_interface(dev->parent);
     struct usb_device *usb_dev = interface_to_usbdev(intf);
-    struct razer_report report = razer_chroma_standard_get_led_state(VARSTORE, GREEN_PROFILE_LED);
-    struct razer_report response = razer_send_payload(usb_dev, &report);
+    struct razer_report report = {0};
+    struct razer_report response = {0};
+
+    switch(usb_dev->descriptor.idProduct) {
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
+        report = razer_chroma_standard_get_led_state(VARSTORE, RED_PROFILE_LED);
+        break;
+    default:
+        report = razer_chroma_standard_get_led_state(VARSTORE, GREEN_PROFILE_LED);
+        break;
+    }
+
+    response = razer_send_payload(usb_dev, &report);
 
     return sprintf(buf, "%d\n", response.arguments[2]);
 }
@@ -682,8 +706,20 @@ static ssize_t razer_attr_read_tartarus_profile_led_blue(struct device *dev, str
 {
     struct usb_interface *intf = to_usb_interface(dev->parent);
     struct usb_device *usb_dev = interface_to_usbdev(intf);
-    struct razer_report report = razer_chroma_standard_get_led_state(VARSTORE, BLUE_PROFILE_LED);
-    struct razer_report response = razer_send_payload(usb_dev, &report);
+    struct razer_report report = {0};
+    struct razer_report response = {0};
+
+    switch(usb_dev->descriptor.idProduct) {
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
+        report = razer_chroma_standard_get_led_state(VARSTORE, GREEN_PROFILE_LED);
+        break;
+    default:
+        report = razer_chroma_standard_get_led_state(VARSTORE, BLUE_PROFILE_LED);
+        break;
+    }
+
+    response = razer_send_payload(usb_dev, &report);
 
     return sprintf(buf, "%d\n", response.arguments[2]);
 }
@@ -696,7 +732,17 @@ static ssize_t razer_attr_write_tartarus_profile_led_red(struct device *dev, str
     struct usb_interface *intf = to_usb_interface(dev->parent);
     struct usb_device *usb_dev = interface_to_usbdev(intf);
     unsigned char enabled = (unsigned char)simple_strtoul(buf, NULL, 10);
-    struct razer_report report = razer_chroma_standard_set_led_state(VARSTORE, RED_PROFILE_LED, enabled);
+    struct razer_report report = {0};
+
+    switch(usb_dev->descriptor.idProduct) {
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
+        report = razer_chroma_standard_set_led_state(VARSTORE, BLUE_PROFILE_LED, enabled);
+        break;
+    default:
+        report = razer_chroma_standard_set_led_state(VARSTORE, RED_PROFILE_LED, enabled);
+        break;
+    }
 
     razer_send_payload(usb_dev, &report);
 
@@ -711,7 +757,17 @@ static ssize_t razer_attr_write_tartarus_profile_led_green(struct device *dev, s
     struct usb_interface *intf = to_usb_interface(dev->parent);
     struct usb_device *usb_dev = interface_to_usbdev(intf);
     unsigned char enabled = (unsigned char)simple_strtoul(buf, NULL, 10);
-    struct razer_report report = razer_chroma_standard_set_led_state(VARSTORE, GREEN_PROFILE_LED, enabled);
+    struct razer_report report = {0};
+
+    switch(usb_dev->descriptor.idProduct) {
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
+        report = razer_chroma_standard_set_led_state(VARSTORE, RED_PROFILE_LED, enabled);
+        break;
+    default:
+        report = razer_chroma_standard_set_led_state(VARSTORE, GREEN_PROFILE_LED, enabled);
+        break;
+    }
 
     razer_send_payload(usb_dev, &report);
     return count;
@@ -725,7 +781,17 @@ static ssize_t razer_attr_write_tartarus_profile_led_blue(struct device *dev, st
     struct usb_interface *intf = to_usb_interface(dev->parent);
     struct usb_device *usb_dev = interface_to_usbdev(intf);
     unsigned char enabled = (unsigned char)simple_strtoul(buf, NULL, 10);
-    struct razer_report report = razer_chroma_standard_set_led_state(VARSTORE, BLUE_PROFILE_LED, enabled);
+    struct razer_report report = {0};
+
+    switch(usb_dev->descriptor.idProduct) {
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
+        report = razer_chroma_standard_set_led_state(VARSTORE, GREEN_PROFILE_LED, enabled);
+        break;
+    default:
+        report = razer_chroma_standard_set_led_state(VARSTORE, BLUE_PROFILE_LED, enabled);
+        break;
+    }
 
     razer_send_payload(usb_dev, &report);
     return count;


### PR DESCRIPTION
Fixes #1089. This commit fixes the wrong keypad profile LEDs on the Tartarus Chroma and Orbweaver Chroma.

It would be useful to know if this alternate ID is needed for other keypads, or just the ones that were  originally added (in which case, [Orbweaver may need to be added](https://github.com/openrazer/openrazer/commit/86af64a8f3d11a13dd09be37a26069b1998855b4#diff-04c6e90faac2675aa89e2176d2eec7d8L72-L76))

#### Devices to be checked

- [x] ~~Nostromo~~ (OK - https://github.com/openrazer/openrazer/commit/86af64a8f3d11a13dd09be37a26069b1998855b4#diff-6f38cc63b8755079814e6aa5d740b081L47-L49)
- [ ] Tartarus
- [x] Tartarus Chroma
- [ ] Tartarus V2
- [ ] Orbweaver
- [x] Orbweaver Chroma
