### PR TITLE
Viper/Ultimate Cleanup

### DIFF
--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -1538,15 +1538,12 @@ class RazerViperUltimateWired(__RazerDeviceSpecialBrightnessSuspend):
 
     USB_VID = 0x1532
     USB_PID = 0x007A
-    HAS_MATRIX = True
-    WAVE_DIRS = (1, 2)
-    MATRIX_DIMS = [1, 20]
-    METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate',
+    METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate', 'get_logo_brightness', 'set_logo_brightness',
+               # Battery
+               'get_battery', 'is_charging', 'set_idle_time', 'set_low_battery_threshold',
                # Logo
-               'get_logo_brightness', 'set_logo_brightness', 'set_logo_wave',
-               'set_logo_static_naga_hex_v2', 'set_logo_spectrum_naga_hex_v2', 'set_logo_none_naga_hex_v2',
-               'set_logo_reactive_naga_hex_v2', 'set_logo_breath_random_naga_hex_v2',
-               'set_logo_breath_single_naga_hex_v2', 'set_logo_breath_dual_naga_hex_v2']
+               'set_logo_static_naga_hex_v2', 'set_logo_spectrum_naga_hex_v2', 'set_logo_none_naga_hex_v2', 'set_logo_reactive_naga_hex_v2',
+               'set_logo_breath_random_naga_hex_v2', 'set_logo_breath_single_naga_hex_v2', 'set_logo_breath_dual_naga_hex_v2']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1577/ee_photo.png"
 
@@ -1586,6 +1583,21 @@ class RazerViperUltimateWireless(RazerViperUltimateWired):
 
     USB_VID = 0x1532
     USB_PID = 0x007B
+    METHODS = RazerViperUltimateWired.METHODS + ['set_charge_effect', 'set_charge_colour']
+
+    def __init__(self, *args, **kwargs):
+        super(RazerViperUltimateWireless, self).__init__(*args, **kwargs)
+
+        self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Viper Ultimate Wireless')
+        self._battery_manager.active = self.config.getboolean('Startup', 'mouse_battery_notifier', fallback=False)
+
+    def _close(self):
+        """
+        Close the key manager
+        """
+        super(RazerViperUltimateWireless, self)._close()
+
+        self._battery_manager.close()
 
 
 class RazerViper(__RazerDeviceSpecialBrightnessSuspend):
@@ -1596,15 +1608,10 @@ class RazerViper(__RazerDeviceSpecialBrightnessSuspend):
 
     USB_VID = 0x1532
     USB_PID = 0x0078
-    HAS_MATRIX = True
-    WAVE_DIRS = (1, 2)
-    MATRIX_DIMS = [1, 16]
-    METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate',
+    METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate', 'get_logo_brightness', 'set_logo_brightness',
                # Logo
-               'get_logo_brightness', 'set_logo_brightness', 'set_logo_wave',
-               'set_logo_static_naga_hex_v2', 'set_logo_spectrum_naga_hex_v2', 'set_logo_none_naga_hex_v2',
-               'set_logo_reactive_naga_hex_v2', 'set_logo_breath_random_naga_hex_v2',
-               'set_logo_breath_single_naga_hex_v2', 'set_logo_breath_dual_naga_hex_v2']
+               'set_logo_static_naga_hex_v2', 'set_logo_spectrum_naga_hex_v2', 'set_logo_none_naga_hex_v2', 'set_logo_reactive_naga_hex_v2',
+               'set_logo_breath_random_naga_hex_v2', 'set_logo_breath_single_naga_hex_v2', 'set_logo_breath_dual_naga_hex_v2']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1539/1539_viper.png"
 

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -56,6 +56,11 @@ static int razer_get_report(struct usb_device *usb_dev, struct razer_report *req
         return razer_get_usb_response(usb_dev, 0x00, request_report, 0x00, response_report, RAZER_NEW_MOUSE_RECEIVER_WAIT_MIN_US, RAZER_NEW_MOUSE_RECEIVER_WAIT_MAX_US);
         break;
 
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+        return razer_get_usb_response(usb_dev, 0x00, request_report, 0x00, response_report, RAZER_VIPER_MOUSE_RECEIVER_WAIT_MIN_US, RAZER_VIPER_MOUSE_RECEIVER_WAIT_MAX_US);
+        break;
+
     default:
         return razer_get_usb_response(usb_dev, 0x00, request_report, 0x00, response_report, RAZER_MOUSE_WAIT_MIN_US, RAZER_MOUSE_WAIT_MAX_US);
     }
@@ -2462,6 +2467,9 @@ static ssize_t razer_attr_write_logo_mode_spectrum(struct device *dev, struct de
     case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_WIRED:
     case USB_DEVICE_ID_RAZER_ABYSSUS_ELITE_DVA_EDITION:
     case USB_DEVICE_ID_RAZER_ABYSSUS_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_VIPER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
     case USB_DEVICE_ID_RAZER_BASILISK:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2:
         report = razer_chroma_extended_matrix_effect_spectrum(VARSTORE, LOGO_LED);
@@ -2511,6 +2519,9 @@ static ssize_t razer_attr_write_logo_mode_reactive(struct device *dev, struct de
         case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_WIRED:
         case USB_DEVICE_ID_RAZER_ABYSSUS_ELITE_DVA_EDITION:
         case USB_DEVICE_ID_RAZER_ABYSSUS_ESSENTIAL:
+        case USB_DEVICE_ID_RAZER_VIPER:
+        case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+        case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
         case USB_DEVICE_ID_RAZER_BASILISK:
         case USB_DEVICE_ID_RAZER_DEATHADDER_V2:
             report = razer_chroma_extended_matrix_effect_reactive(VARSTORE, LOGO_LED, speed, (struct razer_rgb*)&buf[1]);
@@ -3654,16 +3665,22 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_custom_frame);
             break;
 
-        case USB_DEVICE_ID_RAZER_VIPER:
-        case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
         case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_effect);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_colour);
