### PR TITLE
Fixes Effect Sync on Mice

### DIFF
--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/charging_pad_chroma.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/charging_pad_chroma.py
@@ -26,8 +26,8 @@ def set_charging_brightness(self, brightness):
 
     self.method_args['brightness'] = brightness
 
-    if brightness > 255:
-        brightness = 255
+    if brightness > 100:
+        brightness = 100
     elif brightness < 0:
         brightness = 0
 
@@ -253,8 +253,8 @@ def set_fast_charging_brightness(self, brightness):
 
     self.method_args['brightness'] = brightness
 
-    if brightness > 255:
-        brightness = 255
+    if brightness > 100:
+        brightness = 100
     elif brightness < 0:
         brightness = 0
 
@@ -480,8 +480,8 @@ def set_fully_charged_brightness(self, brightness):
 
     self.method_args['brightness'] = brightness
 
-    if brightness > 255:
-        brightness = 255
+    if brightness > 100:
+        brightness = 100
     elif brightness < 0:
         brightness = 0
 

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/deathadder_chroma.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/deathadder_chroma.py
@@ -113,8 +113,8 @@ def set_logo_brightness(self, brightness):
 
     self.method_args['brightness'] = brightness
 
-    if brightness > 255:
-        brightness = 255
+    if brightness > 100:
+        brightness = 100
     elif brightness < 0:
         brightness = 0
 
@@ -317,8 +317,8 @@ def set_scroll_brightness(self, brightness):
 
     self.method_args['brightness'] = brightness
 
-    if brightness > 255:
-        brightness = 255
+    if brightness > 100:
+        brightness = 100
     elif brightness < 0:
         brightness = 0
 

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/lanceheadte.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/lanceheadte.py
@@ -5,6 +5,7 @@ from openrazer_daemon.dbus_services import endpoint
 def set_logo_wave(self, direction):
     """
     Set the wave effect on the device
+
     :param direction: (0|1) - down to up, (1|2) up to down
     :type direction: int
     """
@@ -30,6 +31,7 @@ def set_logo_wave(self, direction):
 def set_scroll_wave(self, direction):
     """
     Set the wave effect on the device
+
     :param direction: (0|1) - down to up, (1|2) up to down
     :type direction: int
     """
@@ -55,6 +57,7 @@ def set_scroll_wave(self, direction):
 def get_left_brightness(self):
     """
     Get the device's brightness
+
     :return: Brightness
     :rtype: float
     """
@@ -67,6 +70,7 @@ def get_left_brightness(self):
 def set_left_brightness(self, brightness):
     """
     Set the device's brightness
+
     :param brightness: Brightness
     :type brightness: int
     """
@@ -96,6 +100,7 @@ def set_left_brightness(self, brightness):
 def set_left_wave(self, direction):
     """
     Set the wave effect on the device
+
     :param direction: (0|1) - down to up, (1|2) up to down
     :type direction: int
     """
@@ -333,6 +338,7 @@ def get_right_brightness(self):
 def set_right_brightness(self, brightness):
     """
     Set the device's brightness
+
     :param brightness: Brightness
     :type brightness: int
     """
@@ -362,6 +368,7 @@ def set_right_brightness(self, brightness):
 def set_right_wave(self, direction):
     """
     Set the wave effect on the device
+
     :param direction: (0|1) - down to up, (1|2) up to down
     :type direction: int
     """

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/lanceheadte.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/lanceheadte.py
@@ -80,8 +80,8 @@ def set_left_brightness(self, brightness):
 
     self.method_args['brightness'] = brightness
 
-    if brightness > 255:
-        brightness = 255
+    if brightness > 100:
+        brightness = 100
     elif brightness < 0:
         brightness = 0
 
@@ -348,8 +348,8 @@ def set_right_brightness(self, brightness):
 
     self.method_args['brightness'] = brightness
 
-    if brightness > 255:
-        brightness = 255
+    if brightness > 100:
+        brightness = 100
     elif brightness < 0:
         brightness = 0
 

--- a/daemon/openrazer_daemon/misc/effect_sync.py
+++ b/daemon/openrazer_daemon/misc/effect_sync.py
@@ -82,9 +82,31 @@ class EffectSync(object):
                     effect_func = getattr(self._parent, 'setLogoActive', None)
                     if effect_func is not None:
                         effect_func(True)
