### PR TITLE
Add support for DPI Stages

### DIFF
--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -2101,8 +2101,9 @@ class RazerBasiliskXHyperSpeed(__RazerDevice):
     USB_VID = 0x1532
     USB_PID = 0x0083
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy',
-               'get_poll_rate', 'set_poll_rate', 'get_battery', 'is_charging',
-               'get_idle_time', 'set_idle_time', 'get_low_battery_threshold',
+               'get_dpi_stages', 'set_dpi_stages', 'get_poll_rate',
+               'set_poll_rate', 'get_battery', 'is_charging', 'get_idle_time',
+               'set_idle_time', 'get_low_battery_threshold',
                'set_low_battery_threshold']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1589/1589_basilisk_x__hyperspeed.png"

--- a/driver/razerchromacommon.c
+++ b/driver/razerchromacommon.c
@@ -1120,6 +1120,65 @@ struct razer_report razer_chroma_misc_get_dpi_xy_byte(void)
 }
 
 /**
+ * Set DPI stages of the device.
+ *
+ * count is the numer of stages to set.
+ * active_stage selected stage number.
+ * dpi is an array of size 2 * count containing pairs of dpi x and dpi y
+ * values, one pair for each stage.
+ *
+ * E.g.:
+ *   count = 3
+ *   active_stage = 1
+ *   dpi = [ 800, 800, 1800, 1800, 3200, 3200]
+ *         | stage 1*|  stage 2  |  stage 3  |
+ */
+struct razer_report razer_chroma_misc_set_dpi_stages(unsigned char variable_storage, unsigned char count, unsigned char active_stage, const unsigned short *dpi)
+{
+    struct razer_report report = get_razer_report(0x04, 0x06, 0x26);
+    unsigned int offset;
+    unsigned int i;
+
+    report.arguments[0] = variable_storage;
+    report.arguments[1] = active_stage;
+    report.arguments[2] = count;
+
+    offset = 3;
+    for (i = 0; i < count; i++) {
+        // Stage number
+        report.arguments[offset++] = i;
+
+        // DPI X
+        report.arguments[offset++] = (dpi[0] >> 8) & 0x00FF;
+        report.arguments[offset++] = dpi[0] & 0x00FF;
+
+        // DPI Y
+        report.arguments[offset++] = (dpi[1] >> 8) & 0x00FF;
+        report.arguments[offset++] = dpi[1] & 0x00FF;
+
+        // Reserved
+        report.arguments[offset++] = 0;
+        report.arguments[offset++] = 0;
+
+        dpi += 2;
+    }
+
+    return report;
+}
+
+/**
+ * Get the DPI stages of the device
+ */
+struct razer_report razer_chroma_misc_get_dpi_stages(unsigned char variable_storage)
+{
+    struct razer_report report = get_razer_report(0x04, 0x86, 0x26);
+
+    report.arguments[0] = variable_storage;
+
+    return report;
+}
+
+/**
  * Get device idle time
  */
 struct razer_report razer_chroma_misc_get_idle_time(void)

--- a/driver/razerchromacommon.h
+++ b/driver/razerchromacommon.h
@@ -116,6 +116,9 @@ struct razer_report razer_chroma_misc_get_dpi_xy(unsigned char variable_storage)
 struct razer_report razer_chroma_misc_set_dpi_xy_byte(unsigned char dpi_x,unsigned char dpi_y);
 struct razer_report razer_chroma_misc_get_dpi_xy_byte(void);
 
+struct razer_report razer_chroma_misc_set_dpi_stages(unsigned char variable_storage, unsigned char count, unsigned char active_stage, const unsigned short *dpi);
+struct razer_report razer_chroma_misc_get_dpi_stages(unsigned char variable_storage);
+
 struct razer_report razer_chroma_misc_get_idle_time(void);
 struct razer_report razer_chroma_misc_set_idle_time(unsigned short idle_time);
 

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -3886,6 +3886,7 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
         case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi_stages);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_level);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_status);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_low_threshold);
@@ -4330,6 +4331,7 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
         case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
             device_remove_file(&hdev->dev, &dev_attr_dpi);
