### PR TITLE
Add test for sysfs/capability inconsistencies

### DIFF
--- a/daemon/openrazer_daemon/hardware/accessory.py
+++ b/daemon/openrazer_daemon/hardware/accessory.py
@@ -209,6 +209,6 @@ class RazerLaptopStandChroma(_RazerDeviceBrightnessSuspend):
     MATRIX_DIMS = [1, 16]
     METHODS = ['get_device_type_accessory', 'set_static_effect', 'set_wave_effect', 'set_spectrum_effect',
                'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect', 'set_breath_dual_effect',
-               'set_custom_effect', 'set_key_row']
+               'set_custom_effect', 'set_key_row', 'set_reactive_effect', 'trigger_reactive_effect']
 
     DEVICE_IMAGE = "https://hybrismediaprod.blob.core.windows.net/sys-master-phoenix-images-container/hfe/hbc/9081459376158/Razer-Laptop-Stand-Chroma-04.jpg"

--- a/daemon/openrazer_daemon/hardware/core.py
+++ b/daemon/openrazer_daemon/hardware/core.py
@@ -24,7 +24,7 @@ class RazerCore(__RazerDeviceBrightnessSuspend):
 
 class RazerCoreXChroma(__RazerDeviceBrightnessSuspend):
     """
-    Class for the Razer Core
+    Class for the Razer Core X Chroma
     """
     USB_VID = 0x1532
     USB_PID = 0x0F1A
@@ -34,6 +34,6 @@ class RazerCoreXChroma(__RazerDeviceBrightnessSuspend):
     DEVICE_IMAGE = "https://hybrismediaprod.blob.core.windows.net/sys-master-phoenix-images-container/h44/h3d/9084457943070/core-x-chroma-gallery1.jpg"
 
     METHODS = ['set_wave_effect', 'set_static_effect', 'set_spectrum_effect',
-               'set_reactive_effect', 'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect', 'set_breath_dual_effect',
+               'set_reactive_effect', 'trigger_reactive_effect', 'set_none_effect', 'set_breath_random_effect', 'set_breath_single_effect', 'set_breath_dual_effect',
                'set_starlight_random_effect', 'set_starlight_single_effect', 'set_starlight_dual_effect',
                'set_custom_effect', 'set_key_row', 'get_device_type_core']

--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -379,7 +379,7 @@ class RazerBlackWidowV3ProWired(_RippleKeyboard):
                'set_starlight_random_effect', 'set_starlight_single_effect', 'set_starlight_dual_effect',
                'set_ripple_effect', 'set_ripple_effect_random_colour',
                # Battery
-               'set_charge_effect', 'set_charge_colour', 'get_battery', 'is_charging', 'set_idle_time', 'set_low_battery_threshold']
+               'set_charge_effect', 'set_charge_colour', 'get_battery', 'is_charging', 'set_low_battery_threshold']
 
     DEVICE_IMAGE = "https://dl.razerzone.com/src/3809-1-EN-v1.png"
 

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -1730,7 +1730,7 @@ class RazerDeathAdderV3ProWired(__RazerDevice):
     USB_PID = 0x00B6
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_dpi_stages', 'set_dpi_stages',
                'get_poll_rate', 'set_poll_rate',
-               'get_battery', 'is_charging', 'get_idle_time', 'set_idle_time']
+               'get_battery', 'is_charging', 'get_idle_time', 'set_idle_time', 'set_low_battery_threshold']
 
     DEVICE_IMAGE = "https://dl.razerzone.com/src/6130/6130-1-en-v2.png"
 
@@ -1790,7 +1790,7 @@ class RazerBasiliskV3ProWired(__RazerDevice):
                # Can set custom matrix effects
                'set_custom_effect', 'set_key_row',
                # Battery
-               'get_battery', 'is_charging', 'get_idle_time', 'set_idle_time']
+               'get_battery', 'is_charging', 'get_idle_time', 'set_idle_time', 'set_low_battery_threshold']
 
     DEVICE_IMAGE = "https://dl.razerzone.com/src2/6220/6220-4-en-v1.png"
 

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -5709,11 +5709,11 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_level);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_status);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_low_threshold);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_device_idle_time);
             fallthrough;
         case USB_DEVICE_ID_RAZER_VIPER:
         case USB_DEVICE_ID_RAZER_VIPER_MINI:
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_device_idle_time);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi_stages);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_brightness);

--- a/pylib/openrazer/_fake_driver/__init__.py
+++ b/pylib/openrazer/_fake_driver/__init__.py
@@ -87,6 +87,9 @@ class FakeDevice(object):
         if serial is not None:
             self.set('device_serial', serial)
 
+        # Disallow write in directory, so disallow creating new files after setup is done.
+        os.chmod(self._tmp_dir, 0o555)
+
     def _get_endpoint_path(self, endpoint):
         return os.path.join(self._tmp_dir, endpoint)
 
