### PR TITLE
daemon: Pass Y=0 for DPI X only devices

### DIFF
--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/mamba.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/mamba.py
@@ -166,14 +166,14 @@ def set_dpi_xy(self, dpi_x, dpi_y):
 
     if self._testing:
         with open(driver_path, 'w') as driver_file:
-            if dpi_y == -1:
+            if dpi_y <= 0:
                 driver_file.write("{}".format(dpi_x))
             else:
                 driver_file.write("{}:{}".format(dpi_x, dpi_y))
         return
 
     # If the application requests just one value to be written
-    if dpi_y == -1:
+    if dpi_y <= 0:
         dpi_bytes = struct.pack('>H', dpi_x)
     else:
         dpi_bytes = struct.pack('>HH', dpi_x, dpi_y)

--- a/pylib/openrazer/client/devices/mice.py
+++ b/pylib/openrazer/client/devices/mice.py
@@ -89,13 +89,17 @@ class RazerMouse(__RazerDevice):
                 raise ValueError("DPI tuple is not of length 2. Length: {0}".format(len(value)))
             max_dpi = self.max_dpi
             dpi_x, dpi_y = value
+            dpi_x_only = self.has('available_dpi')
 
             if not isinstance(dpi_x, int) or not isinstance(dpi_y, int):
                 raise ValueError("DPI X or Y is not an integer, X:{0} Y:{1}".format(type(dpi_x), type(dpi_y)))
 
             if dpi_x < 0 or dpi_x > max_dpi:
                 raise ValueError("DPI X either too small or too large, X:{0}".format(dpi_x))
-            if dpi_y < 0 or dpi_y > max_dpi:
+
+            if dpi_x_only and not dpi_y == 0:
+                raise ValueError("DPI Y is not supported for this device")
+            elif dpi_y < 0 or dpi_y > max_dpi:
                 raise ValueError("DPI Y either too small or too large, Y:{0}".format(dpi_y))
 
             self._dbus_interfaces['dpi'].setDPI(dpi_x, dpi_y)


### PR DESCRIPTION
DPI for X-only mice could not be set via the pylib due to a minimum check of zero for the Y value. The daemon expected a value of `-1` for such devices. However, `-1` cannot be submitted via D-Bus because it's an unsigned integer (cannot be negative). To address this, this commit changes the value to `0`.

Up to now, frontends using the Python library could not pass `-1`, and passing `0` did not work either. This fixes setting DPI for those devices.

Addresses: https://github.com/polychromatic/polychromatic/issues/354#issuecomment-926243379
Original logic: polychromatic/polychromatic#209

Addresses: #1183