+            device_remove_file(&hdev->dev, &dev_attr_dpi_stages);
             device_remove_file(&hdev->dev, &dev_attr_charge_level);
             device_remove_file(&hdev->dev, &dev_attr_charge_status);
             device_remove_file(&hdev->dev, &dev_attr_charge_low_threshold);

--- a/driver/razermouse_driver.h
+++ b/driver/razermouse_driver.h
@@ -82,6 +82,8 @@
 #define RAZER_VIPER_MOUSE_RECEIVER_WAIT_MIN_US 59900
 #define RAZER_VIPER_MOUSE_RECEIVER_WAIT_MAX_US 60000
 
+#define RAZER_MOUSE_MAX_DPI_STAGES 5
+
 struct razer_mouse_device {
     struct usb_device *usb_dev;
     struct mutex lock;

--- a/pylib/openrazer/_fake_driver/razeratherisreceiver.cfg
+++ b/pylib/openrazer/_fake_driver/razeratherisreceiver.cfg
@@ -8,6 +8,7 @@ files = r,charge_level,255
         r,device_serial,XX0000000062
         r,device_type,%(name)s
         rw,dpi,800:800
+        rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerbasiliskxhyperspeed.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskxhyperspeed.cfg
@@ -8,6 +8,7 @@ files = r,charge_level,255
         r,device_serial,XX0000000083
         r,device_type,%(name)s
         rw,dpi,800:800
+        rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
         r,version,1.0.0

--- a/pylib/openrazer/client/devices/mice.py
+++ b/pylib/openrazer/client/devices/mice.py
@@ -14,6 +14,7 @@ class RazerMouse(__RazerDevice):
         # Capabilities
         self._capabilities['poll_rate'] = self._has_feature('razer.device.misc', ('getPollRate', 'setPollRate'))
         self._capabilities['dpi'] = self._has_feature('razer.device.dpi', ('getDPI', 'setDPI'))
+        self._capabilities['dpi_stages'] = self._has_feature('razer.device.dpi', ('getDPIStages', 'setDPIStages'))
         self._capabilities['available_dpi'] = self._has_feature('razer.device.dpi', 'availableDPI')
         self._capabilities['battery'] = self._has_feature('razer.device.power', 'getBattery')
 
@@ -83,17 +84,105 @@ class RazerMouse(__RazerDevice):
         if self.has('dpi'):
             if len(value) != 2:
                 raise ValueError("DPI tuple is not of length 2. Length: {0}".format(len(value)))
+            max_dpi = self.max_dpi
             dpi_x, dpi_y = value
 
             if not isinstance(dpi_x, int) or not isinstance(dpi_y, int):
                 raise ValueError("DPI X or Y is not an integer, X:{0} Y:{1}".format(type(dpi_x), type(dpi_y)))
 
-            if dpi_x < 0 or dpi_x > 16000:  # TODO add in max dpi option
+            if dpi_x < 0 or dpi_x > max_dpi:
                 raise ValueError("DPI X either too small or too large, X:{0}".format(dpi_x))
-            if dpi_y < 0 or dpi_y > 16000:  # TODO add in max dpi option
+            if dpi_y < 0 or dpi_y > max_dpi:
                 raise ValueError("DPI Y either too small or too large, Y:{0}".format(dpi_y))
 
             self._dbus_interfaces['dpi'].setDPI(dpi_x, dpi_y)
+        else:
+            raise NotImplementedError()
+
+    @property
+    def dpi_stages(self) -> (int, list):
+        """
+        Get mouse DPI stages
+
+        Will return a tuple containing the active DPI stage number and the list
+        of DPI stages as tuples.
+        The active DPI stage number must be: >= 1 and <= nr of DPI stages.
+        :return: active DPI stage number and DPI stages
+                 (1, [(500, 500), (1000, 1000), (2000, 2000) ...]
+        :rtype: (int, list)
+
+        :raises NotImplementedError: if function is not supported
+        """
+        if self.has('dpi_stages'):
+            response = self._dbus_interfaces['dpi'].getDPIStages()
+            dpi_stages = []
+
+            active_stage = int(response[0])
+
+            for dpi_x, dpi_y in response[1]:
+                dpi_stages.append((int(dpi_x), int(dpi_y)))
+
+            return (active_stage, dpi_stages)
+        else:
+            raise NotImplementedError()
+
+    @dpi_stages.setter
+    def dpi_stages(self, value: (int, list)):
+        """
+        Set mouse DPI stages
+
+        Daemon does type validation but can't be too careful
+        :param value: active DPI stage number and list of DPI X, Y tuples
+        :type value: (int, list)
+
+        :raises ValueError: when the input is invalid
+        :raises NotImplementedError: If function is not supported
+        """
+        if self.has('dpi_stages'):
+            max_dpi = self.max_dpi
+            dpi_stages = []
+
+            active_stage = value[0]
+            if not isinstance(active_stage, int):
+                raise ValueError(
+                    "Active DPI stage is not an integer: {0}".format(
+                        type(active_stage)))
+
+            if active_stage < 1:
+                raise ValueError(
+                    "Active DPI stage has invalid value: {0} < 1".format(
+                        active_stage))
+
+            for stage in value[1]:
+                if len(stage) != 2:
+                    raise ValueError(
+                        "DPI tuple is not of length 2. Length: {0}".format(
+                            len(stage)))
+
+                dpi_x, dpi_y = stage
+
+                if not isinstance(dpi_x, int) or not isinstance(dpi_y, int):
+                    raise ValueError(
+                        "DPI X or Y is not an integer, X:{0} Y:{1}".format(
+                            type(dpi_x), type(dpi_y)))
+
+                if dpi_x < 0 or dpi_x > max_dpi:
+                    raise ValueError(
+                        "DPI X either too small or too large, X:{0}".format(
+                            dpi_x))
+                if dpi_y < 0 or dpi_y > max_dpi:
+                    raise ValueError(
+                        "DPI Y either too small or too large, Y:{0}".format(
+                            dpi_y))
+
+                dpi_stages.append((dpi_x, dpi_y))
+
+            if active_stage > len(dpi_stages):
+                raise ValueError(
+                    "Active DPI stage has invalid value: {0} > {1}".format(
+                        active_stage, len(dpi_stages)))
+
+            self._dbus_interfaces['dpi'].setDPIStages(active_stage, dpi_stages)
         else:
             raise NotImplementedError()
 

--- a/scripts/generate_fake_driver.sh
+++ b/scripts/generate_fake_driver.sh
@@ -11,6 +11,7 @@ declare -A files_metadata=(
     ["device_serial"]="r;XX0000000000" # default value will get overwritten
     ["device_type"]="r;%(name)s"
     ["dpi"]="rw;800:800"
+    ["dpi_stages"]="rw;0x010320032005dc05dc"
     ["firmware_version"]="r;v1.0"
     ["game_led_state"]="rw;0"
     ["is_mug_present"]="r;0"


### PR DESCRIPTION
This PR implements support for writing and reading DPI stages. This is pretty complex because it accepts a variable number of parameters. I'm open to any kind of suggestions or feedback.

- Adds `dpi_stages` device file.
- The number of DPI stages is hard-limited by `RAZER_MOUSE_MAX_DPI_STAGES` (currently it's 5).

To set the DPI stages convert each DPI stage to 4 bytes:
- 2 bytes (unsigned short) x-axis DPI
- 2 bytes (unsigned short) y-axis DPI

Concatenate the bytes from all the DPI stages, producing n*4 bytes where n is the number of DPI stages, and write them to `device_stages`.

To print the DPI stages simply read the `dpi_stages` file.

Example:
```bash
$ echo -ne '\x03\x20\x03\x20\x07\x08\x07\x08\x0e\x10\x0e\x10\x1c\x20\x1c\x21' > dpi_stages
$ cat dpi_stages
800:800,1800:1800,3600:3600,7200:7201
```

Tested on a Basilisk X HyperSpeed. The settings persist on the device.

TODO:
- [x] Add support to the daemon
- [x] Add support to the python library