@@ -192,6 +195,9 @@ class FakeDevice(object):
             for endpoint in self.endpoints:
                 path = os.path.join(self._tmp_dir, endpoint)
                 os.chmod(path, 0o660)
+
+            # Allow write in directory again for cleanup
+            os.chmod(self._tmp_dir, 0o755)
 
             shutil.rmtree(self._tmp_dir)
 

--- a/pylib/openrazer/_fake_driver/razerviper.cfg
+++ b/pylib/openrazer/_fake_driver/razerviper.cfg
@@ -3,8 +3,7 @@
 [device]
 dir_name = 0003:1532:0078.0001
 name = Razer Viper
-files = rw,device_idle_time,600
-        rw,device_mode,0x0000
+files = rw,device_mode,0x0000
         r,device_serial,XX0000000078
         r,device_type,%(name)s
         rw,dpi,800:800

--- a/pylib/openrazer/_fake_driver/razervipermini.cfg
+++ b/pylib/openrazer/_fake_driver/razervipermini.cfg
@@ -3,8 +3,7 @@
 [device]
 dir_name = 0003:1532:008A.0001
 name = Razer Viper Mini
-files = rw,device_idle_time,600
-        rw,device_mode,0x0000
+files = rw,device_mode,0x0000
         r,device_serial,XX000000008A
         r,device_type,%(name)s
         rw,dpi,800:800

--- a/scripts/ci/test-daemon.py
+++ b/scripts/ci/test-daemon.py
@@ -106,7 +106,7 @@ def test_sysfs_consistency(d):
         check_sysfs("keyboard_layout", "kbd_layout")
 
     # Devices with a matrix defined should have a suitable "custom" sysfs. Krakens are a special case.
-    if d._matrix_dimensions != (-1, -1):
+    if d._matrix_dimensions != (-1, -1) and d.name.find("Kraken") == -1:
         check_sysfs("lighting_led_matrix", "matrix_custom_frame")
         check_sysfs("lighting_led_matrix", "matrix_effect_custom")
 
@@ -136,9 +136,17 @@ def test_sysfs_consistency(d):
         check_sysfs(f"lighting_{prefix}_breath_single", f"{prefix}_matrix_effect_breath")
 
 
+def test_ripple_capable(d):
+    # Check that the device has a matrix for a software ripple effect
+    if d.has("lighting_ripple") or d.has("lighting_ripple_random"):
+        if d._matrix_dimensions == (-1, -1):
+            _test_failed(d.name, "Cannot have a ripple capability without a matrix")
+
+
 for d in devmgr.devices:
     test_sanity_check_matrix_capabilities(d)
     test_sysfs_consistency(d)
+    test_ripple_capable(d)
 test_wired_wireless_naming()
 
 if not passed:

--- a/scripts/ci/test-daemon.py
+++ b/scripts/ci/test-daemon.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python3
 import openrazer.client
+import glob
 
+daemon_test_dir = "/tmp/daemon_test"
 devmgr = openrazer.client.DeviceManager()
 passed = True
 
@@ -36,8 +38,107 @@ def test_wired_wireless_naming():
                 _test_failed(striped_name, "Naming pattern is inconsistent. Append \"(Wired)\" for the other USB PID.")
 
 
