### PR TITLE
Clean up unused statistics/heatmaps

### DIFF
--- a/daemon/openrazer_daemon/daemon.py
+++ b/daemon/openrazer_daemon/daemon.py
@@ -273,7 +273,7 @@ class RazerDaemon(DBusService):
         :type config_file: str or None
         """
         # Generate sections as trying to access a value even if a default exists will die if the section does not
-        for section in ('General', 'Startup', 'Statistics'):
+        for section in ('General', 'Startup'):
             self._config[section] = {}
 
         self._config['General'] = {
@@ -284,9 +284,6 @@ class RazerDaemon(DBusService):
             'devices_off_on_screensaver': True,
             'mouse_battery_notifier': True,
             'restore_persistence': True,
-        }
-        self._config['Statistics'] = {
-            'key_statistics': True,
         }
 
         if config_file is not None and os.path.exists(config_file):

--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -39,7 +39,6 @@ class _MacroKeyboard(_RazerDeviceBrightnessSuspend):
         except FileNotFoundError:  # Could be called when daemon is stopping or device is removed.
             pass
 
-        # TODO look into saving stats in /var/run maybe
         self.key_manager.close()
 
 
@@ -102,7 +101,6 @@ class RazerNostromo(_RazerDeviceBrightnessSuspend):
         """
         super(RazerNostromo, self)._close()
 
-        # TODO look into saving stats in /var/run maybe
         # self.key_manager.close()
 
 
@@ -133,7 +131,6 @@ class RazerTartarus(_RazerDeviceBrightnessSuspend):
         """
         super(RazerTartarus, self)._close()
 
-        # TODO look into saving stats in /var/run maybe
         # self.key_manager.close()
 
 
@@ -164,7 +161,6 @@ class RazerTartarusChroma(_RazerDeviceBrightnessSuspend):
         """
         super(RazerTartarusChroma, self)._close()
 
-        # TODO look into saving stats in /var/run maybe
         # self.key_manager.close()
 
 
@@ -209,7 +205,6 @@ class RazerTartarusV2(_RippleKeyboard):
         """
         super(RazerTartarusV2, self)._close()
 
-        # TODO look into saving stats in /var/run maybe
         # self.key_manager.close()
 
 
@@ -242,7 +237,6 @@ class RazerOrbweaver(_RazerDeviceBrightnessSuspend):
         """
         super(RazerOrbweaver, self)._close()
 
-        # TODO look into saving stats in /var/run maybe
         # self.key_manager.close()
 
 
