### PR TITLE
Deprecate "razer_urls" in favour of "device_image"

### DIFF
--- a/daemon/openrazer_daemon/hardware/accessory.py
+++ b/daemon/openrazer_daemon/hardware/accessory.py
@@ -23,12 +23,6 @@ class RazerChromaMugHolder(_RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets2.razerzone.com/images/mug-holder/e64e507b73e61c44789d996065fd9645-1500x1000mug_01.jpg"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets2.razerzone.com/images/mug-holder/e64e507b73e61c44789d996065fd9645-1500x1000mug_01.jpg",
-        "perspective_img": "https://assets2.razerzone.com/images/mug-holder/e64e507b73e61c44789d996065fd9645-1500x1000mug_01.jpg"
-    }
-
 
 class RazerChromaHDK(_RazerDeviceBrightnessSuspend):
     """
@@ -43,11 +37,6 @@ class RazerChromaHDK(_RazerDeviceBrightnessSuspend):
                'set_custom_effect', 'set_key_row']
 
     DEVICE_IMAGE = "https://assets2.razerzone.com/images/chromahdk2017/788b689d471fedbc0c5a175592316657-gallery-08.jpg"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets2.razerzone.com/images/chromahdk2017/788b689d471fedbc0c5a175592316657-gallery-08.jpg"
-    }
 
 
 class RazerBaseStationChroma(_RazerDeviceBrightnessSuspend):
@@ -64,11 +53,6 @@ class RazerBaseStationChroma(_RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://rzrwarranty.s3.amazonaws.com/145dcc47f9f9d33b0bd07b066364704160f45e87b756d690b203decec7d1e87c.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": DEVICE_IMAGE
-    }
-
 
 class RazerNommoChroma(_RazerDeviceBrightnessSuspend):
     """
@@ -84,11 +68,6 @@ class RazerNommoChroma(_RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://d4kkpd69xt9l7.cloudfront.net/sys-master/root/he6/h1a/8939927175198/nommo-gallery-1500x1000-11.jpg"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": DEVICE_IMAGE
-    }
-
 
 class RazerNommoPro(_RazerDeviceBrightnessSuspend):
     """
@@ -103,8 +82,3 @@ class RazerNommoPro(_RazerDeviceBrightnessSuspend):
                'set_custom_effect', 'set_key_row']
 
     DEVICE_IMAGE = "https://d4kkpd69xt9l7.cloudfront.net/sys-master/root/h89/hc4/9003754717214/razer-nommo-pro-audio-04.jpg"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": DEVICE_IMAGE
-    }

--- a/daemon/openrazer_daemon/hardware/core.py
+++ b/daemon/openrazer_daemon/hardware/core.py
@@ -15,13 +15,6 @@ class RazerCore(__RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/684/684_razer_core.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/684/684_razer_core.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/23914/gallery_core/razer-core-6.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/23914/gallery_core/razer-core-3.png"
-    }
-
     METHODS = ['set_wave_effect', 'set_static_effect', 'set_spectrum_effect',
                'set_reactive_effect', 'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect', 'set_breath_dual_effect',
                'set_custom_effect', 'set_key_row', 'get_device_type_core']

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -35,11 +35,7 @@ class RazerDevice(DBusService):
 
     WAVE_DIRS = (1, 2)
 
-    RAZER_URLS = {
-        "top_img": None,
-        "side_img": None,
-        "perspective_img": None
-    }
+    DEVICE_IMAGE = None
 
     def __init__(self, device_path, device_number, config, testing=False, additional_interfaces=None, additional_methods=[]):
 
@@ -96,12 +92,15 @@ class RazerDevice(DBusService):
             ('razer.device.misc', 'getSerial', self.get_serial, None, 's'),
             ('razer.device.misc', 'suspendDevice', self.suspend_device, None, None),
             ('razer.device.misc', 'getDeviceMode', self.get_device_mode, None, 's'),
-            ('razer.device.misc', 'getRazerUrls', self.get_image_json, None, 's'),
+            ('razer.device.misc', 'getDeviceImage', self.get_device_image, None, 's'),
             ('razer.device.misc', 'setDeviceMode', self.set_device_mode, 'yy', None),
             ('razer.device.misc', 'resumeDevice', self.resume_device, None, None),
             ('razer.device.misc', 'getVidPid', self.get_vid_pid, None, 'ai'),
             ('razer.device.misc', 'getDriverVersion', openrazer_daemon.dbus_services.dbus_methods.version, None, 's'),
             ('razer.device.misc', 'hasDedicatedMacroKeys', self.dedicated_macro_keys, None, 'b'),
+
+            # Deprecated API, but kept for backwards compatibility
+            ('razer.device.misc', 'getRazerUrls', self.get_image_json, None, 's')
         }
 
         for m in methods:
@@ -279,7 +278,15 @@ class RazerDevice(DBusService):
         return result
 
     def get_image_json(self):
-        return json.dumps(self.RAZER_URLS)
+        # Deprecated API, but kept for backwards compatibility
+        return json.dumps({
+            "top_img": self.get_device_image(),
+            "side_img": self.get_device_image(),
+            "perspective_img": self.get_device_image()
+        })
+
+    def get_device_image(self):
+        return self.DEVICE_IMAGE
 
     def load_methods(self):
         """

--- a/daemon/openrazer_daemon/hardware/headsets.py
+++ b/daemon/openrazer_daemon/hardware/headsets.py
@@ -20,13 +20,6 @@ class RazerKraken71(__RazerDevice):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/229/229_kraken_71.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/229/229_kraken_71.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/17519/03.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/17519/01.png"
-    }
-
     @staticmethod
     def decode_bitfield(bitfield):
         return {
@@ -94,13 +87,6 @@ class RazerKraken71Chroma(__RazerDevice):
                'get_current_effect_kraken', 'get_static_effect_args_kraken', 'get_breath_effect_args_kraken', 'set_custom_kraken']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/280/280_kraken_71_chroma.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/280/280_kraken_71_chroma.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/17519/03.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/17519/01.png"