+                    effect_func = getattr(self._parent, 'setLeftActive', None)
+                    if effect_func is not None:
+                        effect_func(True)
+                    effect_func = getattr(self._parent, 'setRightActive', None)
+                    if effect_func is not None:
+                        effect_func(True)
                     effect_func = getattr(self._parent, 'setBacklightActive', None)
                     if effect_func is not None:
                         effect_func(True)
+                else:
+                    effect_func = getattr(self._parent, 'setScrollNone', None)
+                    if effect_func is not None:
+                        effect_func()
+                    effect_func = getattr(self._parent, 'setLogoNone', None)
+                    if effect_func is not None:
+                        effect_func()
+                    effect_func = getattr(self._parent, 'setLeftNone', None)
+                    if effect_func is not None:
+                        effect_func()
+                    effect_func = getattr(self._parent, 'setRightNone', None)
+                    if effect_func is not None:
+                        effect_func()
+                    effect_func = getattr(self._parent, 'setBacklightNone', None)
+                    if effect_func is not None:
+                        effect_func()
 
                 # The target device doesn't have these methods, use similar ones
 
@@ -94,6 +116,18 @@ class EffectSync(object):
                     effect_func = getattr(self._parent, 'setBreathSingle', None)
                     if effect_func is not None:
                         effect_func(*pargs)
+                    effect_func = getattr(self._parent, 'setScrollBreathSingle', None)
+                    if effect_func is not None:
+                        effect_func(*pargs)
+                    effect_func = getattr(self._parent, 'setLogoBreathSingle', None)
+                    if effect_func is not None:
+                        effect_func(*pargs)
+                    effect_func = getattr(self._parent, 'setLeftBreathSingle', None)
+                    if effect_func is not None:
+                        effect_func(*pargs)
+                    effect_func = getattr(self._parent, 'setRightBreathSingle', None)
+                    if effect_func is not None:
+                        effect_func(*pargs)
                     effect_func = getattr(self._parent, 'setScrollPulsate', None)
                     if effect_func is not None:
                         effect_func(*pargs)
@@ -103,43 +137,18 @@ class EffectSync(object):
                     effect_func = getattr(self._parent, 'setBacklightPulsate', None)
                     if effect_func is not None:
                         effect_func(*pargs)
-
-                elif effect_name in ('setBreathSingle', 'setBreathRandom', 'setBreathDual', 'setBreathTriple'):
-                    if effect_name == 'setBreathRandom':
-                        pargs = (0x00, 0xFF, 0x00)  # Green
-                    else:
-                        pargs = args[0:3]  # limit args to first 3, as setBreathDual gives 6 args and setBreathTriple gives 9 args
-                    effect_func = getattr(self._parent, 'setPulsate', None)
-                    if effect_func is not None:
-                        # setPulsate doesn't take any argument
-                        effect_func()
-                    effect_func = getattr(self._parent, 'setScrollPulsate', None)
-                    if effect_func is not None:
-                        effect_func(*pargs)
-                    effect_func = getattr(self._parent, 'setLogoPulsate', None)
-                    if effect_func is not None:
-                        effect_func(*pargs)
-                    effect_func = getattr(self._parent, 'setBacklightPulsate', None)
-                    if effect_func is not None:
-                        effect_func(*pargs)
-
-                elif effect_name == 'setNone':
-                    #print("setNone stub")
-                    effect_func = getattr(self._parent, 'setScrollActive', None)
-                    if effect_func is not None:
-                        effect_func(False)
-                    effect_func = getattr(self._parent, 'setLogoActive', None)
-                    if effect_func is not None:
-                        effect_func(False)
-                    effect_func = getattr(self._parent, 'setBacklightActive', None)
-                    if effect_func is not None:
-                        effect_func(False)
 
                 elif effect_name == 'setSpectrum':
                     effect_func = getattr(self._parent, 'setScrollSpectrum', None)
                     if effect_func is not None:
                         effect_func()
                     effect_func = getattr(self._parent, 'setLogoSpectrum', None)
+                    if effect_func is not None:
+                        effect_func()
+                    effect_func = getattr(self._parent, 'setLeftSpectrum', None)
+                    if effect_func is not None:
+                        effect_func()
+                    effect_func = getattr(self._parent, 'setRightSpectrum', None)
                     if effect_func is not None:
                         effect_func()
                     effect_func = getattr(self._parent, 'setBacklightSpectrum', None)
@@ -153,7 +162,147 @@ class EffectSync(object):
                     effect_func = getattr(self._parent, 'setLogoStatic', None)
                     if effect_func is not None:
                         effect_func(*args)
