### PR TITLE
fixed '' in driver_file

### DIFF
--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/chroma_keyboard.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/chroma_keyboard.py
@@ -18,7 +18,7 @@ def get_brightness(self):
     driver_path = self.get_driver_path('matrix_brightness')
 
     with open(driver_path, 'r') as driver_file:
-        brightness = round(float(driver_file.read()) * (100.0 / 255.0), 2)
+        brightness = round(float(driver_file.read() or 0) * (100.0 / 255.0), 2)
 
         self.method_args['brightness'] = brightness
 


### PR DESCRIPTION
fixes

```
libopenrazer: There was an error in virtual uchar libopenrazer::openrazer::Led::getBrightness()
libopenrazer: org.freedesktop.DBus.Python.ValueError
libopenrazer: Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/dbus/service.py", line 711, in _message_cb
    retval = candidate_method(self, *args, **keywords)
  File "/usr/lib/python3.8/site-packages/openrazer_daemon/dbus_services/dbus_methods/chroma_keyboard.py", line 21, in get_brightness
    brightness = round(float(driver_file.read()) * (100.0 / 255.0), 2)
ValueError: could not convert string to float: ''

terminate called after throwing an instance of 'libopenrazer::DBusException'
  what():  std::exception
[1]    22859 abort (core dumped)  ./builddir/src/razergenie
```