-    }
 
     @staticmethod
     def decode_bitfield(bitfield):
@@ -171,13 +157,6 @@ class RazerKraken71V2(__RazerDevice):
                'get_current_effect_kraken', 'get_static_effect_args_kraken', 'get_breath_effect_args_kraken', 'set_custom_kraken']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/729/729_kraken_71_v2.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/729/729_kraken_71_v2.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/26005/kraken71v2_gallery01-v2.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/26005/kraken71v2_gallery03-v2.png"
-    }
 
     @staticmethod
     def decode_bitfield(bitfield):
@@ -259,13 +238,6 @@ class RazerKrakenUltimate(__RazerDevice):
                'get_static_effect_args_kraken', 'get_breath_effect_args_kraken', 'set_custom_kraken']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1603/rzr_kraken_ultimate_render01_2019_resized.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": DEVICE_IMAGE,
-        "side_img": DEVICE_IMAGE,
-        "perspective_img": DEVICE_IMAGE
-    }
 
     @staticmethod
     def decode_bitfield(bitfield):

--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -78,13 +78,6 @@ class RazerNostromo(_RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/564/564_tartarus_classic.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/564/564_tartarus_classic.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/59/razer-nostromo-gallery-1.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/59/razer-nostromo-gallery-2.png"
-    }
-
     def __init__(self, *args, **kwargs):
         super(RazerNostromo, self).__init__(*args, **kwargs)
         # Methods are loaded into DBus by this point
@@ -116,13 +109,6 @@ class RazerTartarus(_RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/228/228_tartarus.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/228/228_tartarus.png",
-        "side_img": "https://assets2.razerzone.com/images/tartarus-classic/f89a70c59f993f08e95a8060ee2623da-Tartarus-Classic-Base_gallery02.jpg",
-        "perspective_img": "https://assets2.razerzone.com/images/tartarus-classic/b3a11ddda103b2473c3253a0a82af389-Tartarus-Classic-Base_gallery03.jpg"
-    }
-
     def __init__(self, *args, **kwargs):
         super(RazerTartarus, self).__init__(*args, **kwargs)
         # Methods are loaded into DBus by this point
@@ -153,13 +139,6 @@ class RazerTartarusChroma(_RazerDeviceBrightnessSuspend):
                'keypad_set_profile_led_green', 'keypad_get_profile_led_blue', 'keypad_set_profile_led_blue', 'get_macros', 'delete_macro', 'add_macro', 'keypad_get_mode_modifier', 'keypad_set_mode_modifier']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/598/598_tartarus_chroma.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/598/598_tartarus_chroma.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/22356/razer-tartarus-chroma-02.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/22356/razer-tartarus-chroma-03.png"
-    }
 
     def __init__(self, *args, **kwargs):
         super(RazerTartarusChroma, self).__init__(*args, **kwargs)
@@ -208,10 +187,6 @@ class RazerTartarusV2(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1255/1255_tartarus_v2.png"
 
-    RAZER_URLS = {
-        "top_img": DEVICE_IMAGE
-    }
-
     def __init__(self, *args, **kwargs):
         super(RazerTartarusV2, self).__init__(*args, **kwargs)
 
@@ -241,13 +216,6 @@ class RazerOrbweaver(_RazerDeviceBrightnessSuspend):
                'bw_set_pulsate', 'bw_set_static']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/56/56_orbweaver.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/56/56_orbweaver.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/7305/razer-orbweaver-latest-02.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/7305/razer-orbweaver-latest-03.png"
-    }
 
     def __init__(self, *args, **kwargs):
         super(RazerOrbweaver, self).__init__(*args, **kwargs)
@@ -290,13 +258,6 @@ class RazerOrbweaverChroma(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/607/607_orbweaver_chroma.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/607/607_orbweaver_chroma.png",
-        "side_img": "https://assets2.razerzone.com/images/orbweaver-chroma/8def7438b6f8d4faf24c9218daa07ad0-orbweaver-crhoma-gallery-03.jpg",
-        "perspective_img": "https://assets2.razerzone.com/images/orbweaver-chroma/518c021598fd22a51a714a1b276d1e9e-orbweaver-crhoma-gallery-04.jpg"
-    }
-
     def __init__(self, *args, **kwargs):
         super(RazerOrbweaverChroma, self).__init__(*args, **kwargs)
         # Methods are loaded into DBus by this point
@@ -328,13 +289,6 @@ class RazerBlackWidowUltimate2012(_MacroKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/563/563_blackwidow_ultimate_classic.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/563/563_blackwidow_ultimate_classic.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/22212/razer-blackwidow-ultimate-classic-gallery-1.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/22212/razer-blackwidow-ultimate-classic-gallery-2.png"
-    }
-
 
 class RazerBlackWidowStealth(_MacroKeyboard):
     """
@@ -350,13 +304,6 @@ class RazerBlackWidowStealth(_MacroKeyboard):
                'get_macro_effect', 'set_macro_effect', 'bw_get_effect', 'bw_set_pulsate', 'bw_set_static', 'get_macros', 'delete_macro', 'add_macro']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/products/17559/razer-blackwidow-gallery-01.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/products/17559/razer-blackwidow-gallery-01.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/17559/razer-blackwidow-gallery-02.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/17559/razer-blackwidow-gallery-04.png"
-    }
 
 
 class RazerBlackWidowStealthEdition(_MacroKeyboard):
@@ -374,13 +321,6 @@ class RazerBlackWidowStealthEdition(_MacroKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/products/17559/razer-blackwidow-gallery-01.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/products/17559/razer-blackwidow-gallery-01.png",
-        "side_img": "https://drh1.img.digitalriver.com/DRHM/Storefront/Company/razerusa/images/product/gallery/razer-blackwidow-stealth-gallery1.jpg",
-        "perspective_img": "https://drh2.img.digitalriver.com/DRHM/Storefront/Company/razerusa/images/product/gallery/razer-blackwidow-stealth-gallery2.jpg"
-    }
-
 
 class RazerBlackWidowUltimate2013(_MacroKeyboard):
     """