+def test_sysfs_consistency(d):
+    # Check sysfs files exist for capabilities
+    vid = str(hex(d._vid))[2:].upper().rjust(4, '0')
+    pid = str(hex(d._pid))[2:].upper().rjust(4, '0')
+
+    def check_sysfs(capability: str, sysfs_name: str):
+        """
+        Check the device has either the given pylib capability for the
+        given sysfs name, and vice versa.
+        """
+        try:
+            expected_path = glob.glob(f"{daemon_test_dir}/*:{vid}:{pid}*/{sysfs_name}", recursive=True)[0]
+        except IndexError:
+            expected_path = ""
+
+        if d.has(capability) and not glob.glob(expected_path, recursive=True):
+            _test_failed(d.name, str(hex(d._pid)) + " Has capability '{}' but no sysfs file: '{}'".format(capability, sysfs_name))
+
+        if not d.has(capability) and glob.glob(expected_path, recursive=True):
+            _test_failed(d.name, str(hex(d._pid)) + " Has sysfs '{}' but no capability set: '{}'".format(sysfs_name, capability))
+
+    def check_any_sysfs(capabilities: list[str], sysfs_names: list[str]):
+        """
+        Check the device has one of these sysfs names for one of these pylib capabilities.
+        """
+        found_sysfs = []
+        found_capability = []
+
+        for sysfs_name in sysfs_names:
+            if glob.glob(f"{daemon_test_dir}/*:{vid}:{pid}*/{sysfs_name}", recursive=True):
+                found_sysfs.append(sysfs_name)
+
+        for capability in capabilities:
+            if d.has(capability):
+                found_capability.append(capability)
+
+        # Skip Razer devices that have non-RGB effects
+        if not found_capability and ("logo_led_effect" in sysfs_names or "scroll_led_effect" in sysfs_names):
+            return
+
+        if not found_capability and found_sysfs:
+            _test_failed(d.name, str(hex(d._pid)) + " Has one of these sysfs {} but none of these capabilities: {}".format(sysfs_names, capabilities))
+
+        if found_capability and not found_sysfs:
+            _test_failed(d.name, str(hex(d._pid)) + " Has one of these capabilities {} but none of these sysfs files: {}".format(capabilities, sysfs_names))
+
+    # check_sysfs("battery", "charge_effect") # FIXME this is not correct, as per PR comments
+    # All devices have a 'set' but not a 'get'
+    check_sysfs("set_low_battery_threshold", "charge_low_threshold")
+    check_sysfs("set_idle_time", "device_idle_time")
+
+    check_sysfs("battery", "charge_level")
+    check_sysfs("battery", "charge_status")
+    check_sysfs("brightness", "matrix_brightness")
+    check_sysfs("dpi", "dpi")
+    check_sysfs("dpi_stages", "dpi_stages")
+    check_sysfs("firmware_version", "firmware_version")
+    check_sysfs("game_mode_led", "game_led_state")
+    check_sysfs("macro_mode_led", "macro_led_state")
+    check_sysfs("macro_mode_led_effect", "macro_led_effect")
+    check_sysfs("poll_rate", "poll_rate")
+    check_sysfs("serial", "device_serial")
+    check_sysfs("type", "device_type")
+
+    if d.type == "keyboard":
+        check_sysfs("keyboard_layout", "kbd_layout")
+
+    # Devices with a matrix defined should have a suitable "custom" sysfs. Krakens are a special case.
+    if d._matrix_dimensions != (-1, -1):
+        check_sysfs("lighting_led_matrix", "matrix_custom_frame")
+        check_sysfs("lighting_led_matrix", "matrix_effect_custom")
+
+    check_sysfs("lighting_breath_single", "matrix_effect_breath")
+    check_sysfs("lighting_none", "matrix_effect_none")
+    check_sysfs("lighting_reactive", "matrix_effect_reactive")
+    check_sysfs("reactive_trigger", "matrix_reactive_trigger")
+    check_sysfs("lighting_spectrum", "matrix_effect_spectrum")
+    check_any_sysfs(["lighting_starlight_random", "lighting_starlight_single", "lighting_starlight_dual"], ["matrix_effect_starlight"])
+    # Ignore devices that have mono-color razer.device.lighting.bw2013.setStatic()
+    if d._pid not in [0x010d, 0x010e, 0x0113, 0x011a, 0x011b, 0x011c, 0x0202]:
+        check_sysfs("lighting_static", "matrix_effect_static")
+    check_sysfs("lighting_wave", "matrix_effect_wave")
+    check_sysfs("lighting_pulsate", "matrix_effect_pulsate")
+    check_sysfs("lighting_blinking", "matrix_effect_blinking")
+
+    check_sysfs("lighting_backlight_active", "backlight_led_state")
+
+    for prefix in ["logo", "scroll", "left", "right", "charging", "fast_charging", "fully_charged"]:
+        check_sysfs(f"lighting_{prefix}_brightness", f"{prefix}_led_brightness")
+        check_sysfs(f"lighting_{prefix}_active", f"{prefix}_led_state")
+
+        for effect in ["none", "reactive", "spectrum", "static", "wave"]:
+            # There are two implementations with different sysfs files
+            check_any_sysfs([f"lighting_{prefix}_{effect}"], [f"{prefix}_matrix_effect_{effect}", f"{prefix}_led_effect"])
+
+        check_sysfs(f"lighting_{prefix}_breath_single", f"{prefix}_matrix_effect_breath")
+
+
 for d in devmgr.devices:
     test_sanity_check_matrix_capabilities(d)
+    test_sysfs_consistency(d)
 test_wired_wireless_naming()
 
 if not passed:


### PR DESCRIPTION
Some devices were implemented setting a daemon capability, so while it appears in frontends, it doesn't work because it's missing the driver counterpart. Likewise, something may have been implemented in the driver, but the capability is not set in the daemon. That could be a problem for third party projects that study the OpenRazer driver.
   
----

## Testers Wanted!

Check the device list below. 

### If your device has a **sysfs** but no capability

To the terminal!

