### PR TITLE
Adds Logo LED Toggle for Razer Blade 15 (2019) Advanced

### DIFF
--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -1043,7 +1043,7 @@ class RazerBlade2019Adv(_RippleKeyboard):
     USB_PID = 0x023A
     HAS_MATRIX = True
     MATRIX_DIMS = [6, 16]
-    METHODS = ['get_device_type_keyboard', 'set_wave_effect', 'set_static_effect', 'set_spectrum_effect',
+    METHODS = ['get_device_type_keyboard', 'get_logo_active', 'set_logo_active', 'set_wave_effect', 'set_static_effect', 'set_spectrum_effect',
                'set_reactive_effect', 'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect',
                'set_breath_dual_effect', 'set_custom_effect', 'set_key_row',
                'set_starlight_random_effect', 'set_starlight_single_effect', 'set_starlight_dual_effect',

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -2385,7 +2385,6 @@ static int razer_kbd_probe(struct hid_device *hdev, const struct hid_device_id *
             break;
 
         case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
-        case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
         case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_wave);            // Wave effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_starlight);       // Starlight effect
@@ -2436,6 +2435,7 @@ static int razer_kbd_probe(struct hid_device *hdev, const struct hid_device_id *
         case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
         case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
         case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+        case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
         case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_wave);            // Wave effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_starlight);       // Starlight effect
@@ -2697,7 +2697,6 @@ static void razer_kbd_disconnect(struct hid_device *hdev)
             break;
 
         case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
-        case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
         case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_wave);            // Wave effect
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_starlight);       // Starlight effect
@@ -2748,6 +2747,7 @@ static void razer_kbd_disconnect(struct hid_device *hdev)
         case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
         case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
         case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+        case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
         case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_wave);            // Wave effect
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_starlight);       // Starlight effect


### PR DESCRIPTION
I'm currently using a `Razer Blade 15 (2019) Advanced` and could not toggle my Logo LEDs via `polychromatic`. 
I followed the steps someone else did for the Mercury model here in #1001 to add support for the 2019 Advanced model as well. 

Everything seems to work locally so far. 
When I open the popup menu from my tray icon, I can toggle the logo with `On` or `Off` under the brightness section. Works fine and as expected. 

But when I open the polychromatic controller, I'm getting an error. This is the error message when opening `polychromatic-controller`:

```bash
There was a problem communicating with the daemon for this device.
Exception: org.freedesktop.DBus.Python.FileNotFoundError: Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/dbus/service.py", line 711, in _message_cb
    retval = candidate_method(self, *args, **keywords)
  File "/usr/lib/python3/dist-packages/openrazer_daemon/dbus_services/dbus_methods/deathadder_chroma.py", line 70, in get_logo_active
    with open(driver_path, 'r') as driver_file:
FileNotFoundError: [Errno 2] No such file or directory: '/sys/devices/pci0000:00/0000:00:14.0/usb1/1-8/1-8:1.2/0003:1532:023A.0004/logo_led_state'
```

This is how it looks like in the UI then:

![image](https://user-images.githubusercontent.com/7868768/93138300-15acaf80-f6df-11ea-985e-40b33fae1edf.png)


Is there anything I would need to change to fix this? I'm sorry, I did not have the time to read through the whole codebase :man_facepalming: 