+        /* fall through */
+        case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_level);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_status);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_low_threshold);
+        /* fall through */
+        case USB_DEVICE_ID_RAZER_VIPER:
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_device_idle_time);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_brightness);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_spectrum);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_reactive);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_breath);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_static);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_none);
@@ -4088,16 +4105,22 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
             device_remove_file(&hdev->dev, &dev_attr_matrix_custom_frame);
             break;
 
-        case USB_DEVICE_ID_RAZER_VIPER:
-        case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
         case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+            device_remove_file(&hdev->dev, &dev_attr_charge_effect);
+            device_remove_file(&hdev->dev, &dev_attr_charge_colour);
+        /* fall through */
+        case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
             device_remove_file(&hdev->dev, &dev_attr_charge_level);
             device_remove_file(&hdev->dev, &dev_attr_charge_status);
-            device_remove_file(&hdev->dev, &dev_attr_poll_rate);
             device_remove_file(&hdev->dev, &dev_attr_charge_low_threshold);
+        /* fall through */
+        case USB_DEVICE_ID_RAZER_VIPER:
+            device_remove_file(&hdev->dev, &dev_attr_poll_rate);
             device_remove_file(&hdev->dev, &dev_attr_device_idle_time);
             device_remove_file(&hdev->dev, &dev_attr_dpi);
             device_remove_file(&hdev->dev, &dev_attr_logo_led_brightness);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_spectrum);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_reactive);
             device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_breath);
             device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_static);
             device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_none);

--- a/driver/razermouse_driver.h
+++ b/driver/razermouse_driver.h
@@ -74,6 +74,9 @@
 #define RAZER_NEW_MOUSE_RECEIVER_WAIT_MIN_US 31000
 #define RAZER_NEW_MOUSE_RECEIVER_WAIT_MAX_US 31100
 
+#define RAZER_VIPER_MOUSE_RECEIVER_WAIT_MIN_US 59900
+#define RAZER_VIPER_MOUSE_RECEIVER_WAIT_MAX_US 60000
+
 struct razer_mouse_device {
     struct usb_device *usb_dev;
     struct mutex lock;

--- a/pylib/openrazer/_fake_driver/razerviper.cfg
+++ b/pylib/openrazer/_fake_driver/razerviper.cfg
@@ -9,9 +9,8 @@ files = r,version,1.0.0
         rw,dpi,800:800
         rw,poll_rate,500
         rw,logo_led_brightness,0
-        w,logo_matrix_effect_breath
-        w,logo_matrix_effect_none
-        w,logo_matrix_effect_reactive
         w,logo_matrix_effect_spectrum
+        w,logo_matrix_effect_reactive
+        w,logo_matrix_effect_breath
         w,logo_matrix_effect_static
-        w,logo_matrix_effect_wave
+        w,logo_matrix_effect_none

--- a/pylib/openrazer/_fake_driver/razerviperultimatewired.cfg
+++ b/pylib/openrazer/_fake_driver/razerviperultimatewired.cfg
@@ -8,10 +8,13 @@ files = r,version,1.0.0
         r,device_serial,XX0000000067
         rw,dpi,800:800
         rw,poll_rate,500
+        r,charge_level,255
+        r,charge_status,1
+        w,charge_low_threshold
+        w,device_idle_time
         rw,logo_led_brightness,0
-        w,logo_matrix_effect_breath
-        w,logo_matrix_effect_none
-        w,logo_matrix_effect_reactive
         w,logo_matrix_effect_spectrum
+        w,logo_matrix_effect_reactive
+        w,logo_matrix_effect_breath
         w,logo_matrix_effect_static
-        w,logo_matrix_effect_wave
+        w,logo_matrix_effect_none

--- a/pylib/openrazer/_fake_driver/razerviperultimatewireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerviperultimatewireless.cfg
@@ -8,10 +8,15 @@ files = r,version,1.0.0
         r,device_serial,XX0000000068
         rw,dpi,800:800
         rw,poll_rate,500
+        r,charge_level,255
+        r,charge_status,1
+        w,charge_low_threshold
+        w,device_idle_time
+        w,charge_effect
+        w,charge_colour
         rw,logo_led_brightness,0
-        w,logo_matrix_effect_breath
-        w,logo_matrix_effect_none
-        w,logo_matrix_effect_reactive
         w,logo_matrix_effect_spectrum
+        w,logo_matrix_effect_reactive
+        w,logo_matrix_effect_breath
         w,logo_matrix_effect_static
-        w,logo_matrix_effect_wave
+        w,logo_matrix_effect_none


### PR DESCRIPTION
The Viper and Viper Ultimate currently only generate device files and reports for breath, static, and none effects in the driver.

Viper / Viper Ultimate:
 - Cleaned up mouse.py by removing method references to wave effect
 - Removed WAVE_DIRS, HAS_MATRIX, and MATRIX_DIMS as wave wasn't being used (not supported), and they only appear to have Logo LEDs
 - Updated to add support for spectrum and reactive effects
 - Cleaned up fake drivers to reflect the current effect functionality in the driver

Viper Ultimate:
- Added missing battery methods to match driver
- Added missing battery manager
- Fixes #1241 wireless timing issue per [comment](https://github.com/openrazer/openrazer/issues/1241#issuecomment-683392261)

Thanks @ddavini, @Algram, and @troudbal for testing