```bash
cd /sys/bus/hid/drivers/
ls

# Enter the razer* directory for that device - keyboards use the "razerkbd" driver
cd razerkbd/

# There's 3 directories here, find out which one contains the effect file to test
ls **/matrix_effect_reactive

# It'll print something like this:
#    0003:1532:0203.000C/matrix_effect_reactive
# Enter that folder (change accordingly, press tab to autocomplete)
cd 0003:1532:0203.000C

# Echo to the file, and see if it works on the hardware
echo -n -e "\x01\x00\xFF\xFF" > matrix_effect_reactive
```

This example is for `matrix_effect_reactive` which echos a colour. If necessary, look up what to echo in the wiki for the [keyboard](https://github.com/openrazer/openrazer/wiki/Using-the-keyboard-driver) or [mouse](https://github.com/openrazer/openrazer/wiki/Using-the-mouse-driver) driver. Let us know if this worked or nothing happens, and perhaps check `dmesg` if the command failed.

### If your device has a **capability** but no sysfs

It means that the hardware effect is not supported, or was incorrectly implemented. This requires hacking the driver and C code to figure out if it exists.

Grab a copy of OpenRazer's source code and try adding a `case` statement in the driver for the device under the relevant function and rebuild the driver. For example, reactive:

```diff
        case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRED:
+       case USB_DEVICE_ID_RAZER_BLADE_2019_BASE:
            report = razer_chroma_extended_matrix_effect_reactive(VARSTORE, BACKLIGHT_LED, speed, (struct razer_rgb*)&buf[1]);
            break;
```
-- https://github.com/openrazer/openrazer/blob/master/driver/razerkbd_driver.c#L1408-L1456

Then rebuild it according to your distro, and try echoing to the sysfs driver.  As a rough guide:

```bash
# Unload driver
sudo modprobe -r razerkbd

# Copy new source file for DKMS
sudo cp /path/to/src.c /usr/src/openrazer-driver-3.2.0/driver/

# Rebuild using DKMS (for most distros)
sudo dkms remove openrazer-driver/3.2.0
sudo dkms install openrazer-driver/3.2.0

# Load driver
sudo modprobe razerkbd
```

Re-plugging the hardware (or a reboot) may be necessary so the kernel definitely loads the new changes.

Let us know here if it works, and if you've found a working change, please create a pull request and mention #1673.

-----

### Approach

Two ways we could tackle each device:

1. Case by case basis, looking at old issues/pcaps. Users with the hardware should help us confirm by modifying the driver/daemon to confirm it works, so we know what to keep/delete.
1. Assume they don't work and remove the inconsistent one. The community could reimplement it later.

Some might require changes to the pylib/daemon due to API design issues.

<details><summary><b>Capabilities not checked</b></summary>

Like with `available_dpi`, I think these are just specific to the daemon, so they are not tested:

- `macro_logic`
- `lighting_profile_led_red`
- `lighting_profile_led_green`
- `lighting_profile_led_blue`
</details>

## To Do

- [x] Some devices have a `battery`, but may not support "idle time" or "low battery threshold". Daemon should separate their capabilities.
- [x] Some `battery` devices have a `set` for idle time / low battery threshold, but not a `get`.
- **BW2013 devices** (like BlackWidow Ultimate 2013 & Deathstalker Expert)
    - #1575
    - #1931
    - [x] Static is not exposed as a capability, but it's different as it accepts no colour parameter.
- [ ] Review [`charge_effect`](https://github.com/openrazer/openrazer/wiki/Using-the-mouse-driver#charge_effect---sets-the-charging-effect-write-only) and [`charge_colour`](https://github.com/openrazer/openrazer/wiki/Using-the-mouse-driver#charge_colour---sets-the-charging-colour-write-only). They're 5+ years old and not in the pylib.
- [x] Razer Chroma Mug Holder has `blinking` but it's not supported properly.
- [x] Razer Ornata doesn't have a `lighting_starlight_random` and breaks the test as the odd one out. Apparently, it wasn't tested at time of its implementation.
- Watch out for devices that had a matrix that didn't physically work:
    -  https://github.com/openrazer/openrazer/issues/1252#issuecomment-714418151
    -  #1305
   
## Devices to fix

These have a `lighting_static` sysfs, but use the 'older' BW2013 protocol which is different to the RGB static.
Will be fixed by [#1575](https://github.com/openrazer/openrazer/issues/1575)

- **Razer BlackWidow Stealth** - c1e5426f059f2566125d9945757e1d8d4c003f50
- **Razer Orbweaver** - 044c982ef2a5fe06b797cee91c19127f7653d4ae
- **Razer BlackWidow Tournament Edition 2014**
- **Razer BlackWidow Ultimate 2013**
- **Razer Deathstalker Expert**
- **Razer BlackWidow Ultimate 2012**
- **Razer BlackWidow Stealth Edition**

To see devices that need fixing:

```bash
killall openrazer-daemon
./scripts/ci/setup-fakedriver.sh
./scripts/ci/launch-daemon.sh
./scripts/ci/test-daemon.sh
```