### PR TITLE
also ask for the HID descriptor

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-device-support.md
+++ b/.github/ISSUE_TEMPLATE/new-device-support.md
@@ -24,6 +24,15 @@ Please post the output of
     ls -lah /dev/input/by-id/
 ```
 
+<details>
+
+```
+Please post the output of
+    usbhid-dump -m 1532 -ed
+```
+
+</details>
+
 ### Packet Captures
 
 <Please see here as we probably need packet captures>


### PR DESCRIPTION
I've created https://github.com/meeuw/razer-emulator so I can emulate OpenRazer devices for OpenRazer but also Synapse (!)

Synapse (or Windows) is VERY picky on the HID descriptor, if something is wrong with the device gets disabled.

I think the Windows drivers use the HID descriptor to determine which interface is used to send the custom control messages, openrazer uses hardcoded values for certain devices (`report_index`) for this.

I suspect many Razer devices don't mind so much what interface is used because what OpenRazer does doesn't always seem to match with the Windows Drivers...

I think it would be good to refactor openrazer to parse the HID descriptor to find out what interface should be used but for this it would be really useful to have a database of HID descriptors.

To give you an idea what the descriptor looks like, there is a nice tool online to parse the descriptor:

https://eleccelerator.com/usbdescreqparser/

```
0x05, 0x0C,        // Usage Page (Consumer)
0x09, 0x01,        // Usage (Consumer Control)
0xA1, 0x01,        // Collection (Application)
0x06, 0x00, 0xFF,  //   Usage Page (Vendor Defined 0xFF00)
0x09, 0x02,        //   Usage (0x02)
0x15, 0x00,        //   Logical Minimum (0)
0x25, 0x01,        //   Logical Maximum (1)
0x75, 0x08,        //   Report Size (8)
0x95, 0x5A,        //   Report Count (90)
0xB1, 0x01,        //   Feature (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
0xC0,              // End Collection
```

Points of interest:

Usage Page (Vendor Defined 0xFF00)
Report Count (90) ( = RAZER_USB_REPORT_LEN)