### PR TITLE
Add config key "restore_persistence"

### DIFF
--- a/daemon/openrazer_daemon/daemon.py
+++ b/daemon/openrazer_daemon/daemon.py
@@ -283,6 +283,7 @@ class RazerDaemon(DBusService):
             'sync_effects_enabled': True,
             'devices_off_on_screensaver': True,
             'mouse_battery_notifier': True,
+            'restore_persistence': True,
         }
         self._config['Statistics'] = {
             'key_statistics': True,

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -316,7 +316,8 @@ class RazerDevice(DBusService):
                 if bright_func is not None:
                     bright_func(self.zone[i]["brightness"])
 
-        self.restore_effect()
+        if self.config.getboolean('Startup', "restore_persistence") is True:
+            self.restore_effect()
 
     def send_effect_event(self, effect_name, *args):
         """

--- a/daemon/resources/man/razer.conf.5
+++ b/daemon/resources/man/razer.conf.5
@@ -50,6 +50,11 @@ This flag specifies if the functionality to turn off razer devices when the scre
 This flag specifies that notifications should be shown every ten minutes with the remaining battery level.
 .P
 .RE
+\fBrestore_persistence\fR \fIbool\fR
+.RS 4
+This flag specifies whether effects saved in persistence.\&conf should be applied when the daemon starts.\&
+.P
+.RE
 .SS STATISTICS
 .P
 The \fB[Statistics]\fR section in the configuration file contains options to control how and when statistics will be collected.

--- a/daemon/resources/man/razer.conf.5.scd
+++ b/daemon/resources/man/razer.conf.5.scd
@@ -36,6 +36,9 @@ The *[Startup]* section in the configuration file contains values to be used dur
 *mouse_battery_notifier* _bool_
 	This flag specifies that notifications should be shown every ten minutes with the remaining battery level.
 
+*restore_persistence* _bool_
+	This flag specifies whether effects saved in persistence.conf should be applied when the daemon starts.
+
 ## STATISTICS
 
 The *[Statistics]* section in the configuration file contains options to control how and when statistics will be collected.

--- a/daemon/resources/razer.conf
+++ b/daemon/resources/razer.conf
@@ -16,6 +16,9 @@ mouse_battery_notifier = True
 # Mouse battery notification frequency [s] (0 to disable)
 mouse_battery_notifier_freq = 600
 
+# Apply effects saved to disk when daemon starts
+restore_persistence = False
+
 [Statistics]
 # Collects number of keypresses per hour per key used to generate a heatmap
 key_statistics = True


### PR DESCRIPTION
No changes to the default behaviour. This allows users to optionally turn off persistence at startup.

Intended for use cases where devices should not be touched at start up. For instance, effects are handled by another program, a script or to retain the last frame from a matrix effect across reboots (useful for older firmware like BlackWidow Chroma)

Fixes #1484.