@@ -396,13 +336,6 @@ class RazerBlackWidowUltimate2013(_MacroKeyboard):
                'get_macro_effect', 'set_macro_effect', 'bw_get_effect', 'bw_set_pulsate', 'bw_set_static', 'get_macros', 'delete_macro', 'add_macro']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/245/438_blackwidow_ultimate_2014.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/245/438_blackwidow_ultimate_2014.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/17561/razer-blackwidow-ultimate-gallery-01.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/17561/razer-blackwidow-ultimate-gallery-04.png"
-    }
 
 
 class RazerBlackWidowChroma(_RippleKeyboard):
@@ -425,13 +358,6 @@ class RazerBlackWidowChroma(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/279/279_blackwidow_chroma.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/279/279_blackwidow_chroma.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/17557/razer-blackwidow-ultimate-gallery-02.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/17557/razer-blackwidow-ultimate-gallery-04.png"
-    }
-
 
 class RazerBlackWidowChromaV2(_RippleKeyboard):
     """
@@ -453,13 +379,6 @@ class RazerBlackWidowChromaV2(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1179/1179_blackwidow_chroma_v2_alt.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1179/1179_blackwidow_chroma_v2_alt.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/26600/razer-blackwidow-chroma-v2-gallery-02-wristrest-green.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/26600/razer-blackwidow-chroma-v2-gallery-03-wristrest.png"
-    }
-
 
 class RazerBlackWidowChromaTournamentEdition(_RippleKeyboard):
     """
@@ -478,13 +397,6 @@ class RazerBlackWidowChromaTournamentEdition(_RippleKeyboard):
                'set_ripple_effect', 'set_ripple_effect_random_colour']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/571/571_blackwidow_tournament_edition_chroma.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/571/571_blackwidow_tournament_edition_chroma.png",
-        "side_img": "https://assets2.razerzone.com/images/blackwidow-te-chroma/87f7492792c72241c6d5bc302e36d46f-Blackwidow-TE-Chroma-Base_gallery3.jpg",
-        "perspective_img": "https://assets2.razerzone.com/images/blackwidow-te-chroma/918fc196cb8aec3e140316650d97a075-Blackwidow-TE-Chroma-Base_gallery5.jpg"
-    }
 
 
 class RazerBlackWidowXChroma(_RippleKeyboard):
@@ -506,13 +418,6 @@ class RazerBlackWidowXChroma(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/716/716_blackwidow_x_chroma.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/716/716_blackwidow_x_chroma.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/24325/razer-blackwidow-x-chroma-redo-3.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/24325/razer-blackwidow-x-chroma-redo-4.png"
-    }
-
 
 class RazerBlackWidowXTournamentEditionChroma(_RippleKeyboard):
     """
@@ -533,13 +438,6 @@ class RazerBlackWidowXTournamentEditionChroma(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/717/717_blackwidow_x_tournament_edition_chroma.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/717/717_blackwidow_x_tournament_edition_chroma.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/24362/razer-blackwidow-te-chroma-gallery-03.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/24362/razer-blackwidow-te-chroma-gallery-04.png"
-    }
-
 
 class RazerBladeStealth(_RippleKeyboard):
     """
@@ -558,13 +456,6 @@ class RazerBladeStealth(_RippleKeyboard):
                'set_ripple_effect', 'set_ripple_effect_random_colour', 'get_logo_active', 'set_logo_active']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/667/667_blade_stealth_2016_6500u.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/667/667_blade_stealth_2016_6500u.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/23914/razer-blade-stealth-gallery-08-v2.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/23914/razer-blade-stealth-gallery-01-v2.png"
-    }
 
 
 class RazerBladeStealthLate2016(_RippleKeyboard):
@@ -585,13 +476,6 @@ class RazerBladeStealthLate2016(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/667/667_blade_stealth_2016_6500u.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/667/667_blade_stealth_2016_6500u.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/26727/rzrblade14-22__store_gallery.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/26727/rzrblade14-02__store_gallery.png"
-    }
-
 
 class RazerBladeProLate2016(_MacroKeyboard):
     """
@@ -610,13 +494,6 @@ class RazerBladeProLate2016(_MacroKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/736/736_blade_pro_2016.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/736/736_blade_pro_2016.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/26227/razer-blade-pro-gallery-13__store_gallery.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/26227/razer-blade-pro-gallery-01__store_gallery.png"
-    }
-
 
 class RazerBladeLate2016(_RippleKeyboard):
     """
@@ -634,13 +511,6 @@ class RazerBladeLate2016(_RippleKeyboard):
                'set_ripple_effect', 'set_ripple_effect_random_colour']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/736/736_blade_pro_2016.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/736/736_blade_pro_2016.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/26227/razer-blade-pro-gallery-13__store_gallery.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/26227/razer-blade-pro-gallery-01__store_gallery.png"
-    }
 
 
 class RazerBladeQHD(_RippleKeyboard):
@@ -662,13 +532,6 @@ class RazerBladeQHD(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/736/736_blade_pro_2016.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/736/736_blade_pro_2016.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/25684/rzrblade14-13__store_gallery.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/25684/rzrblade14-02__store_gallery.png"
-    }
-
 
 class RazerBlackWidowUltimate2016(_RippleKeyboard):
     """
@@ -689,13 +552,6 @@ class RazerBlackWidowUltimate2016(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/616/616_blackwidow_ultimate_2016.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/616/616_blackwidow_ultimate_2016.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/22916/razer-blackwidow-gallery-07.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/22916/razer-blackwidow-gallery-02.png"
-    }
-
 
 class RazerBlackWidowXUltimate(_RippleKeyboard):
     """