+                    effect_func = getattr(self._parent, 'setLeftStatic', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setRightStatic', None)
+                    if effect_func is not None:
+                        effect_func(*args)
                     effect_func = getattr(self._parent, 'setBacklightStatic', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+
+                elif effect_name == 'setWave':
+                    effect_func = getattr(self._parent, 'setScrollWave', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setLogoWave', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setLeftWave', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setRightWave', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setBacklightWave', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+
+                elif effect_name == 'setReactive':
+                    effect_func = getattr(self._parent, 'setScrollReactive', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setLogoReactive', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setLeftReactive', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setRightReactive', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setBacklightReactive', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+
+                elif effect_name in ('setBreathRandom', 'setBreathSingle', 'setBreathDual', 'setBreathTriple'):
+                    if effect_name in ('setBreathRandom', 'setBreathSingle'):
+                        pargs = (0x00, 0xFF, 0x00)  # Green
+                    else:
+                        pargs = args[0:3]  # limit args to first 3, as setBreathDual gives 6 args and setBreathTriple gives 9 args
+
+                    if effect_name == 'setBreathRandom':
+                        effect_func = getattr(self._parent, 'setPulsate', None)
+                        if effect_func is not None:
+                            # setPulsate doesn't take any argument
+                            effect_func()
+                        effect_func = getattr(self._parent, 'setScrollPulsate', None)
+                        if effect_func is not None:
+                            effect_func(*pargs)
+                        effect_func = getattr(self._parent, 'setLogoPulsate', None)
+                        if effect_func is not None:
+                            effect_func(*pargs)
+                        effect_func = getattr(self._parent, 'setBacklightPulsate', None)
+                        if effect_func is not None:
+                            effect_func(*pargs)
+
+                        effect_func = getattr(self._parent, 'setScrollBreathRandom', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+                        effect_func = getattr(self._parent, 'setLogoBreathRandom', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+                        effect_func = getattr(self._parent, 'setLeftBreathRandom', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+                        effect_func = getattr(self._parent, 'setRightBreathRandom', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+                        effect_func = getattr(self._parent, 'setBacklightBreathRandom', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+
+                    if effect_name == 'setBreathSingle':
+                        if effect_func is not None:
+                            effect_func(*pargs)
+                        effect_func = getattr(self._parent, 'setScrollPulsate', None)
+                        if effect_func is not None:
+                            effect_func(*pargs)
+                        effect_func = getattr(self._parent, 'setLogoPulsate', None)
+                        if effect_func is not None:
+                            effect_func(*pargs)
+                        effect_func = getattr(self._parent, 'setBacklightPulsate', None)
+                        if effect_func is not None:
+                            effect_func(*pargs)
+
+                        effect_func = getattr(self._parent, 'setScrollBreathSingle', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+                        effect_func = getattr(self._parent, 'setLogoBreathSingle', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+                        effect_func = getattr(self._parent, 'setLeftBreathSingle', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+                        effect_func = getattr(self._parent, 'setRightBreathSingle', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+                        effect_func = getattr(self._parent, 'setBacklightBreathSingle', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+
+                    if effect_name == 'setBreathDual':
+                        effect_func = getattr(self._parent, 'setScrollBreathDual', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+                        effect_func = getattr(self._parent, 'setLogoBreathDual', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+                        effect_func = getattr(self._parent, 'setLeftBreathDual', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+                        effect_func = getattr(self._parent, 'setRightBreathDual', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+                        effect_func = getattr(self._parent, 'setBacklightBreathDual', None)
+                        if effect_func is not None:
+                            effect_func(*args)
+
+                elif effect_name == 'setBrightness':
+                    effect_func = getattr(self._parent, 'setScrollBrightness', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setLogoBrightness', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setLeftBrightness', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setRightBrightness', None)
+                    if effect_func is not None:
+                        effect_func(*args)
+                    effect_func = getattr(self._parent, 'setBacklightBrightness', None)
                     if effect_func is not None:
                         effect_func(*args)
 


### PR DESCRIPTION
Fixes Effect Sync on Mice

- [x] Adds Ignored Left / Right Mouse Lighting Zones (When notifications are received from other devices)
- [x] Fixes Flakiness With Sync'ed Brightness Settings for Mice

Not Fixed

- [ ] Apply Effect to All Mouse Zones (When the notification comes from one of the mouse's zones and effect sync is enabled)
  - Was trying to find a way to determine when Sync Effects was enabled, and only run effect from parent device then, but haven't found a working solution yet
  - #1489