### PR TITLE
daemon: Only save DPI persistence above zero

### DIFF
--- a/daemon/openrazer_daemon/daemon.py
+++ b/daemon/openrazer_daemon/daemon.py
@@ -312,8 +312,11 @@ class RazerDaemon(DBusService):
         for device in self._razer_devices:
             self._persistence[device.dbus.storage_name] = {}
             if 'set_dpi_xy' in device.dbus.METHODS or 'set_dpi_xy_byte' in device.dbus.METHODS:
-                self._persistence[device.dbus.storage_name]['dpi_x'] = str(device.dbus.dpi[0])
-                self._persistence[device.dbus.storage_name]['dpi_y'] = str(device.dbus.dpi[1])
+                dpi_x = int(device.dbus.dpi[0])
+                dpi_y = int(device.dbus.dpi[1])
+                if dpi_x > 0 and dpi_y > 0:
+                    self._persistence[device.dbus.storage_name]['dpi_x'] = str(dpi_x)
+                    self._persistence[device.dbus.storage_name]['dpi_y'] = str(dpi_y)
 
             if 'set_poll_rate' in device.dbus.METHODS:
                 self._persistence[device.dbus.storage_name]['poll_rate'] = str(device.dbus.poll_rate)


### PR DESCRIPTION
Rarely, the persistence.conf file saves DPI X/Y with a value of 0, causing the DPI to be really slow on next boot. It's possible that the device sent a value of zero, so this change makes sure that only DPI values above 0 are being persisted.

Potential fix for @LiamDawe from polychromatic/polychromatic#332

---

Slightly related, but I have observed my Mamba TE sometimes gets an incorrect reading (1800, 0 DPI) opening the device in Polychromatic.