@@ -715,13 +571,6 @@ class RazerBlackWidowXUltimate(_RippleKeyboard):
                'set_ripple_effect']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/718/718_blackwidow_x_ultimate.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/718/718_blackwidow_x_ultimate.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/24363/razer-blackwidow-x-ultimate-redo-3.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/24363/razer-blackwidow-x-ultimate-redo-4.png"
-    }
 
 
 class RazerOrnataChroma(_RippleKeyboard):
@@ -744,13 +593,6 @@ class RazerOrnataChroma(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/727/727_ornata_chroma.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/727/727_ornata_chroma.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/25713/razer-ornata-chroma-gallery-07.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/25713/razer-ornata-chroma-gallery-08.png"
-    }
-
 
 class RazerHuntsmanElite(_RippleKeyboard):
     """
@@ -771,11 +613,6 @@ class RazerHuntsmanElite(_RippleKeyboard):
                'set_ripple_effect', 'set_ripple_effect_random_colour']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1361/1361_huntsman_elite.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1361/1361_huntsman_elite.png"
-    }
 
 
 class RazerHuntsmanTournamentEdition(_RippleKeyboard):
@@ -798,11 +635,6 @@ class RazerHuntsmanTournamentEdition(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1537/1537_huntsman_te.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1537/1537_huntsman_te.png"
-    }
-
 
 class RazerBlackWidowElite(_RippleKeyboard):
     """
@@ -823,11 +655,6 @@ class RazerBlackWidowElite(_RippleKeyboard):
                'set_ripple_effect', 'set_ripple_effect_random_colour']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1398/1398_blackwidowelite.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1398/1398_blackwidowelite.png"
-    }
 
 
 class RazerHuntsman(_RippleKeyboard):
@@ -850,11 +677,6 @@ class RazerHuntsman(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1360/1360_huntsman-3.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1360/1360_huntsman-3.png"
-    }
-
 
 class RazerCynosaChroma(_RippleKeyboard):
     """
@@ -876,11 +698,6 @@ class RazerCynosaChroma(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1256/1256_cynosa_chroma.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1256/1256_cynosa_chroma.png"
-    }
-
 
 class RazerCynosaLite(_RippleKeyboard):
     """
@@ -896,11 +713,6 @@ class RazerCynosaLite(_RippleKeyboard):
                'get_macro_effect', 'set_macro_effect', 'get_macros', 'delete_macro', 'add_macro']
 
     DEVICE_IMAGE = "https://assets2.razerzone.com/images/og-image/cynosa-lite-OGimage.jpg"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets2.razerzone.com/images/og-image/cynosa-lite-OGimage.jpg"
-    }
 
 
 class RazerBlackWidowLite(_RippleKeyboard):
@@ -979,13 +791,6 @@ class RazerOrnata(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/726/726_ornata.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/726/726_ornata.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/25675/razer_ornata_003.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/25675/razer_ornata_004.png"
-    }
-
 
 class RazerAnansi(_MacroKeyboard):
     """
@@ -1003,13 +808,6 @@ class RazerAnansi(_MacroKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/54/54_anansi.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/54/54_anansi.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/58/razer-anansi-gallery-3.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/58/razer-anansi-gallery-2.png"
-    }
-
 
 class RazerDeathStalkerExpert(_MacroKeyboard):
     """
@@ -1023,13 +821,6 @@ class RazerDeathStalkerExpert(_MacroKeyboard):
                'get_macro_effect', 'set_macro_effect', 'bw_get_effect', 'bw_set_pulsate', 'bw_set_static', 'get_macros', 'delete_macro', 'add_macro']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/49/49_razer_deathstalker.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/49/49_razer_deathstalker.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/771/razer-dstalk-gallery-3.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/771/razer-dstalk-gallery-2.png"
-    }
 
 
 class RazerDeathStalkerChroma(_RippleKeyboard):
@@ -1049,13 +840,6 @@ class RazerDeathStalkerChroma(_RippleKeyboard):
                'get_macro_effect', 'set_macro_effect', 'get_macros', 'delete_macro', 'add_macro']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/665/665_deathstalker_chroma.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/665/665_deathstalker_chroma.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/22563/rzr_deathstalker_chroma_03.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/22563/rzr_deathstalker_chroma_02.png"
-    }
 
 
 class RazerBlackWidowChromaOverwatch(_RippleKeyboard):
@@ -1078,13 +862,6 @@ class RazerBlackWidowChromaOverwatch(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/products/23326/overwatch-razer-gallery-5.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/products/23326/overwatch-razer-gallery-5.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/23326/overwatch-razer-gallery-3.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/23326/overwatch-razer-gallery-1.png"
-    }
-
 
 class RazerBladeStealthMid2017(_RippleKeyboard):
     """
@@ -1104,13 +881,6 @@ class RazerBladeStealthMid2017(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1213/1213_blade_stealth_2017_7500u.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1213/1213_blade_stealth_2017_7500u.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/26727/rzrblade14-22__store_gallery.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/26727/rzrblade14-02__store_gallery.png"
-    }
-
 
 class RazerBladePro2017(_RippleKeyboard):
     """
