### PR TITLE
pylib: Fix minimum check for DPI Y

### DIFF
--- a/pylib/openrazer/client/devices/mice.py
+++ b/pylib/openrazer/client/devices/mice.py
@@ -89,14 +89,20 @@ class RazerMouse(__RazerDevice):
                 raise ValueError("DPI tuple is not of length 2. Length: {0}".format(len(value)))
             max_dpi = self.max_dpi
             dpi_x, dpi_y = value
+            dpi_x_only = self.has('available_dpi')
 
             if not isinstance(dpi_x, int) or not isinstance(dpi_y, int):
                 raise ValueError("DPI X or Y is not an integer, X:{0} Y:{1}".format(type(dpi_x), type(dpi_y)))
 
             if dpi_x < 0 or dpi_x > max_dpi:
                 raise ValueError("DPI X either too small or too large, X:{0}".format(dpi_x))
-            if dpi_y < 0 or dpi_y > max_dpi:
-                raise ValueError("DPI Y either too small or too large, Y:{0}".format(dpi_y))
+
+            if dpi_x_only:
+                if not dpi_y == -1:
+                    raise ValueError("DPI Y is not supported for this device")
+            else:
+                if dpi_y < 0 or dpi_y > max_dpi:
+                    raise ValueError("DPI Y either too small or too large, Y:{0}".format(dpi_y))
 
             self._dbus_interfaces['dpi'].setDPI(dpi_x, dpi_y)
         else:


### PR DESCRIPTION
The DPI for X-only mice cannot be set via the pylib due to a minimum check of zero for the Y value. The daemon logic expects a value of -1 for such devices.

Up to now, frontends using the library had errors thrown passing -1, and broken behaviour passing 0 for the Y value, which can now be corrected.

An additional check ensures that only compatible devices pass -1 for DPI Y, as passing -1 will throw an Overflow Error for DPI X/Y-capable mice.

Addresses: https://github.com/polychromatic/polychromatic/issues/354#issuecomment-925062999
Original logic: polychromatic/polychromatic#209