### PR TITLE
Add SPDX identifiers for driver files

### DIFF
--- a/driver/razeraccessory_driver.c
+++ b/driver/razeraccessory_driver.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1323,5 +1324,3 @@ static struct hid_driver razer_accessory_driver = {
 };
 
 module_hid_driver(razer_accessory_driver);
-
-

--- a/driver/razeraccessory_driver.h
+++ b/driver/razeraccessory_driver.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2015 Terry Cain <terrys-home.co.uk>
  */

--- a/driver/razerchromacommon.c
+++ b/driver/razerchromacommon.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 #include "razerchromacommon.h"
 
 

--- a/driver/razerchromacommon.h
+++ b/driver/razerchromacommon.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 #ifndef DRIVER_RAZERCHROMACOMMON_H_
 #define DRIVER_RAZERCHROMACOMMON_H_
 

--- a/driver/razercommon.c
+++ b/driver/razercommon.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2015 Tim Theede <pez2001@voyagerproject.de>
  *               2015 Terry Cain <terry@terrys-home.co.uk>

--- a/driver/razercommon.h
+++ b/driver/razercommon.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2015 Tim Theede <pez2001@voyagerproject.de>
  *               2015 Terry Cain <terry@terrys-home.co.uk>

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/driver/razerkbd_driver.h
+++ b/driver/razerkbd_driver.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2015 Tim Theede <pez2001@voyagerproject.de>
  *               2015 Terry Cain <terrys-home.co.uk>

--- a/driver/razerkraken_driver.c
+++ b/driver/razerkraken_driver.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/driver/razerkraken_driver.h
+++ b/driver/razerkraken_driver.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2015 Terry Cain <terrys-home.co.uk>
  */

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/driver/razermouse_driver.h
+++ b/driver/razermouse_driver.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2015 Terry Cain <terry@terrys-home.co.uk>
  */

--- a/driver/usb_hid_keys.h
+++ b/driver/usb_hid_keys.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 // USB HID keycodes
 // http://www.freebsddiary.org/APC/usb_hid_usages.php
 


### PR DESCRIPTION
This allows for easily identifying the license used in the driver files.