### PR TITLE
fix destruction of default Ubuntu 21.04 python3 setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,8 +150,6 @@ appstream_uninstall:
 ubuntu_install: setup_dkms ubuntu_udev_install ubuntu_daemon_install ubuntu_python_library_install appstream_install
 	@echo -e "\n::\033[34m Installing for Ubuntu\033[0m"
 	@echo "====================================================="
-	mv $(DESTDIR)/usr/lib/python3.* $(DESTDIR)/usr/lib/python3
-	mv $(DESTDIR)/usr/lib/python3/site-packages $(DESTDIR)/usr/lib/python3/dist-packages
 
 install_i_know_what_i_am_doing: all driver_install udev_install python_library_install
 	@make --no-print-directory -C daemon install DESTDIR=$(DESTDIR)


### PR DESCRIPTION
This destroyed my default python3 setup on Ubuntu 21.04 by moving all my "/usr/lib/python3.*" versions to subfolders in "/usr/lib/python3" and renaming directories that could already exist such as site-packages for other projects.  Understandably, there are other Debian and Ubuntu specific build directions, but I believe this "mv" should not fall under "ubuntu_install" in the Makefile.