@@ -1129,13 +899,6 @@ class RazerBladePro2017(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1200/1200_blade_pro_2017.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1200/1200_blade_pro_2017.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/26227/razer-blade-pro-gallery-13__store_gallery.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/26227/razer-blade-pro-gallery-01__store_gallery.png"
-    }
-
 
 class RazerBladePro2017FullHD(_RippleKeyboard):
     """
@@ -1153,13 +916,6 @@ class RazerBladePro2017FullHD(_RippleKeyboard):
                'set_ripple_effect', 'set_ripple_effect_random_colour', 'blade_get_logo_active', 'blade_set_logo_active']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1200/1200_blade_pro_2017.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1200/1200_blade_pro_2017.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/26227/razer-blade-pro-gallery-13__store_gallery.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/26227/razer-blade-pro-gallery-01__store_gallery.png"
-    }
 
 
 class RazerBladeStealthLate2017(_RippleKeyboard):
@@ -1180,13 +936,6 @@ class RazerBladeStealthLate2017(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1213/1213_blade_stealth_2017_7500u.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1213/1213_blade_stealth_2017_7500u.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/26727/rzrblade14-22__store_gallery.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/26727/rzrblade14-02__store_gallery.png"
-    }
-
 
 class RazerBlade2018(_RippleKeyboard):
     """
@@ -1204,13 +953,6 @@ class RazerBlade2018(_RippleKeyboard):
                'set_ripple_effect', 'set_ripple_effect_random_colour', 'get_logo_active', 'set_logo_active']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1418/1418_blade_2018__base.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1418/1418_blade_2018__base.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/26227/razer-blade-pro-gallery-13__store_gallery.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/26227/razer-blade-pro-gallery-01__store_gallery.png"
-    }
 
 
 class RazerBlade2018Mercury(_RippleKeyboard):
@@ -1230,13 +972,6 @@ class RazerBlade2018Mercury(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://d4kkpd69xt9l7.cloudfront.net/sys-master/images/h97/h78/9088805240862/RZ09-02386EM2-R3U1.png_300Wx300H"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://d4kkpd69xt9l7.cloudfront.net/sys-master/images/h97/h78/9088805240862/RZ09-02386EM2-R3U1.png_300Wx300H",
-        "side_img": "https://assets2.razerzone.com/images/blade-15/shop/blade15-mercury-7.jpg",
-        "perspective_img": "https://assets2.razerzone.com/images/blade-15/shop/blade15-mercury-1.jpg"
-    }
-
 
 class RazerBlade2018Base(_RippleKeyboard):
     """
@@ -1252,13 +987,6 @@ class RazerBlade2018Base(_RippleKeyboard):
                'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1418/1418_blade_2018__base.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1418/1418_blade_2018__base.png",
-        "side_img": "https://assets2.razerzone.com/images/blade-15/shop/blade15-d1-6.jpg",
-        "perspective_img": "https://assets2.razerzone.com/images/blade-15/shop/blade15-d1-1.jpg"
-    }
 
 
 class RazerBladeStealth2019(_RippleKeyboard):
@@ -1276,13 +1004,6 @@ class RazerBladeStealth2019(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1475/1475_bladestealth13(2019).png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1475/1475_bladestealth13(2019).png",
-        "side_img": "https://assets.razerzone.com/eeimages/hazel3/img/gallery/blade_stealth_h3_black_3.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/support/products/1475/1475_bladestealth13(2019).png"
-    }
-
 
 class RazerBladeStealthLate2019(_RippleKeyboard):
     """
@@ -1297,13 +1018,6 @@ class RazerBladeStealthLate2019(_RippleKeyboard):
 
     DEVICE_IMAGE = "https://assets2.razerzone.com/images/blade-stealth-13/shop/stealth-l2p-1.jpg"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets2.razerzone.com/images/blade-stealth-13/shop/stealth-l2p-2.jpg",
