### PR TITLE
Remove Gdk dependency

### DIFF
--- a/daemon/openrazer_daemon/daemon.py
+++ b/daemon/openrazer_daemon/daemon.py
@@ -15,9 +15,6 @@ import time
 import setproctitle
 import dbus.mainloop.glib
 import dbus.service
-import gi
-gi.require_version('Gdk', '3.0')
-import gi.repository
 from gi.repository import GLib
 from pyudev import Context, Monitor, MonitorObserver
 import grp

--- a/daemon/openrazer_daemon/keyboard.py
+++ b/daemon/openrazer_daemon/keyboard.py
@@ -2,9 +2,6 @@
 Module to handle custom colours
 """
 
-import gi
-gi.require_version('Gdk', '3.0')
-from gi.repository import Gdk
 import struct
 import subprocess
 
@@ -404,28 +401,6 @@ class KeyboardColour(object):
     Keyboard class which represents the colour state of the keyboard.
     """
 
-    @staticmethod
-    def gdk_colour_to_rgb(gdk_color):
-        """
-        Converts GDK colour to (R,G,B) tuple
-
-        :param gdk_color: GDK colour
-        :type gdk_color: Gdk.Color or tuple
-
-        :return: Tuple of 3 ints
-        :rtype: tuple
-        """
-        if isinstance(gdk_color, (list, tuple)):
-            return gdk_color
-
-        assert type(gdk_color) is Gdk.Color, "Is not of type Gdk.Color"
-
-        red = int(gdk_color.red_float * 255)
-        green = int(gdk_color.green_float * 255)
-        blue = int(gdk_color.blue_float * 255)
-
-        return red, green, blue
-
     def __init__(self, rows, columns):
         self.rows = rows
         self.columns = columns
@@ -486,11 +461,11 @@ class KeyboardColour(object):
         :type col: int
 
         :param colour: Colour to set
-        :type colour: Gdk.Color or tuple
+        :type colour: tuple
 
         :raises KeyDoesNotExistError: If given key does not exist
         """
-        self.colors[row][col].set(KeyboardColour.gdk_colour_to_rgb(colour))
+        self.colors[row][col].set(colour)
 
     def get_key_colour(self, key):
         """


### PR DESCRIPTION
The pylib library indirectly inherited Gdk as it imports the `keyboard` and `misc.macro` modules from `openrazer_daemon`. In practice, Gdk isn't used at all, so it is safe to remove. This looks to be legacy code as `gdk_colour_to_rgb()` was always returning a tuple.

Removing the dependency prevents a crash when the pylib is used in an application/script that uses PyQt5/PySide2 under specific conditions.

Fixes polychromatic/polychromatic#317
Fixes polychromatic/polychromatic#319

----

Here's a test case - [test_case.py.gz](https://github.com/openrazer/openrazer/files/6216460/test_case.py.gz)


One known culprit throwing a GI error is when the user uses the `gtk2` qt theme/plugin:

1. Install `qt5-styleplugins` (AUR, similarly named for other distros)
2. `export QT_QPA_PLATFORMTHEME=gtk2`
3. `./test_case.py`