### PR TITLE
fix deathstalker matrix

### DIFF
--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -933,7 +933,7 @@ class RazerDeathStalkerChroma(_RippleKeyboard):
     USB_PID = 0x0204
     HAS_MATRIX = True
     DEDICATED_MACRO_KEYS = True
-    MATRIX_DIMS = [1, 6]
+    MATRIX_DIMS = [1, 12]
     METHODS = ['get_device_type_keyboard', 'set_wave_effect', 'set_static_effect', 'set_spectrum_effect',
                'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect', 'set_breath_dual_effect',
                'set_custom_effect', 'set_key_row', 'get_game_mode', 'set_game_mode', 'get_macro_mode', 'set_macro_mode',


### PR DESCRIPTION
The deathstalker chroma has 6 colour zones in the hardware, but requires a 1x12 matrix since each of them is represented by 2 separately addressable LEDs.