-        "side_img": "https://assets2.razerzone.com/images/blade-stealth-13/shop/stealth-l2p-3.jpg",
-        "perspective_img": "https://assets2.razerzone.com/images/blade-stealth-13/shop/stealth-l2p-1.jpg"
-    }
-
 
 class RazerBladeStealthEarly2020(_RippleKeyboard):
     """
@@ -1317,12 +1031,6 @@ class RazerBladeStealthEarly2020(_RippleKeyboard):
                'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect']
 
     DEVICE_IMAGE = "https://assets2.razerzone.com/images/blade-stealth-13/shop/sl25p-fhd-4.jpg"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "side_img": "https://assets2.razerzone.com/images/blade-stealth-13/shop/sl25p-6.jpg",
-        "perspective_img": "https://assets2.razerzone.com/images/blade-stealth-13/shop/sl25p-fhd-5.jpg"
-    }
 
 
 class RazerBlade2019Adv(_RippleKeyboard):
@@ -1342,13 +1050,6 @@ class RazerBlade2019Adv(_RippleKeyboard):
                'set_ripple_effect', 'set_ripple_effect_random_colour']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1482/blade15.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1482/blade15.png",
-        "side_img": "https://assets2.razerzone.com/images/blade-15/blade15-usp-ports-advanced-model.jpg",
-        "perspective_img": "https://d4kkpd69xt9l7.cloudfront.net/sys-master/root/h78/h94/9126618628126/razer-blade-15-gallery07.jpg"
-    }
 
 
 class RazerBladeMid2019Mercury(_RippleKeyboard):

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -43,11 +43,6 @@ class RazerLanceheadWirelessWired(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1205/1205_lancehead.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1205/1205_lancehead.png"
-    }
-
     DPI_MAX = 16000
 
     def _suspend_device(self):
@@ -134,11 +129,6 @@ class RazerLanceheadWired(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1205/1205_lancehead.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1205/1205_lancehead.png"
-    }
-
     DPI_MAX = 16000
 
     def _suspend_device(self):
@@ -216,11 +206,6 @@ class RazerDeathAdderEssentialWhiteEdition(__RazerDeviceSpecialBrightnessSuspend
 
     DEVICE_IMAGE = "https://assets2.razerzone.com/images/da10m/carousel/razer-death-adder-gallery-25.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets2.razerzone.com/images/da10m/carousel/razer-death-adder-gallery-25.png"
-    }
-
     DPI_MAX = 6400
 
     def _suspend_device(self):
@@ -267,11 +252,6 @@ class RazerAbyssusEliteDVaEdition(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1288/d.va_abyssus_elite.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1288/d.va_abyssus_elite.png"
-    }
-
     DPI_MAX = 7200
 
     def _suspend_device(self):
@@ -316,11 +296,6 @@ class RazerAbyssusEssential(__RazerDeviceSpecialBrightnessSuspend):
                'set_logo_breath_random_naga_hex_v2', 'set_logo_breath_single_naga_hex_v2', 'set_logo_breath_dual_naga_hex_v2']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1290/1290_abyssusessential.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1290/1290_abyssusessential.png"
-    }
 
     DPI_MAX = 7200
 
@@ -374,11 +349,6 @@ class RazerLanceheadTE(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1203/1206_lanceheadte.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1203/1206_lanceheadte.png"
-    }
-
     DPI_MAX = 16000
 
     def _suspend_device(self):
@@ -429,13 +399,6 @@ class RazerMambaChromaWireless(__RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/609/609_mamba_500x500.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/609/609_mamba_500x500.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/22343/razer-mamba-gallery-10.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/22343/razer-mamba-gallery-04.png"
-    }
-
     DPI_MAX = 16000
 
     def __init__(self, *args, **kwargs):
@@ -469,13 +432,6 @@ class RazerMambaChromaWired(__RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/609/609_mamba_500x500.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/609/609_mamba_500x500.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/22343/razer-mamba-gallery-01.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/22343/razer-mamba-gallery-04.png"
-    }
-
     DPI_MAX = 16000
 
 
@@ -494,13 +450,6 @@ class RazerMambaTE(__RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/606/606_mambate_500x500.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/606/606_mambate_500x500.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/22294/mambategallery-800x800-5.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/22294/mambategallery-800x800-2.png"
-    }
-
     DPI_MAX = 16000
 
 
@@ -513,13 +462,6 @@ class RazerAbyssus(__RazerDevice):
     METHODS = ['get_device_type_mouse', 'set_logo_active', 'get_logo_active', 'get_poll_rate', 'set_poll_rate']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/274/abyssus2014_500x500.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/274/abyssus2014_500x500.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/17026/abyssus2014_gallery_4.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/17079/abyssus2014_gallery_3_2.png"
-    }
 
     def _resume_device(self):
         self.logger.debug("Abyssus doesn't have suspend/resume")
@@ -538,13 +480,6 @@ class RazerImperator(__RazerDevice):
                'get_poll_rate', 'set_poll_rate', 'set_scroll_active', 'get_scroll_active']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/215/215_imperator.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/215/215_imperator.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/37/razer-imperator-gallery-2.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/37/razer-imperator-gallery-1.png"
-    }
 
     DPI_MAX = 6400
 
@@ -566,13 +501,6 @@ class RazerOuroboros(__RazerDevice):
                'get_battery', 'is_charging', 'set_idle_time', 'set_low_battery_threshold']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/26/26_ouroboros.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/26/26_ouroboros.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/752/razer-ouroboros-gallery-2.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/752/razer-ouroboros-gallery-2.png"
-    }
 
     DPI_MAX = 8200
 
@@ -616,13 +544,6 @@ class RazerOrochi2013(__RazerDevice):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/612/612_orochi_2015.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/612/612_orochi_2015.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/6713/razer-orochi-2013-gallery-3.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/6713/razer-orochi-2013-gallery-5.png"
-    }
-
     def _resume_device(self):
         self.logger.debug("Orochi doesn't have suspend/resume")
 
@@ -642,13 +563,6 @@ class RazerOrochiWired(__RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/612/612_orochi_2015.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/612/612_orochi_2015.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/22770/razer-orochi-07-01.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/22770/razer-orochi-08-01.png"
-    }
-
     DPI_MAX = 8200
 
 
@@ -664,13 +578,6 @@ class RazerDeathAdderChroma(__RazerDeviceSpecialBrightnessSuspend):
                'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/278/278_deathadder_chroma.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/278/278_deathadder_chroma.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/17963/deathadder_chroma_gallery_5.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/17963/deathadder_chroma_gallery_4.png"
-    }
 
     DPI_MAX = 10000
 
@@ -724,13 +631,6 @@ class RazerDeathAdder2013(__RazerDeviceSpecialBrightnessSuspend):
                'get_logo_active', 'set_logo_active', 'set_logo_static', 'set_logo_pulsate', 'set_logo_blinking']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/561/561_deathadder_classic.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/561/561_deathadder_classic.png",
-        "side_img": None,
-        "perspective_img": None
-    }
 
     DPI_MAX = 6400
 
@@ -797,13 +697,6 @@ class RazerNagaHexV2(__RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/715/715_nagahexv2_500x500.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/715/715_nagahexv2_500x500.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/25031/nagahexv2-gallery-6.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/25031/nagahexv2-gallery-3.png"
-    }
-
     DPI_MAX = 16000
 
     def __init__(self, *args, **kwargs):
@@ -864,14 +757,7 @@ class RazerNaga2012(__RazerDevice):
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy_byte', 'set_dpi_xy_byte', 'get_poll_rate', 'set_poll_rate',
                'get_logo_active', 'set_logo_active', 'get_scroll_active', 'set_scroll_active', 'set_backlight_active', 'get_backlight_active']
 
-    DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/products/39/razer-naga-gallery-1.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/products/39/razer-naga-gallery-4.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/39/razer-naga-gallery-3.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/39/razer-naga-gallery-1.png"
-    }
+    DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/products/39/razer-naga-gallery-4.png"
 
     DPI_MAX = 5600
 
@@ -934,13 +820,6 @@ class RazerNagaChroma(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/636/636_naga_chroma.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/636/636_naga_chroma.png",
-        "side_img": "https://assets2.razerzone.com/images/razer-naga-chroma/28b8a7b0bf18c4bb0ffe6fe22d070dba-razer-naga-chroma-gallery-02.jpg",
-        "perspective_img": "https://assets2.razerzone.com/images/razer-naga-chroma/15fc24f88b577a6d080ed9e0e6a1b219-razer-naga-chroma-gallery-03.jpg"
-    }
-
     DPI_MAX = 16000
 
     def __init__(self, *args, **kwargs):
@@ -973,11 +852,6 @@ class RazerNagaTrinity(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1251/1251_razer_naga_trinity.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1251/1251_razer_naga_trinity.png"
-    }
-
     DPI_MAX = 16000
 
     def __init__(self, *args, **kwargs):
@@ -1007,13 +881,6 @@ class RazerNagaHex(__RazerDevice):
                'get_logo_active', 'set_logo_active', 'get_scroll_active', 'set_scroll_active']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/23/23_naga_hex.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/23/23_naga_hex.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/12/razer-naga-hex-gallery-5.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/12/razer-naga-hex-gallery-1.png"
-    }
 
     DPI_MAX = 5600
 
@@ -1061,13 +928,6 @@ class RazerNagaHexRed(__RazerDevice):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/products/12/razer-naga-hex-gallery-12.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/products/12/razer-naga-hex-gallery-12.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/12/razer-naga-hex-gallery-11.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/12/razer-naga-hex-gallery-7.png"
-    }
-
     DPI_MAX = 5600
 
     def _suspend_device(self):
@@ -1113,13 +973,6 @@ class RazerTaipan(__RazerDevice):
                'get_logo_active', 'set_logo_active', 'get_scroll_active', 'set_scroll_active']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/19/19_taipan.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/19/19_taipan.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/293/razer-taipan-gallery-3-black__store_gallery.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/293/razer-taipan-gallery-4-black__store_gallery.png"
-    }
 
     DPI_MAX = 8200
 
@@ -1177,13 +1030,6 @@ class RazerDeathAdderElite(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/724/724_deathadderelite_500x500.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/724/724_deathadderelite_500x500.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/25919/daelite_gallery03.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/25919/daelite_gallery02.png"
-    }
-
     DPI_MAX = 16000
 
     def _suspend_device(self):
@@ -1233,13 +1079,6 @@ class RazerDiamondbackChroma(__RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/613/613_diamondback.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/613/613_diamondback.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/22772/rzr_diamondback_04__store_gallery.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/22772/rzr_diamondback_02__store_gallery.png"
-    }
-
 
 class RazerDeathAdder3_5G(__RazerDevice):
     """
