### PR TITLE
daemon: hardware: huntsman TE: Fix matrix indexing

### DIFF
--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -788,7 +788,7 @@ class RazerHuntsmanTournamentEdition(_RippleKeyboard):
     USB_PID = 0x0243
     HAS_MATRIX = True
     WAVE_DIRS = (0, 1)
-    MATRIX_DIMS = [6, 16]
+    MATRIX_DIMS = [6, 18]
     METHODS = ['get_device_type_keyboard', 'set_wave_effect', 'set_static_effect', 'set_spectrum_effect',
                'set_reactive_effect', 'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect', 'set_breath_dual_effect',
                'set_custom_effect', 'set_key_row', 'get_game_mode', 'set_game_mode', 'get_macro_mode', 'set_macro_mode',


### PR DESCRIPTION
The Huntsman TE is a TKL, with some mappings going out to 17 (0
inclusive). Set the dims to 18 to cover for this, though some keys
don't exist in the actual mapping.

I noticed that the ripple effect didn't light up the rightmost two columns. This fixes that as they're now addressed.