### PR TITLE
Fix razer_chroma_misc_get_dpi_xy

### DIFF
--- a/driver/razerchromacommon.c
+++ b/driver/razerchromacommon.c
@@ -1090,7 +1090,7 @@ struct razer_report razer_chroma_misc_get_dpi_xy(unsigned char variable_storage)
 {
     struct razer_report report = get_razer_report(0x04, 0x85, 0x07);
 
-    report.arguments[0] = VARSTORE;
+    report.arguments[0] = variable_storage;
 
     return report;
 }


### PR DESCRIPTION
I don't know exactly what `VARSTORE` means and I don't know if this fixes or breaks anything in practice, but it looks like this function doesn't use its argument.