### PR TITLE
pylib: Fix UnknownMethodException for charging zones

### DIFF
--- a/pylib/openrazer/client/fx.py
+++ b/pylib/openrazer/client/fx.py
@@ -670,7 +670,7 @@ class SingleLed(BaseRazerFX):
         return self.has('{0}_{1}'.format(self._led_name, item))
 
     def _getattr(self, name):
-        attr = name.replace('#', self._led_name.title())
+        attr = name.replace('#', self._led_name.title().replace("_", ""))
         return getattr(self._lighting_dbus, attr, None)
 
     @property


### PR DESCRIPTION
When attempting to use the Python library for the `fast_charging` or `fully_charged` zones, an `UnknownMethodException` was thrown due to an extra underscore.

This caused "`setFastChargingWave`" to become "`setFast_ChargingWave`" which is incorrect. The method path is correct to use an underscore: `razer.device.lighting.fast_charging`

The other zones are unaffected as underscores are not used for the DBUS method name itself (e.g. `setLogoStatic, setScrollStatic`, etc)