@@ -283,7 +277,6 @@ class RazerOrbweaverChroma(_RippleKeyboard):
         """
         super(RazerOrbweaverChroma, self)._close()
 
-        # TODO look into saving stats in /var/run maybe
         # self.key_manager.close()
 
 

--- a/daemon/openrazer_daemon/misc/key_event_management.py
+++ b/daemon/openrazer_daemon/misc/key_event_management.py
@@ -220,7 +220,6 @@ class KeyboardKeyManager(object):
     * Receiving keypresses from the KeyWatcher
     * Logic to deal with GameMode shortcut not working when macro's not enabled
     * Logic to deal with recording on the fly macros and replaying them
-    * Stores number of keypresses / key / hour, stats are used for heatmaps / time-series
 
     It will be used to store keypresses in a list (for at most 2 seconds) if enabled for the ripple effect, when I
     get round to making the effect.
@@ -248,9 +247,6 @@ class KeyboardKeyManager(object):
         else:
             self._logger.warning("No event files for KeyWatcher")
 
-        self._record_stats = parent.config.get('Statistics', 'key_statistics')
-        self._stats = {}
-
         self._recording_macro = False
         self._macros = {}
 
@@ -271,8 +267,6 @@ class KeyboardKeyManager(object):
 
         if self._should_grab_event_files:
             self.grab_event_files(True)
-
-    # TODO add property for enabling key stats?
 
     @property
     def temp_key_store(self):
@@ -342,8 +336,6 @@ class KeyboardKeyManager(object):
           then it will record keys, then pressing FN+F9 will save macro.
         * Pressing any macro key will run macro.
         * Pressing FN+F10 will toggle game mode.
-        * Pressing any key will increment a statistical number in a dictionary used for generating
-          heatmaps.
         :param event_time: Time event occurred
         :type event_time: datetime.datetime
 
@@ -400,23 +392,6 @@ class KeyboardKeyManager(object):
 
             else:
                 # Key press
-
-                # This is the key for storing stats, by generating hour timestamps it will bucket data nicely.
-                storage_bucket = event_time.strftime('%Y%m%d%H')
-
-                try:
-                    # Try and increment key in bucket
-                    self._stats[storage_bucket][key_name] += 1
-                    # self._logger.debug("Increased key %s", key_name)
-                except KeyError:
-                    # Create bucket
-                    self._stats[storage_bucket] = dict.fromkeys(self.KEY_MAP, 0)
-                    try:
-                        # Increment key
-                        self._stats[storage_bucket][key_name] += 1
-                        # self._logger.debug("Increased key %s", key_name)
-                    except KeyError as err:
-                        self._logger.exception("Got key error. Couldn't store in bucket", exc_info=err)
 
                 if self._temp_key_store_active:
                     colour = random_colour_picker(self._last_colour_choice, COLOUR_CHOICES)
@@ -667,8 +642,6 @@ class GamepadKeyManager(KeyboardKeyManager):
           then it will record keys, then pressing FN+F9 will save macro.
         * Pressing any macro key will run macro.
         * Pressing FN+F10 will toggle game mode.
-        * Pressing any key will increment a statistical number in a dictionary used for generating
-          heatmaps.
         :param event_time: Time event occurred
         :type event_time: datetime.datetime
 
@@ -705,23 +678,6 @@ class GamepadKeyManager(KeyboardKeyManager):
 
             key_name = self.GAMEPAD_EVENT_MAPPING[key_id]
             # Key press
-
-            # This is the key for storing stats, by generating hour timestamps it will bucket data nicely.
-            storage_bucket = event_time.strftime('%Y%m%d%H')
-
-            try:
-                # Try and increment key in bucket
-                self._stats[storage_bucket][key_name] += 1
-                # self._logger.debug("Increased key %s", key_name)
-            except KeyError:
-                # Create bucket
-                self._stats[storage_bucket] = dict.fromkeys(self.GAMEPAD_KEY_MAPPING, 0)
-                try:
-                    # Increment key
-                    self._stats[storage_bucket][key_name] += 1
-                    # self._logger.debug("Increased key %s", key_name)
-                except KeyError as err:
-                    self._logger.exception("Got key error. Couldn't store in bucket", exc_info=err)
 
             if self._temp_key_store_active:
                 colour = random_colour_picker(self._last_colour_choice, COLOUR_CHOICES)

--- a/daemon/resources/man/openrazer-daemon.8
+++ b/daemon/resources/man/openrazer-daemon.8
@@ -19,7 +19,7 @@ openrazer-daemon - Daemon to manage Razer devices in userspace
 .P
 \fBopenrazer-daemon\fR is a userspace service which is designed to be an intermediary between userspace programs and the Razer drivers.\& It will provide some higher level functions to allow similar operation to the Windows Razer Synapse program.\& This service is designed to be started by xdg-autostart as a session service.\&
 .P
-The service has the functionality to sync effects between multiple devices, perform on-the-fly macro recording and playback and reimplements the FN+Keys logic so they work when \fBmacro_keys\fR are enabled.\& The service can also perform various ripple effects, it can turn off the devices when the screensaver is active and also optionally store key metrics to provide usage heatmaps.\&
+The service has the functionality to sync effects between multiple devices, perform on-the-fly macro recording and playback and reimplements the FN+Keys logic so they work when \fBmacro_keys\fR are enabled.\& The service can also perform various ripple effects and turn off the devices when the screensaver is active.\&
 .P
 Note, that all paths shown as defaults, eg ~/.\&local/share/ or ~/.\&config/ can be changed with XDG Base Directory specification variables: \fB$XDG_CONFIG_HOME\fR, \fB$XDG_DATA_HOME\fR and \fB$XDG_RUNTIME_DIR\fR.\&
 .P

--- a/daemon/resources/man/openrazer-daemon.8.scd
+++ b/daemon/resources/man/openrazer-daemon.8.scd
@@ -12,7 +12,7 @@ openrazer-daemon - Daemon to manage Razer devices in userspace
 
 *openrazer-daemon* is a userspace service which is designed to be an intermediary between userspace programs and the Razer drivers. It will provide some higher level functions to allow similar operation to the Windows Razer Synapse program. This service is designed to be started by xdg-autostart as a session service.
 
-The service has the functionality to sync effects between multiple devices, perform on-the-fly macro recording and playback and reimplements the FN+Keys logic so they work when *macro_keys* are enabled. The service can also perform various ripple effects, it can turn off the devices when the screensaver is active and also optionally store key metrics to provide usage heatmaps.
+The service has the functionality to sync effects between multiple devices, perform on-the-fly macro recording and playback and reimplements the FN+Keys logic so they work when *macro_keys* are enabled. The service can also perform various ripple effects and turn off the devices when the screensaver is active.
 
 Note, that all paths shown as defaults, eg ~/.local/share/ or ~/.config/ can be changed with XDG Base Directory specification variables: *$XDG_CONFIG_HOME*, *$XDG_DATA_HOME* and *$XDG_RUNTIME_DIR*.
 

--- a/daemon/resources/man/razer.conf.5
+++ b/daemon/resources/man/razer.conf.5
@@ -56,16 +56,6 @@ This flag specifies that notifications should be shown every ten minutes with th
 This flag specifies whether effects saved in persistence.\&conf should be applied when the daemon starts.\&
 .P
 .RE
-.SS STATISTICS
-.P
-The \fB[Statistics]\fR section in the configuration file contains options to control how and when statistics will be collected.\&
-.P
-\fBkey_statistics\fR \fIbool\fR
-.RS 4
-This flag specifies if the daemon is to collect key statistics.\& Currently this is only collecting the key count per hour per key.\&
-.P
-.P
-.RE
 .SH SEE ALSO
 .P
 \fBopenrazer-daemon\fR(8)

--- a/daemon/resources/man/razer.conf.5.scd
+++ b/daemon/resources/man/razer.conf.5.scd
@@ -39,14 +39,6 @@ The *[Startup]* section in the configuration file contains values to be used dur
 *restore_persistence* _bool_
 	This flag specifies whether effects saved in persistence.conf should be applied when the daemon starts.
 
-## STATISTICS
-
-The *[Statistics]* section in the configuration file contains options to control how and when statistics will be collected.
-
-*key_statistics* _bool_
-	This flag specifies if the daemon is to collect key statistics. Currently this is only collecting the key count per hour per key.
-
-
 # SEE ALSO
 
 *openrazer-daemon*(8)

--- a/daemon/resources/razer.conf
+++ b/daemon/resources/razer.conf
@@ -18,7 +18,3 @@ mouse_battery_notifier_freq = 600
 
 # Apply effects saved to disk when daemon starts
 restore_persistence = False
-
-[Statistics]
-# Collects number of keypresses per hour per key used to generate a heatmap
-key_statistics = True


### PR DESCRIPTION
This "feature" has been stale for 5 years, as it was never finished nor functional. 

This commit cleans up the daemon, like removing the configuration key and updating the man pages. This should prevent any confusion or worry to users over this feature, although `razer.conf` for existing users will still show the outdated key if editing by hand.