### PR TITLE
Proposal: don't use varstore for custom frames

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -1712,12 +1712,12 @@ static ssize_t razer_attr_write_mode_custom(struct device *dev, struct device_at
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
     case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
-        report = razer_chroma_standard_matrix_effect_custom_frame(VARSTORE); // Possibly could use VARSTORE
+        report = razer_chroma_standard_matrix_effect_custom_frame(NOSTORE);
         report.transaction_id.id = 0x3F;  // TODO move to a usb_device variable
         break;
 
     default:
-        report = razer_chroma_standard_matrix_effect_custom_frame(VARSTORE); // Possibly could use VARSTORE
+        report = razer_chroma_standard_matrix_effect_custom_frame(NOSTORE);
         break;
     }
     razer_send_payload(usb_dev, &report);


### PR DESCRIPTION
According to the wiki:

> Some keyboards do have the functionality to store multiple frames but I've been told it can wear down flash memory and there's no benefit anyway as spamming frames is what Synapse does and that gets along just fine.

Using VARSTORE may indeed wear out the memory in these devices when using effects like Ripple or Polychromatic animated effects (or future software effects).