@@ -1256,11 +1095,6 @@ class RazerDeathAdder3_5G(__RazerDevice):
     DPI_MAX = 3500
 
     DEVICE_IMAGE = "https://assets2.razerzone.com/images/da10m/carousel/razer-death-adder-gallery-04.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets2.razerzone.com/images/da10m/carousel/razer-death-adder-gallery-04.png"
-    }
 
     def _suspend_device(self):
         """
@@ -1304,13 +1138,6 @@ class RazerMamba2012Wireless(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/192/192_mamba_2012.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/192/192_mamba_2012.png",
-        "side_img": None,
-        "perspective_img": "https://assets.razerzone.com/eeimages/support/products/18/mamba1.jpg"
-    }
-
     DPI_MAX = 6400
 
     def __init__(self, *args, **kwargs):
@@ -1342,13 +1169,6 @@ class RazerMamba2012Wired(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/192/192_mamba_2012.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/192/192_mamba_2012.png",
-        "side_img": None,
-        "perspective_img": "https://assets.razerzone.com/eeimages/support/products/18/mamba1.jpg"
-    }
-
     DPI_MAX = 6400
 
 
@@ -1372,11 +1192,6 @@ class RazerMambaWirelessWired(__RazerDeviceSpecialBrightnessSuspend):
                'set_custom_effect', 'set_key_row']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1404/1404_mamba_wireless.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1404/1404_mamba_wireless.png"
-    }
 
     DPI_MAX = 16000
 
@@ -1445,13 +1260,6 @@ class RazerNaga2014(__RazerDevice):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/227/227_razer_naga_2014.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/227/227_razer_naga_2014.png",
-        "side_img": "https://assets2.razerzone.com/images/razer-naga-2014/1de23ed838df6362d79b02ff1f5d9efa-razer-naga-2014-gallery-05.jpg",
-        "perspective_img": "https://assets2.razerzone.com/images/razer-naga-2014/1de23ed838df6362d79b02ff1f5d9efa-razer-naga-2014-gallery-05.jpg"
-    }
-
     DPI_MAX = 8200
 
     def _suspend_device(self):
@@ -1500,13 +1308,6 @@ class RazerOrochi2011(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/612/612_orochi_2015.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/612/612_orochi_2015.png",
-        "side_img": "https://assets2.razerzone.com/images/razer-orochi/60d430d24a21c8b7bb8b9aba65b0a84e-Orochi-Base_gallery_2.jpg",
-        "perspective_img": "https://assets2.razerzone.com/images/razer-orochi/d6dd3766e7d8b5e937b4bffc8e4f9dee-Orochi-Base_gallery_7.jpg"
-    }
-
     DPI_MAX = 4000
 
     def _suspend_device(self):
@@ -1551,13 +1352,6 @@ class RazerAbyssusV2(__RazerDeviceSpecialBrightnessSuspend):
                'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/721/721_abyssusv2.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/721/721_abyssusv2.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/25266/abyssus-v2-gallery-04.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/25266/abyssus-v2-gallery-03.png"
-    }
 
     DPI_MAX = 5000
 
@@ -1613,13 +1407,6 @@ class RazerAbyssus1800(__RazerDevice):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1277/1277_abyssus_2000.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1277/1277_abyssus_2000.png",
-        "side_img": None,
-        "perspective_img": None
-    }
-
 
 class RazerAbyssus2000(__RazerDevice):
     """
