### PR TITLE
daemon: Fix misplaced sleep in serial number getter

### DIFF
--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -213,9 +213,9 @@ class RazerDevice(DBusService):
                     serial = ''
 
                 count += 1
-                time.sleep(0.1)
 
                 if len(serial) == 0:
+                    time.sleep(0.1)
                     self.logger.debug('getting serial: {0} count:{1}'.format(serial, count))
 
             if serial == '' or serial == 'Default string' or serial == 'empty (NULL)' or serial == 'As printed in the D cover':


### PR DESCRIPTION
Previously we would always read the serial number and sleep 0.1 seconds
even if querying the serial number has succeeded. Move the sleep to only
sleep when really needed.

This decreases the init time of the daemon for ~80 devices from ~10
seconds to ~2 seconds.