### PR TITLE
add install_requires to setup.py

### DIFF
--- a/daemon/setup.py
+++ b/daemon/setup.py
@@ -6,5 +6,12 @@ from setuptools import setup, find_packages
 setup(
     name="openrazer_daemon",
     version="3.6.1",
-    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
+    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    install_requires=[
+        "daemonize >= 2.4.7",
+        "dbus-python >= 1.2.0",
+        "PyGObject >= 3.20.0",
+        "pyudev >= 0.16.1",
+        "setproctitle >= 1.1.8",
+    ],
 )

--- a/pylib/setup.py
+++ b/pylib/setup.py
@@ -7,7 +7,11 @@ setup(
     name="openrazer",
     version="3.6.1",
     packages=find_packages(exclude=["tests", "openrazer._fake_driver"]),
-    install_requires=['dbus-python', 'numpy'],
+    install_requires=[
+        "dbus-python >= 1.2.0",
+        "numpy >= 1.11.0",
+        "openrazer_daemon == 3.6.1",
+    ],
     author="OpenRazer contributors",
     description="Library for interacting with the OpenRazer daemon.",
     license="GPLv2+",


### PR DESCRIPTION
I think it's valuable to specify what Python packages OpenRazer requires, I also added a minimum version (these versions are the latest versions available in Ubuntu Xenial).

Ubuntu Xenial is really ancient (with Python 3.5), is this still a requirement?