@@ -1634,13 +1421,6 @@ class RazerAbyssus2000(__RazerDevice):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1277/1277_abyssus_2000.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1277/1277_abyssus_2000.png",
-        "side_img": None,
-        "perspective_img": None
-    }
-
 
 class RazerDeathAdder3500(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -1654,11 +1434,6 @@ class RazerDeathAdder3500(__RazerDeviceSpecialBrightnessSuspend):
                'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/561/561_deathadder_classic.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/561/561_deathadder_classic.png"
-    }
 
     DPI_MAX = 3500
 
@@ -1721,11 +1496,6 @@ class RazerViperUltimateWired(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1577/ee_photo.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": DEVICE_IMAGE
-    }
-
     DPI_MAX = 20000
 
     def _suspend_device(self):
@@ -1784,11 +1554,6 @@ class RazerViper(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1539/1539_viper.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1539/1539_viper.png"
-    }
-
     DPI_MAX = 16000
 
     def _suspend_device(self):
@@ -1834,11 +1599,6 @@ class RazerDeathAdderEssential(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 6400
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1385/1385_deathadderessential.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1385/1385_deathadderessential.png"
-    }
 
     def _suspend_device(self):
         """
@@ -1899,11 +1659,6 @@ class RazerMambaElite(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1390/1390_mamba_elite.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": DEVICE_IMAGE
-    }
-
     def _suspend_device(self):
         """
         Suspend the device
@@ -1956,10 +1711,6 @@ class RazerDeathAdder1800(__RazerDevice):
 
     DEVICE_IMAGE = "https://rzrwarranty.s3.amazonaws.com/a7daf40ad78c9584a693e310effa956019cdcd081391f93f71a7cd36d3dc577e.png"
 
-    RAZER_URLS = {
-        "top_img": DEVICE_IMAGE
-    }
-
 
 class RazerBasilisk(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -1981,11 +1732,6 @@ class RazerBasilisk(__RazerDeviceSpecialBrightnessSuspend):
                'set_custom_effect', 'set_key_row']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1241/1241_basilisk.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": DEVICE_IMAGE
-    }
 
     DPI_MAX = 16000
 
@@ -2036,11 +1782,6 @@ class RazerDeathAdderV2(__RazerDeviceSpecialBrightnessSuspend):
     USB_VID = 0x1532
     USB_PID = 0x0084
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1612/1612_razerdeathadderv2.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/1612/1612_razerdeathadderv2.png"
-    }
 
     DPI_MAX = 20000
 

--- a/daemon/openrazer_daemon/hardware/mouse_mat.py
+++ b/daemon/openrazer_daemon/hardware/mouse_mat.py
@@ -18,13 +18,6 @@ class RazerFirefly(__RazerDeviceBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/594/594_firefly_500x500.png"
 
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/594/594_firefly_500x500.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/21936/fireflycloth-gallery-6.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/21936/fireflycloth-gallery-3.png"
-    }
-
 
 class RazerFireflyHyperflux(__RazerDeviceBrightnessSuspend):
     """
@@ -39,13 +32,6 @@ class RazerFireflyHyperflux(__RazerDeviceBrightnessSuspend):
                'set_key_row']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/594/594_firefly_500x500.png"
-
-    # Deprecated - RAZER_URLS be removed in future.
-    RAZER_URLS = {
-        "top_img": "https://assets.razerzone.com/eeimages/support/products/594/594_firefly_500x500.png",
-        "side_img": "https://assets.razerzone.com/eeimages/products/21936/fireflycloth-gallery-6.png",
-        "perspective_img": "https://assets.razerzone.com/eeimages/products/21936/fireflycloth-gallery-3.png"
-    }
 
 
 class RazerGoliathus(__RazerDeviceBrightnessSuspend):

--- a/pylib/openrazer/client/devices/__init__.py
+++ b/pylib/openrazer/client/devices/__init__.py
@@ -32,6 +32,9 @@ class RazerDevice(object):
         self._fw = str(self._dbus_interfaces['device'].getFirmware())
         self._drv_version = str(self._dbus_interfaces['device'].getDriverVersion())
         self._has_dedicated_macro = None
+        self._device_image = None
+
+        # Deprecated API, but kept for backwards compatibility
         self._urls = None
 
         if vid_pid is None:
@@ -339,11 +342,21 @@ class RazerDevice(object):
         return self._has_dedicated_macro
 
     @property
-    def razer_urls(self) -> dict:
-        if self._urls is None:
-            self._urls = json.loads(str(self._dbus_interfaces['device'].getRazerUrls()))
+    def device_image(self) -> str:
+        if self._device_image is None:
+            self._device_image = str(self._dbus_interfaces['device'].getDeviceImage())
 
-        return self._urls
+        return self._device_image
+
+    @property
+    def razer_urls(self) -> dict:
+        # Deprecated API, but kept for backwards compatibility
+        return {
+            "DEPRECATED": True,
+            "top_img": self.device_image,
+            "side_img": self.device_image,
+            "perspective_img": self.device_image
+        }
 
     def __str__(self):
         return self._name


### PR DESCRIPTION
This has been deprecated for quite some time.

Frontends have only been using one image, so only one device image needs to be defined. This commit de-duplicates this data and provides a shim so older versions of frontends will continue to work.

* DBUS call is now `getDeviceImage()` ~~replacing `getRazerUrls()`~~ _(kept for backwards compatibility)_
* Python library now has a new `device_image` property for a device object, but shims `razer_urls` for those older frontend versions.