### PR TITLE
PREFIX and UDEV_PREFIX Additions to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@
 # that you can find in the wiki.
 # ***************************************************************************
 
+# PREFIX is used to prefix where the files will be installed under DESTDIR
+PREFIX?=/usr
+# UDEV_PREFIX is specifically a prefix for udev files
+UDEV_PREFIX?=$(PREFIX)
 # DESTDIR is used to install into a different root directory
 DESTDIR?=/
 # Specify the kernel directory to use
@@ -113,29 +117,29 @@ clean: driver_clean
 setup_dkms:
 	@echo -e "\n::\033[34m Installing DKMS files\033[0m"
 	@echo "====================================================="
-	install -m 644 -v -D Makefile $(DESTDIR)/usr/src/$(DKMS_NAME)-$(DKMS_VER)/Makefile
-	install -m 644 -v -D install_files/dkms/dkms.conf $(DESTDIR)/usr/src/$(DKMS_NAME)-$(DKMS_VER)/dkms.conf
-	install -m 755 -v -d driver $(DESTDIR)/usr/src/$(DKMS_NAME)-$(DKMS_VER)/driver
-	install -m 644 -v -D driver/Makefile $(DESTDIR)/usr/src/$(DKMS_NAME)-$(DKMS_VER)/driver/Makefile
-	install -m 644 -v driver/*.c $(DESTDIR)/usr/src/$(DKMS_NAME)-$(DKMS_VER)/driver/
-	install -m 644 -v driver/*.h $(DESTDIR)/usr/src/$(DKMS_NAME)-$(DKMS_VER)/driver/
-	rm -fv $(DESTDIR)/usr/src/$(DKMS_NAME)-$(DKMS_VER)/driver/*.mod.c
+	install -m 644 -v -D Makefile $(DESTDIR)$(PREFIX)/src/$(DKMS_NAME)-$(DKMS_VER)/Makefile
+	install -m 644 -v -D install_files/dkms/dkms.conf $(DESTDIR)$(PREFIX)/src/$(DKMS_NAME)-$(DKMS_VER)/dkms.conf
+	install -m 755 -v -d driver $(DESTDIR)$(PREFIX)/src/$(DKMS_NAME)-$(DKMS_VER)/driver
+	install -m 644 -v -D driver/Makefile $(DESTDIR)$(PREFIX)/src/$(DKMS_NAME)-$(DKMS_VER)/driver/Makefile
+	install -m 644 -v driver/*.c $(DESTDIR)$(PREFIX)/src/$(DKMS_NAME)-$(DKMS_VER)/driver/
+	install -m 644 -v driver/*.h $(DESTDIR)$(PREFIX)/src/$(DKMS_NAME)-$(DKMS_VER)/driver/
+	rm -fv $(DESTDIR)$(PREFIX)/src/$(DKMS_NAME)-$(DKMS_VER)/driver/*.mod.c
 
 remove_dkms:
 	@echo -e "\n::\033[34m Removing DKMS files\033[0m"
 	@echo "====================================================="
-	rm -rf $(DESTDIR)/usr/src/$(DKMS_NAME)-$(DKMS_VER)
+	rm -rf $(DESTDIR)$(PREFIX)/src/$(DKMS_NAME)-$(DKMS_VER)
 
 udev_install:
 	@echo -e "\n::\033[34m Installing OpenRazer udev rules\033[0m"
 	@echo "====================================================="
-	install -m 644 -v -D install_files/udev/99-razer.rules $(DESTDIR)/usr/lib/udev/rules.d/99-razer.rules
-	install -m 755 -v -D install_files/udev/razer_mount $(DESTDIR)/usr/lib/udev/razer_mount
+	install -m 644 -v -D install_files/udev/99-razer.rules $(DESTDIR)$(UDEV_PREFIX)/lib/udev/rules.d/99-razer.rules
+	install -m 755 -v -D install_files/udev/razer_mount $(DESTDIR)$(UDEV_PREFIX)/lib/udev/razer_mount
 
 udev_uninstall:
 	@echo -e "\n::\033[34m Uninstalling OpenRazer udev rules\033[0m"
 	@echo "====================================================="
-	rm -f $(DESTDIR)/usr/lib/udev/rules.d/99-razer.rules $(DESTDIR)/usr/lib/udev/razer_mount
+	rm -f $(DESTDIR)$(PREFIX)/lib/udev/rules.d/99-razer.rules $(DESTDIR)$(PREFIX)/lib/udev/razer_mount
 
 ubuntu_udev_install:
 	@echo -e "\n::\033[34m Installing OpenRazer udev rules\033[0m"
@@ -151,20 +155,20 @@ ubuntu_udev_uninstall:
 appstream_install:
 	@echo -e "\n::\033[34m Installing OpenRazer AppStream metadata\033[0m"
 	@echo "====================================================="
-	install -m 644 -v -D install_files/appstream/io.github.openrazer.openrazer.metainfo.xml $(DESTDIR)/usr/share/metainfo/io.github.openrazer.openrazer.metainfo.xml
+	install -m 644 -v -D install_files/appstream/io.github.openrazer.openrazer.metainfo.xml $(DESTDIR)$(PREFIX)/share/metainfo/io.github.openrazer.openrazer.metainfo.xml
 
 appstream_uninstall:
 	@echo -e "\n::\033[34m Uninstalling OpenRazer AppStream metadata\033[0m"
 	@echo "====================================================="
-	rm -f $(DESTDIR)/usr/share/metainfo/io.github.openrazer.openrazer.metainfo.xml
+	rm -f $(DESTDIR)$(PREFIX)/share/metainfo/io.github.openrazer.openrazer.metainfo.xml
 
 # Install for Ubuntu
 # WARNING: do not use this target manually, it is just meant for Debian packaging! Read the warning on top of the file!
 ubuntu_install: setup_dkms ubuntu_udev_install ubuntu_daemon_install ubuntu_python_library_install appstream_install
 	@echo -e "\n::\033[34m Installing for Ubuntu\033[0m"
 	@echo "====================================================="
-	mv $(DESTDIR)/usr/lib/python3.* $(DESTDIR)/usr/lib/python3
-	mv $(DESTDIR)/usr/lib/python3/site-packages $(DESTDIR)/usr/lib/python3/dist-packages
+	mv $(DESTDIR)$(PREFIX)/lib/python3.* $(DESTDIR)$(PREFIX)/lib/python3
+	mv $(DESTDIR)$(PREFIX)/lib/python3/site-packages $(DESTDIR)$(PREFIX)/lib/python3/dist-packages
 
 install_i_know_what_i_am_doing: all driver_install udev_install python_library_install
 	@make --no-print-directory -C daemon install DESTDIR=$(DESTDIR)


### PR DESCRIPTION
Hello,

This change just adds the PREFIX and UDEV_PREFIX variables in the Makefile.

The changes won't affect building on the systems that openrazer currently works on since the PREFIX and UDEV_PREFIX variables are currently set to /usr.

This change is to make building (well, specifically installing) openrazer for, according to the Makefile, "those who know what they are doing" easier.