### PR TITLE
udev: Check binding for 'razer' driver in addition to 'hid-generic'

### DIFF
--- a/install_files/udev/razer_mount
+++ b/install_files/udev/razer_mount
@@ -42,15 +42,17 @@ if [ ! -d /sys/bus/hid/drivers/"$DRIVER" ] ; then
 	mesg "Modprobed $DRIVER"
 fi
 
-if [ -d /sys/bus/hid/drivers/hid-generic/"$DEVICE_ID" ] ; then
-	# Unbind from hid
-	mesg "Unbinding $DEVICE_ID from hid-generic"
-	printf '%s' "$DEVICE_ID" > /sys/bus/hid/drivers/hid-generic/unbind
-	mesg "Binding $DEVICE_ID to $DRIVER"
-	printf '%s' "$DEVICE_ID" > /sys/bus/hid/drivers/"$DRIVER"/bind
-	sleep 0.1
-	mesg "Finished binding $DEVICE_ID"
-fi
+for GENERIC_DRIVER in "razer" "hid-generic"; do
+	if [ -d /sys/bus/hid/drivers/"$GENERIC_DRIVER"/"$DEVICE_ID" ] ; then
+		# Unbind from hid
+		mesg "Unbinding $DEVICE_ID from $GENERIC_DRIVER"
+		printf '%s' "$DEVICE_ID" > /sys/bus/hid/drivers/"$GENERIC_DRIVER"/unbind
+		mesg "Binding $DEVICE_ID to $DRIVER"
+		printf '%s' "$DEVICE_ID" > /sys/bus/hid/drivers/"$DRIVER"/bind
+		sleep 0.1
+		mesg "Finished binding $DEVICE_ID"
+	fi
+done
 
 if [ -d /sys/bus/hid/drivers/"$DRIVER"/"$DEVICE_ID" ] ; then
 	mesg "Changing group /sys/bus/hid/drivers/$DRIVER/$DEVICE_ID/"


### PR DESCRIPTION
Fixes #1860.

[The upstream Linux kernel introduced a `razer` driver](https://github.com/torvalds/linux/commit/047b6188b66e42513a2b0d36244f03d06f882e59) for a handful of older Razer devices. This commit will check and unbind from that driver in addition to `hid-generic`, allowing these devices to continue using the OpenRazer driver.
