### PR TITLE
driver: razerkbd: fix fn processing in raw_event for newer devices

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -2145,8 +2145,10 @@ static int razer_raw_event(struct hid_device *hdev, struct hid_report *report, u
         return 0;
     }
 
-    // The event were looking for is 16 bytes long and starts with 0x04
-    if(intf->cur_altsetting->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_KEYBOARD && size == 16 && data[0] == 0x04) {
+    // The event were looking for is 16 or 22 bytes long and starts with 0x04.
+    // Newer firmware seems to use 22 bytes.
+    if(intf->cur_altsetting->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_KEYBOARD &&
+       ((size == 22) || (size == 16)) && data[0] == 0x04) {
         // Convert 04... to 0100...
         int index = size-1; // This way we start at 2nd last value, does subtract 1 from the 15key rollover though (not an issue cmon)
         u8 cur_value = 0x00;


### PR DESCRIPTION
I'm 90% sure that an engineer at razer mistyped 16 instead of 0x16
(22) for the max descriptor and tried to fix it, or vice-versa in
newer keyboard firmware.. Anyways, let's look for both 16 and 0x16.

Should fix https://github.com/openrazer/openrazer/issues/1174, fix https://github.com/openrazer/openrazer/issues/1349, fix https://github.com/openrazer/openrazer/issues/1248, fix https://github.com/openrazer/openrazer/issues/872, and probably some others. 

Please help me test as I only have a Huntsman TE.