### PR TITLE
Add category to .desktop file

### DIFF
--- a/install_files/desktop/openrazer-daemon.desktop
+++ b/install_files/desktop/openrazer-daemon.desktop
@@ -5,6 +5,7 @@ Keywords=razer;keyboard;chroma;
 NoDisplay=false
 Exec=/usr/bin/openrazer-daemon --foreground --verbose
 Icon=/usr/share/pixmaps/python3.xpm
+Categories=System;HardwareSettings;
 Terminal=false
 Type=Application
 X-GNOME-Autostart-Phase=Applications


### PR DESCRIPTION
Currently, once OpenRazer has been installed, the installation will put the application in 'Lost & Found' (while using KDE) due to the fact that the .desktop doesn't have a specified category. This commit fixes the .desktop file and addresses the symptom.