### PR TITLE
Improve battery notification presentation & add option to configure % threshold

### DIFF
--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -387,6 +387,7 @@ class RazerBlackWidowV3ProWired(_RippleKeyboard):
         self._battery_manager = _BatteryManager(self, self._device_number, "Razer BlackWidow V3 Pro (Wired)")
         self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
         self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         super()._close()
@@ -842,6 +843,7 @@ class RazerBlackWidowV3MiniHyperspeed(_RippleKeyboard):
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer BlackWidow V3 Mini Hyperspeed')
         self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
         self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         """

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -138,6 +138,7 @@ class RazerLanceheadWirelessReceiver(RazerLanceheadWirelessWired):
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Lancehead Wireless')
         self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
         self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         """
@@ -224,6 +225,7 @@ class RazerLanceheadWireless(RazerLanceheadWired):
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Lancehead')
         self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
         self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         """
@@ -454,6 +456,7 @@ class RazerMambaChromaWireless(__RazerDeviceBrightnessSuspend):
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Mamba')
         self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
         self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         """
@@ -1247,6 +1250,7 @@ class RazerMamba2012Wireless(__RazerDeviceSpecialBrightnessSuspend):
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Mamba')
         self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
         self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         """
@@ -1389,6 +1393,7 @@ class RazerMambaWirelessReceiver(RazerMambaWirelessWired):
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Mamba Wireless')
         self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
         self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         """
@@ -1745,6 +1750,7 @@ class RazerViperUltimateWireless(RazerViperUltimateWired):
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Viper Ultimate Wireless')
         self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
         self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         """
@@ -2270,6 +2276,7 @@ class RazerBasiliskUltimateReceiver(RazerBasiliskUltimateWired):
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Basilisk Ultimate')
         self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
         self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         """
@@ -2447,6 +2454,7 @@ class RazerDeathAdderV2ProWireless(RazerDeathAdderV2ProWired):
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer DeathAdder V2 Pro Wireless')
         self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
         self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         """
@@ -2479,6 +2487,7 @@ class RazerAtherisReceiver(__RazerDevice):
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Atheris (Receiver)')
         self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
         self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         """
@@ -2519,6 +2528,7 @@ class RazerBasiliskXHyperSpeed(__RazerDevice):
         self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Basilisk X HyperSpeed')
         self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
         self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         """
@@ -2556,11 +2566,10 @@ class RazerOrochiV2Receiver(__RazerDevice):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._battery_manager = _BatteryManager(
-            self, self._device_number, 'Razer Orochi V2')
-
-        self._battery_manager.active = self.config.getboolean(
-            'Startup', 'mouse_battery_notifier', fallback=False)
+        self._battery_manager = _BatteryManager(self, self._device_number, 'Razer Orochi V2')
+        self._battery_manager.active = self.config.getboolean('Startup', 'battery_notifier', fallback=False)
+        self._battery_manager.frequency = self.config.getint('Startup', 'battery_notifier_freq', fallback=10 * 60)
+        self._battery_manager.percent = self.config.getint('Startup', 'battery_notifier_percent', fallback=33)
 
     def _close(self):
         """

--- a/daemon/openrazer_daemon/misc/battery_notifier.py
+++ b/daemon/openrazer_daemon/misc/battery_notifier.py
@@ -31,7 +31,7 @@ class BatteryNotifier(threading.Thread):
 
         if self._notify2:
             try:
-                notify2.init('openrazer_daemon')
+                notify2.init('OpenRazer')
             except Exception as err:
                 self._logger.warning("Failed to init notification daemon, err: {0}".format(err))
                 self._notify2 = False
@@ -43,7 +43,7 @@ class BatteryNotifier(threading.Thread):
         self._get_battery_func = parent.getBattery
 
         if self._notify2:
-            self._notification = notify2.Notification(summary="{0}")
+            self._notification = notify2.Notification(summary=device_name)
             self._notification.set_timeout(NOTIFY_TIMEOUT)
 
         self._last_notify_time = datetime.datetime(1970, 1, 1)
@@ -79,21 +79,32 @@ class BatteryNotifier(threading.Thread):
                 time.sleep(0.2)
                 battery_level = self._get_battery_func()
 
-            if battery_level < 10.0:
-                if battery_level == 0.0:
-                    # Do nothing
-                    pass
-                else:
-                    if self._notify2:
-                        self._notification.update(summary="{0} Battery at {1:.1f}%".format(self._device_name, battery_level), message='Please charge your device', icon='notification-battery-low')
-                        self._notification.show()
-            else:
-                if self._notify2:
-                    self._notification.update(summary="{0} Battery at {1:.1f}%".format(self._device_name, battery_level))
-                    self._notification.show()
+            title = self._device_name
+            battery_percent = int(round(battery_level, 0))
+            message = "Battery is {0}%".format(battery_percent)
+            icon = "battery-full"
+
+            if battery_level == 0.0:
+                # Do nothing
+                pass
+
+            elif battery_level <= 10.0:
+                message = "Battery is low ({0}%). Please charge your device".format(battery_percent)
+                icon = "battery-empty"
+
+            elif battery_level <= 30.0:
+                icon = "battery-low"
+
+            elif battery_level <= 70.0:
+                icon = "battery-good"
+
+            elif battery_level == 100.0:
+                message = "Battery is fully charged ({0}%)".format(battery_percent)
 
             if self._notify2:
