### PR TITLE
Add read support for idle_time and low_battery_threshold

### DIFF
--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/mamba.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/mamba.py
@@ -53,6 +53,25 @@ def set_idle_time(self, idle_time):
         driver_file.write(str(idle_time))
 
 
+@endpoint('razer.device.power', 'getIdleTime', out_sig='q')
+def get_idle_time(self):
+    """
+    Get the idle time of the mouse in seconds
+
+    :return: Idle time in seconds (unsigned short)
+    :rtype: int
+    """
+    self.logger.debug("DBus call get_idle_time")
+
+    driver_path = self.get_driver_path('device_idle_time')
+
+    with open(driver_path, 'r') as driver_file:
+        result = driver_file.read()
+        result = int(result.strip())
+
+    return result
+
+
 @endpoint('razer.device.power', 'setLowBatteryThreshold', in_sig='y')
 def set_low_battery_threshold(self, threshold):
     """
@@ -69,6 +88,25 @@ def set_low_battery_threshold(self, threshold):
 
     with open(driver_path, 'w') as driver_file:
         driver_file.write(str(threshold))
+
+
+@endpoint('razer.device.power', 'getLowBatteryThreshold', out_sig='y')
+def get_low_battery_threshold(self):
+    """
+    Get the low battery threshold as a percentage
+
+    :return: Battery threshold as a percentage
+    :rtype: int
+    """
+    self.logger.debug("DBus call get_low_battery_threshold")
+
+    driver_path = self.get_driver_path('charge_low_threshold')
+
+    with open(driver_path, 'r') as driver_file:
+        result = driver_file.read()
+        result = int(result.strip())
+
+    return round((result / 255) * 100)
 
 
 @endpoint('razer.device.lighting.power', 'setChargeEffect', in_sig='y')

--- a/driver/razerchromacommon.c
+++ b/driver/razerchromacommon.c
@@ -1120,6 +1120,14 @@ struct razer_report razer_chroma_misc_get_dpi_xy_byte(void)
 }
 
 /**
+ * Get device idle time
+ */
+struct razer_report razer_chroma_misc_get_idle_time(void)
+{
+    return get_razer_report(0x07, 0x83, 0x02);
+}
+
+/**
  * Set device idle time
  *
  * Device will go into powersave after this time.
@@ -1137,6 +1145,14 @@ struct razer_report razer_chroma_misc_set_idle_time(unsigned short idle_time)
     report.arguments[1] = idle_time & 0x00FF;
 
     return report;
+}
+
+/**
+ * Get low battery threshold
+ */
+struct razer_report razer_chroma_misc_get_low_battery_threshold(void)
+{
+    return get_razer_report(0x07, 0x81, 0x01);
 }
 
 /**

--- a/driver/razerchromacommon.h
+++ b/driver/razerchromacommon.h
@@ -116,7 +116,10 @@ struct razer_report razer_chroma_misc_get_dpi_xy(unsigned char variable_storage)
 struct razer_report razer_chroma_misc_set_dpi_xy_byte(unsigned char dpi_x,unsigned char dpi_y);
 struct razer_report razer_chroma_misc_get_dpi_xy_byte(void);
 
+struct razer_report razer_chroma_misc_get_idle_time(void);
 struct razer_report razer_chroma_misc_set_idle_time(unsigned short idle_time);
+
+struct razer_report razer_chroma_misc_get_low_battery_threshold(void);
 struct razer_report razer_chroma_misc_set_low_battery_threshold(unsigned char battery_threshold);
 
 struct razer_report razer_chroma_misc_set_orochi2011_led(unsigned char led_bitfield);

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -1282,7 +1282,25 @@ static ssize_t razer_attr_read_mouse_dpi(struct device *dev, struct device_attri
 }
 
 /**
- * Write device file "set_idle_time"
+ * Read device file "device_idle_time"
+ *
+ * Gets the time this device will go into powersave as a number of seconds.
+ */
+static ssize_t razer_attr_read_get_idle_time(struct device *dev, struct device_attribute *attr, char *buf)
+{
+    struct razer_mouse_device *device = dev_get_drvdata(dev);
+    struct razer_report report = razer_chroma_misc_get_idle_time();
+    struct razer_report response = {0};
+    unsigned short idle_time = 0;
+
+    response = razer_send_payload(device->usb_dev, &report);
+
+    idle_time = (response.arguments[0] << 8) | (response.arguments[1] & 0xFF);
+    return sprintf(buf, "%u\n", idle_time);
+}
+
+/**
+ * Write device file "device_idle_time"
  *
  * Sets the idle time to the ASCII number written to this file.
  */
@@ -1298,7 +1316,21 @@ static ssize_t razer_attr_write_set_idle_time(struct device *dev, struct device_
 }
 
 /**
- * Write device file "set_low_battery_threshold"
+ * Read device file "charge_low_threshold"
+ */
+static ssize_t razer_attr_read_low_battery_threshold(struct device *dev, struct device_attribute *attr, char *buf)
+{
+    struct razer_mouse_device *device = dev_get_drvdata(dev);
+    struct razer_report report = razer_chroma_misc_get_low_battery_threshold();
+    struct razer_report response = {0};
+
+    response = razer_send_payload(device->usb_dev, &report);
+
+    return sprintf(buf, "%d\n", response.arguments[0]);
+}
+
+/**
+ * Write device file "charge_low_threshold"
  *
  * Sets the low battery blink threshold to the ASCII number written to this file.
  */
@@ -3042,13 +3074,13 @@ static DEVICE_ATTR(dpi,                       0660, razer_attr_read_mouse_dpi,  
 static DEVICE_ATTR(device_type,               0440, razer_attr_read_device_type,           NULL);
 static DEVICE_ATTR(device_mode,               0660, razer_attr_read_device_mode,           razer_attr_write_device_mode);
 static DEVICE_ATTR(device_serial,             0440, razer_attr_read_get_serial,            NULL);
-static DEVICE_ATTR(device_idle_time,          0220, NULL,                                  razer_attr_write_set_idle_time);
+static DEVICE_ATTR(device_idle_time,          0660, razer_attr_read_get_idle_time,         razer_attr_write_set_idle_time);
 
 static DEVICE_ATTR(charge_level,              0440, razer_attr_read_get_battery,           NULL);
 static DEVICE_ATTR(charge_status,             0440, razer_attr_read_is_charging,           NULL);
 static DEVICE_ATTR(charge_effect,             0220, NULL,                                  razer_attr_write_set_charging_effect);
 static DEVICE_ATTR(charge_colour,             0220, NULL,                                  razer_attr_write_set_charging_colour);
-static DEVICE_ATTR(charge_low_threshold,      0220, NULL,                                  razer_attr_write_set_low_battery_threshold);
+static DEVICE_ATTR(charge_low_threshold,      0660, razer_attr_read_low_battery_threshold, razer_attr_write_set_low_battery_threshold);
 
 static DEVICE_ATTR(matrix_brightness,         0660, razer_attr_read_matrix_brightness,     razer_attr_write_matrix_brightness);
 static DEVICE_ATTR(matrix_custom_frame,       0220, NULL,                                  razer_attr_write_set_key_row);

--- a/pylib/openrazer/client/devices/mice.py
+++ b/pylib/openrazer/client/devices/mice.py
@@ -162,6 +162,16 @@ class RazerMouse(__RazerDevice):
         if self.has('battery'):
             self._dbus_interfaces['power'].setIdleTime(idle_time)
 
+    def get_idle_time(self) -> int:
+        """
+        Gets the idle time of the device
+
+        :return: Number of seconds before this device goes into powersave
+                 (60-900)
+        """
+        if self.has('battery'):
+            return int(self._dbus_interfaces['power'].getIdleTime())
+
     def set_low_battery_threshold(self, threshold) -> None:
         """
         Set the low battery threshold as a percentage
@@ -171,3 +181,12 @@ class RazerMouse(__RazerDevice):
         """
         if self.has('battery'):
             self._dbus_interfaces['power'].setLowBatteryThreshold(threshold)
+
+    def get_low_battery_threshold(self) -> int:
+        """
+        Get the low battery threshold as a percentage
+
+        :return: Battery threshold as a percentage
+        """
+        if self.has('battery'):
+            return int(self._dbus_interfaces['power'].getLowBatteryThreshold())

--- a/scripts/ci/install-check-deps.sh
+++ b/scripts/ci/install-check-deps.sh
@@ -5,6 +5,7 @@ apt-get -y install \
     python3-pip
 
 pip3 install autopep8
+pip3 install 'isort<5' # isort 5+ requires Python 3.6+
 pip3 install pylint
 
 # pylint errors with 1.8+ on pylib/tests/integration_tests/test_device_manager.py about the missing 'coverage' module


### PR DESCRIPTION
I tested the device files and the dbus interface with QDbusViewer and they work fine for my Basilisk X HyperSpeed.

Related issue: https://github.com/openrazer/openrazer/issues/1085