### PR TITLE
Allow to configure battery notification frequency

### DIFF
--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -95,6 +95,7 @@ class RazerLanceheadWirelessReceiver(RazerLanceheadWirelessWired):
 
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Lancehead Wireless')
         self._battery_manager.active = self.config.getboolean('Startup', 'mouse_battery_notifier', fallback=False)
+        self._battery_manager.frequency = self.config.getint('Startup', 'mouse_battery_notifier_freq', fallback=10 * 60)
 
     def _close(self):
         """
@@ -185,6 +186,7 @@ class RazerLanceheadWireless(RazerLanceheadWired):
 
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Lancehead')
         self._battery_manager.active = self.config.getboolean('Startup', 'mouse_battery_notifier', fallback=False)
+        self._battery_manager.frequency = self.config.getint('Startup', 'mouse_battery_notifier_freq', fallback=10 * 60)
 
     def _close(self):
         """
@@ -441,6 +443,7 @@ class RazerMambaChromaWireless(__RazerDeviceBrightnessSuspend):
 
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Mamba')
         self._battery_manager.active = self.config.getboolean('Startup', 'mouse_battery_notifier', fallback=False)
+        self._battery_manager.frequency = self.config.getint('Startup', 'mouse_battery_notifier_freq', fallback=10 * 60)
 
     def _close(self):
         """
@@ -1315,6 +1318,7 @@ class RazerMamba2012Wireless(__RazerDeviceSpecialBrightnessSuspend):
 
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Mamba')
         self._battery_manager.active = self.config.getboolean('Startup', 'mouse_battery_notifier', fallback=False)
+        self._battery_manager.frequency = self.config.getint('Startup', 'mouse_battery_notifier_freq', fallback=10 * 60)
 
     def _close(self):
         """
@@ -1416,6 +1420,7 @@ class RazerMambaWirelessReceiver(RazerMambaWirelessWired):
 
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Mamba Wireless')
         self._battery_manager.active = self.config.getboolean('Startup', 'mouse_battery_notifier', fallback=False)
+        self._battery_manager.frequency = self.config.getint('Startup', 'mouse_battery_notifier_freq', fallback=10 * 60)
 
     def _close(self):
         """

--- a/daemon/openrazer_daemon/misc/battery_notifier.py
+++ b/daemon/openrazer_daemon/misc/battery_notifier.py
@@ -13,7 +13,6 @@ except ImportError:
 
 
 # TODO https://askubuntu.com/questions/110969/notify-send-ignores-timeout
-INTERVAL_FREQ = 60 * 10
 NOTIFY_TIMEOUT = 4000
 
 
@@ -28,6 +27,7 @@ class BatteryNotifier(threading.Thread):
         self._notify2 = notify2 is not None
 
         self.event = threading.Event()
+        self.frequency = 0
 
         if self._notify2:
             try:
@@ -68,7 +68,7 @@ class BatteryNotifier(threading.Thread):
     def notify_battery(self):
         now = datetime.datetime.now()
 
-        if (now - self._last_notify_time).seconds > INTERVAL_FREQ:
+        if (now - self._last_notify_time).seconds > self.frequency:
             # Update last notified
             self._last_notify_time = now
 
@@ -97,7 +97,7 @@ class BatteryNotifier(threading.Thread):
         """
 
         while not self._shutdown:
-            if self.event.is_set():
+            if self.event.is_set() and self.frequency > 0:
                 self.notify_battery()
 
             time.sleep(0.1)
@@ -145,3 +145,11 @@ class BatteryManager(object):
             self._battery_thread.event.set()
         else:
             self._battery_thread.event.clear()
+
+    @property
+    def frequency(self):
+        return self._battery_thread.frequency
+
+    @frequency.setter
+    def frequency(self, frequency):
+        self._battery_thread.frequency = frequency

--- a/daemon/resources/razer.conf
+++ b/daemon/resources/razer.conf
@@ -13,6 +13,8 @@ devices_off_on_screensaver = True
 # Mouse battery notifier
 mouse_battery_notifier = True
 
+# Mouse battery notification frequency [s] (0 to disable)
+mouse_battery_notifier_freq = 600
 
 [Statistics]
 # Collects number of keypresses per hour per key used to generate a heatmap


### PR DESCRIPTION
I tested this only manually so far. Not sure if anything else would be required.

I thought about completely removing the config variable "mouse_battery_notifier" and just check whether "mouse_battery_notifier_freq" is > 0, but I guess that may create incompatibilities with exiting config files.