### PR TITLE
Correct misconfigured matrix capabilities in the daemon

### DIFF
--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -744,13 +744,10 @@ class RazerBlackWidowLite(_RippleKeyboard):
 
     USB_VID = 0x1532
     USB_PID = 0x0235
-    HAS_MATRIX = True
-    MATRIX_DIMS = [6, 22]
     METHODS = ['get_device_type_keyboard', 'set_static_effect',
                'set_none_effect', 'set_breath_single_effect',
-               'set_key_row', 'get_game_mode', 'set_game_mode', 'get_macro_mode', 'set_macro_mode',
-               'get_macro_effect', 'set_macro_effect', 'get_macros', 'delete_macro', 'add_macro',
-               ]
+               'get_game_mode', 'set_game_mode', 'get_macro_mode', 'set_macro_mode',
+               'get_macro_effect', 'set_macro_effect', 'get_macros', 'delete_macro', 'add_macro']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1456/1456_blackwidowlite_-_2.png"
 
@@ -786,7 +783,7 @@ class RazerBlackWidowEssential(_RippleKeyboard):
     HAS_MATRIX = True
     MATRIX_DIMS = [6, 22]
     METHODS = ['get_device_type_keyboard', 'set_static_effect', 'set_none_effect',
-               'set_breath_single_effect', 'set_key_row', 'get_game_mode',
+               'set_breath_single_effect', 'set_key_row', 'set_custom_effect', 'get_game_mode',
                'set_game_mode', 'get_macro_mode', 'set_macro_mode', 'get_macro_effect',
                'set_macro_effect', 'get_macros', 'delete_macro', 'add_macro']
 
@@ -1002,8 +999,6 @@ class RazerBlade2018Base(_RippleKeyboard):
 
     USB_VID = 0x1532
     USB_PID = 0x023B
-    HAS_MATRIX = True
-    MATRIX_DIMS = [6, 16]
     METHODS = ['get_device_type_keyboard', 'set_static_effect', 'set_spectrum_effect',
                'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect']
 
@@ -1018,8 +1013,6 @@ class RazerBladeStealth2019(_RippleKeyboard):
 
     USB_VID = 0x1532
     USB_PID = 0x0239
-    HAS_MATRIX = True
-    MATRIX_DIMS = [6, 16]
     METHODS = ['get_device_type_keyboard', 'set_static_effect', 'set_spectrum_effect',
                'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect']
 

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -941,7 +941,7 @@ class RazerNagaTrinity(__RazerDeviceSpecialBrightnessSuspend):
 
     USB_VID = 0x1532
     USB_PID = 0x0067
-    HAS_MATRIX = True
+    HAS_MATRIX = False  # TODO Device supports matrix, driver missing
     DEDICATED_MACRO_KEYS = True
     MATRIX_DIMS = [1, 3]
     METHODS = ['get_device_type_mouse', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate',
@@ -1682,6 +1682,7 @@ class RazerViperUltimateWired(__RazerDeviceSpecialBrightnessSuspend):
 
     USB_VID = 0x1532
     USB_PID = 0x007A
+    HAS_MATRIX = False  # TODO device probably has matrix support
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate', 'get_logo_brightness', 'set_logo_brightness',
                # Battery
                'get_battery', 'is_charging', 'set_idle_time', 'set_low_battery_threshold',
@@ -1752,6 +1753,8 @@ class RazerViper(__RazerDeviceSpecialBrightnessSuspend):
 
     USB_VID = 0x1532
     USB_PID = 0x0078
+    HAS_MATRIX = False  # TODO Device should have matrix support
+    MATRIX_DIMS = [1, 1]
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate', 'get_logo_brightness', 'set_logo_brightness',
                # Logo
                'set_logo_static_naga_hex_v2', 'set_logo_spectrum_naga_hex_v2', 'set_logo_none_naga_hex_v2', 'set_logo_reactive_naga_hex_v2',

--- a/daemon/openrazer_daemon/hardware/mouse_mat.py
+++ b/daemon/openrazer_daemon/hardware/mouse_mat.py
@@ -26,10 +26,9 @@ class RazerFireflyHyperflux(__RazerDeviceBrightnessSuspend):
     USB_VID = 0x1532
     USB_PID = 0x0068
     HAS_MATRIX = True
-    MATRIX_DIMS = [1, 1]
-    METHODS = ['get_device_type_mousemat', 'set_static_effect', 'set_spectrum_effect',
-               'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect', 'set_breath_dual_effect',
-               'set_key_row']
+    MATRIX_DIMS = [1, 17]
+    METHODS = ['get_device_type_mousemat', 'set_static_effect', 'set_spectrum_effect', 'set_key_row', 'set_custom_effect',
+               'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect', 'set_breath_dual_effect']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/594/594_firefly_500x500.png"
 

--- a/scripts/ci/test-daemon.py
+++ b/scripts/ci/test-daemon.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python3
+import openrazer.client
+
+devmgr = openrazer.client.DeviceManager()
+
+for d in devmgr.devices:
+    # Sanity check matrix capabilities
+    if d.has("lighting_led_matrix"):
+        d.fx.advanced.matrix[0, 0] = [0, 255, 0]
+        try:
+            d.fx.advanced.draw()
+        except Exception as e:
+            print('\n~~~ ' + d.name + ' ~~~\n')
+            print(e)

--- a/scripts/ci/test-daemon.sh
+++ b/scripts/ci/test-daemon.sh
@@ -11,3 +11,5 @@ if [ "$all_devices" != "$daemon_devices" ]; then
     echo
     exit 1
 fi
+
+PYTHONPATH="pylib:daemon" python3 scripts/ci/test-daemon.py


### PR DESCRIPTION
Fixes #1252.

* Devices that were throwing `embedded null byte` didn't have a `matrix_effect_custom` sysfs file, and so had `HAS_MATRIX` set to `False`.
* Devices that had this file had `set_key_row` and/or `set_custom_effect` added.

:heavy_check_mark:  The test script in that issue (against fake devices) passes without exceptions being thrown. 