### PR TITLE
daemon: Initialize poll rate when successive DBus call

### DIFF
--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -241,6 +241,9 @@ class RazerDevice(DBusService):
 
         poll_rate_func = getattr(self, "setPollRate", None)
         if poll_rate_func is not None:
+            # Check if DPI was set and delay for successive DBus call
+            if dpi_func is not None:
+                time.sleep(0.5)
             poll_rate_func(self.poll_rate)
 
         # load last effects


### PR DESCRIPTION
Testing done by @pschloenzke for https://github.com/openrazer/openrazer/issues/427#issuecomment-1196977743 shows that on daemon start poll rate initialization may fail. This appears to be due to successive DBus calls, set DPI followed by set poll rate, happening at virtually the same instance.

The patch introduces an additional check for the existence of a function used to set DPI. If the function is found a delay of half a second will occur before the function to set poll rate is called. This patch has been tested and is reported to resolve the issue, see https://github.com/openrazer/openrazer/issues/427#issuecomment-1197799965.