-                self._logger.debug("{0} Battery at {1:.1f}%".format(self._device_name, battery_level))
+                self._notification.update(summary=title, message=message, icon=icon)
+                self._notification.show()
+                self._logger.debug("{0} Battery at {1}%".format(self._device_name, battery_percent))
 
     def run(self):
         """

--- a/daemon/openrazer_daemon/misc/battery_notifier.py
+++ b/daemon/openrazer_daemon/misc/battery_notifier.py
@@ -28,6 +28,7 @@ class BatteryNotifier(threading.Thread):
 
         self.event = threading.Event()
         self.frequency = 0
+        self.percent = 0
 
         if self._notify2:
             try:
@@ -73,6 +74,7 @@ class BatteryNotifier(threading.Thread):
             self._last_notify_time = now
 
             battery_level = self._get_battery_func()
+            battery_percent = int(round(battery_level, 0))
 
             # Sometimes on wifi don't get batt
             if battery_level == -1.0:
@@ -80,7 +82,6 @@ class BatteryNotifier(threading.Thread):
                 battery_level = self._get_battery_func()
 
             title = self._device_name
-            battery_percent = int(round(battery_level, 0))
             message = "Battery is {0}%".format(battery_percent)
             icon = "battery-full"
 
@@ -102,9 +103,11 @@ class BatteryNotifier(threading.Thread):
                 message = "Battery is fully charged ({0}%)".format(battery_percent)
 
             if self._notify2:
-                self._notification.update(summary=title, message=message, icon=icon)
-                self._notification.show()
                 self._logger.debug("{0} Battery at {1}%".format(self._device_name, battery_percent))
+
+                if battery_level <= self.percent:
+                    self._notification.update(summary=title, message=message, icon=icon)
+                    self._notification.show()
 
     def run(self):
         """
@@ -168,3 +171,11 @@ class BatteryManager(object):
     @frequency.setter
     def frequency(self, frequency):
         self._battery_thread.frequency = frequency
+
+    @property
+    def percent(self):
+        return self._battery_thread.percent
+
+    @percent.setter
+    def percent(self, percent):
+        self._battery_thread.percent = percent

--- a/daemon/resources/man/razer.conf.5
+++ b/daemon/resources/man/razer.conf.5
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "razer.conf" "5" "2021-10-03"
+.TH "razer.conf" "5" "2021-11-09"
 .P
 .SH NAME
 .P
@@ -54,6 +54,11 @@ This flag specifies that notifications should be shown regularly with the remain
 \fBbattery_notifier_freq\fR \fIint\fR
 .RS 4
 This flag specifies how often the notification with the remaining battery level should be shown.\&
+.P
+.RE
+\fBbattery_notifier_percent\fR \fIint\fR
+.RS 4
+This flag specifies what battery percentage the device should reach before sending notifications.\&
 .P
 .RE
 \fBrestore_persistence\fR \fIbool\fR

--- a/daemon/resources/man/razer.conf.5.scd
+++ b/daemon/resources/man/razer.conf.5.scd
@@ -39,6 +39,9 @@ The *[Startup]* section in the configuration file contains values to be used dur
 *battery_notifier_freq* _int_
 	This flag specifies how often the notification with the remaining battery level should be shown.
 
+*battery_notifier_percent* _int_
+	This flag specifies what battery percentage the device should reach before sending notifications.
+
 *restore_persistence* _bool_
 	This flag specifies whether effects saved in persistence.conf should be applied when the daemon starts.
 

--- a/daemon/resources/razer.conf
+++ b/daemon/resources/razer.conf
@@ -16,5 +16,8 @@ battery_notifier = True
 # Battery notification frequency [s] (0 to disable)
 battery_notifier_freq = 600
 
+# Battery notifications appear when device reaches this percentage
+battery_notifier_percent = 33
+
 # Apply effects saved to disk when daemon starts
 restore_persistence = False


### PR DESCRIPTION
* Adds `battery_notifier_percent` to set when notifications should start appearing. New default: 33%.
* Use standard `battery-*` icons and adapt based on percentage. `notification-battery-low` seemed non-standard and couldn't be found in Adwaida, GNOME or Breeze.
* Clean up code for easier reading.
* Change application title to "OpenRazer", for notification systems like Breeze which support showing the application name.

Closes #1662.

### Before
![image](https://user-images.githubusercontent.com/13032135/141017779-7c9ea90e-a949-4e52-9c58-0e94ce916719.png)

### After
![image](https://user-images.githubusercontent.com/13032135/141018479-5e08d6ea-0988-44c5-931b-e4a25c3f104d.png)
