### PR TITLE
DRAFT: Changed dbus-user-session dependency to dbus-session-bus

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9),
                dkms,
                python3,
                python3-setuptools
-Standards-Version: 4.2.1
+Standards-Version: 4.6.0
 Vcs-Browser: https://github.com/openrazer/openrazer/
 Vcs-Git: https://github.com/openrazer/openrazer.git
 Homepage: https://openrazer.github.io/
@@ -68,7 +68,7 @@ Depends: ${misc:Depends},
          python3-daemonize (>= 2.4.0),
          gir1.2-gtk-3.0,
          xautomation,
-         dbus-user-session
+         dbus-session-bus
 Recommends: python3-openrazer (= ${binary:Version})
 Conflicts: razer-daemon
 Provides: razer-daemon


### PR DESCRIPTION
Fixes #1443. Apologizes for the very late pull request, but I became busy and as they say: better late than never. I tested the tool on Debian 11.0, and Devuan Beowulf and it appears to still be working on both. I'm not really sure what to add as it only changes the debian package listed requirements to the newer version, and it seems to be fine. This will cause issues with distributions that don't have the `dbus-session-bus` virtual package. It appears that all currently supported versions of Debian (9/Stretch) and onward all have the virtual package which makes me inclined to believe this isn't an issue. If it is then I can specify that either `dbus-session-bus` or `dbus-user-session` as opposed to only `dbus-session-bus`.

I struggled to find information for which versions of Debian haven't had https://www.debian.org/doc/debian-policy/upgrading-checklist.html#version-4-3-0 applied though so I don't know about 8, or earlier.