### PR TITLE
daemon: Initialize Y=0 for DPI X only devices

### DIFF
--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -93,7 +93,12 @@ class RazerDevice(DBusService):
                 "wave_dir": 1,
             }
 
-        self.dpi = [1800, 1800]
+        # Check for a DPI X only device since they need a Y value of 0
+        if 'available_dpi' in self.METHODS:
+            self.dpi = [1800, 0]
+        else:
+            self.dpi = [1800, 1800]
+
         self.poll_rate = 500
 
         self._effect_sync = effect_sync.EffectSync(self, device_number)


### PR DESCRIPTION
Testing done by @pschloenzke for https://github.com/openrazer/openrazer/issues/427#issuecomment-1193778484 has revealed that the daemon may fail on initialization of DPI for DPI X only devices when a Y value other than 0 is assigned. This patch has been tested and is reported to resolve the issue, see https://github.com/openrazer/openrazer/issues/427#issuecomment-1196977743.
