### PR TITLE
Refactor suspend/resume handling

### DIFF
--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -309,20 +309,7 @@ class RazerDevice(DBusService):
                     except KeyError:
                         pass
 
-                if 'set_' + i + '_active' in self.METHODS:
-                    active_func = getattr(self, "set" + self.capitalize_first_char(i) + "Active", None)
-                    if active_func is not None:
-                        active_func(self.zone[i]["active"])
-
-                # load brightness level
-                bright_func = None
-                if i == "backlight":
-                    bright_func = getattr(self, "setBrightness", None)
-                elif 'set_' + i + '_brightness' in self.METHODS:
-                    bright_func = getattr(self, "set" + self.capitalize_first_char(i) + "Brightness", None)
-
-                if bright_func is not None:
-                    bright_func(self.zone[i]["brightness"])
+        self.restore_brightness()
 
         if self.config.getboolean('Startup', "restore_persistence") is True:
             self.restore_effect()
@@ -350,6 +337,30 @@ class RazerDevice(DBusService):
         :rtype: bool
         """
         return self.DEDICATED_MACRO_KEYS
+
+    def restore_brightness(self):
+        """
+        Set the device to the current brightness/active state.
+
+        This is used at launch time.
+        """
+        for i in self.ZONES:
+            if self.zone[i]["present"]:
+                # load active state
+                if 'set_' + i + '_active' in self.METHODS:
+                    active_func = getattr(self, "set" + self.capitalize_first_char(i) + "Active", None)
+                    if active_func is not None:
+                        active_func(self.zone[i]["active"])
+
+                # load brightness level
+                bright_func = None
+                if i == "backlight":
+                    bright_func = getattr(self, "setBrightness", None)
+                elif 'set_' + i + '_brightness' in self.METHODS:
+                    bright_func = getattr(self, "set" + self.capitalize_first_char(i) + "Brightness", None)
+
+                if bright_func is not None:
+                    bright_func(self.zone[i]["brightness"])
 
     def restore_effect(self):
         """

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -368,6 +368,28 @@ class RazerDevice(DBusService):
                 if bright_func is not None:
                     bright_func(self.zone[i]["brightness"])
 
+    def disable_brightness(self):
+        """
+        Set brightness to 0 and/or active state to false.
+        """
+        for i in self.ZONES:
+            if self.zone[i]["present"]:
+                # set active state
+                if 'set_' + i + '_active' in self.METHODS:
+                    active_func = getattr(self, "set" + self.capitalize_first_char(i) + "Active", None)
+                    if active_func is not None:
+                        active_func(False)
+
+                # set brightness level
+                bright_func = None
+                if i == "backlight":
+                    bright_func = getattr(self, "setBrightness", None)
+                elif 'set_' + i + '_brightness' in self.METHODS:
+                    bright_func = getattr(self, "set" + self.capitalize_first_char(i) + "Brightness", None)
+
+                if bright_func is not None:
+                    bright_func(0)
+
     def restore_effect(self):
         """
         Set the device to the current effect

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -451,6 +451,8 @@ class RazerDevice(DBusService):
         :param value: Value
         :type value: string
         """
+        self.logger.debug("Set persistence (%s, %s, %s)", zone, key, value)
+
         self.persistence.status["changed"] = True
 
         if zone:

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -1042,6 +1042,7 @@ class RazerDevice(DBusService):
         self.disable_persistence = True
 
         self.disable_brightness()
+        self._suspend_device()
 
         self.disable_notify = False
         self.disable_persistence = False
@@ -1055,21 +1056,20 @@ class RazerDevice(DBusService):
         self.disable_persistence = True
 
         self.restore_brightness()
+        self._resume_device()
 
         self.disable_notify = False
         self.disable_persistence = False
 
     def _suspend_device(self):
         """
-        Suspend device
+        Override to implement custom suspend behavior
         """
-        raise NotImplementedError()
 
     def _resume_device(self):
         """
-        Resume device
+        Override to implement custom resume behavior
         """
-        raise NotImplementedError()
 
     def _close(self):
         """

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -57,6 +57,7 @@ class RazerDevice(DBusService):
         self._observer_list = []
         self._effect_sync_propagate_up = False
         self._disable_notifications = False
+        self._disable_persistence = False
         self.additional_interfaces = []
         if additional_interfaces is not None:
             self.additional_interfaces.extend(additional_interfaces)
@@ -451,6 +452,8 @@ class RazerDevice(DBusService):
         :param value: Value
         :type value: string
         """
+        if self._disable_persistence:
+            return
         self.logger.debug("Set persistence (%s, %s, %s)", zone, key, value)
 
         self.persistence.status["changed"] = True
@@ -851,6 +854,26 @@ class RazerDevice(DBusService):
         :type value: bool
         """
         self._disable_notifications = value
+
+    @property
+    def disable_persistence(self):
+        """
+        Disable persistence flag
+
+        :return: Flag
+        :rtype: bool
+        """
+        return self._disable_persistence
+
+    @disable_persistence.setter
+    def disable_persistence(self, value):
+        """
+        Set the disable persistence flag
+
+        :param value: Disable
+        :type value: bool
+        """
+        self._disable_persistence = value
 
     def get_driver_path(self, driver_filename):
         """

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -1205,18 +1205,9 @@ class RazerDevice(DBusService):
         return "{0}:{1}".format(self.__class__.__name__, self.serial)
 
 
-class RazerDeviceSpecialBrightnessSuspend(RazerDevice):
-    """
-    Class for suspend using brightness
-
-    Suspend functions
-    """
-
-
-class RazerDeviceBrightnessSuspend(RazerDeviceSpecialBrightnessSuspend):
+class RazerDeviceBrightnessSuspend(RazerDevice):
     """
     Class for devices that have get_brightness and set_brightness
-    Inherits from RazerDeviceSpecialBrightnessSuspend
     """
 
     def __init__(self, *args, **kwargs):

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -1212,32 +1212,6 @@ class RazerDeviceSpecialBrightnessSuspend(RazerDevice):
     Suspend functions
     """
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = openrazer_daemon.dbus_services.dbus_methods.get_brightness(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        openrazer_daemon.dbus_services.dbus_methods.set_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        openrazer_daemon.dbus_services.dbus_methods.set_brightness(self, brightness)
-        self.disable_notify = False
-
 
 class RazerDeviceBrightnessSuspend(RazerDeviceSpecialBrightnessSuspend):
     """

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -242,14 +242,6 @@ class RazerDevice(DBusService):
                 except KeyError:
                     pass
 
-        dpi_func = getattr(self, "setDPI", None)
-        if dpi_func is not None:
-            dpi_func(self.dpi[0], self.dpi[1])
-
-        poll_rate_func = getattr(self, "setPollRate", None)
-        if poll_rate_func is not None:
-            poll_rate_func(self.poll_rate)
-
         # load last effects
         for i in self.ZONES:
             if self.zone[i]["present"]:
@@ -309,6 +301,7 @@ class RazerDevice(DBusService):
                     except KeyError:
                         pass
 
+        self.restore_dpi_poll_rate()
         self.restore_brightness()
 
         if self.config.getboolean('Startup', "restore_persistence") is True:
@@ -337,6 +330,18 @@ class RazerDevice(DBusService):
         :rtype: bool
         """
         return self.DEDICATED_MACRO_KEYS
+
+    def restore_dpi_poll_rate(self):
+        """
+        Set the device DPI & poll rate to the saved value
+        """
+        dpi_func = getattr(self, "setDPI", None)
+        if dpi_func is not None:
+            dpi_func(self.dpi[0], self.dpi[1])
+
+        poll_rate_func = getattr(self, "setPollRate", None)
+        if poll_rate_func is not None:
+            poll_rate_func(self.poll_rate)
 
     def restore_brightness(self):
         """

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -1038,14 +1038,26 @@ class RazerDevice(DBusService):
         Suspend device
         """
         self.logger.info("Suspending %s", self.__class__.__name__)
-        self._suspend_device()
+        self.disable_notify = True
+        self.disable_persistence = True
+
+        self.disable_brightness()
+
+        self.disable_notify = False
+        self.disable_persistence = False
 
     def resume_device(self):
         """
         Resume device
         """
         self.logger.info("Resuming %s", self.__class__.__name__)
-        self._resume_device()
+        self.disable_notify = True
+        self.disable_persistence = True
+
+        self.restore_brightness()
+
+        self.disable_notify = False
+        self.disable_persistence = False
 
     def _suspend_device(self):
         """

--- a/daemon/openrazer_daemon/hardware/headsets.py
+++ b/daemon/openrazer_daemon/hardware/headsets.py
@@ -23,33 +23,15 @@ class RazerKraken71(__RazerDevice):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/229/229_kraken_71.png"
 
     def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
         self.suspend_args.clear()
-
         self.suspend_args['effect'] = self.zone["backlight"]["effect"]
 
-        self.disable_notify = True
         _dbus_chroma.set_none_effect(self)
-        self.disable_notify = False
 
     def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-
         effect = self.suspend_args.get('effect', '')
-
-        self.disable_notify = True
         if effect == 'static':  # Static on classic is only 1 colour
             _dbus_chroma.set_static_effect(self, 0x00, 0x00, 0x00)
-
-        self.disable_notify = False
 
 
 class RazerKraken71Alternate(RazerKraken71):
@@ -74,39 +56,22 @@ class RazerKraken71Chroma(__RazerDevice):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/280/280_kraken_71_chroma.png"
 
     def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
         self.suspend_args.clear()
-
         self.suspend_args['effect'] = self.zone["backlight"]["effect"]
         self.suspend_args['args'] = self.zone["backlight"]["colors"][0:3]
 
-        self.disable_notify = True
         _dbus_chroma.set_none_effect(self)
-        self.disable_notify = False
 
     def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-
         effect = self.suspend_args.get('effect', '')
         args = self.suspend_args.get('args', [])
 
-        self.disable_notify = True
         if effect == 'spectrum':
             _dbus_chroma.set_spectrum_effect(self)
         elif effect == 'static':
             _dbus_chroma.set_static_effect(self, *args)
         elif effect == 'breathSingle':
             _dbus_chroma.set_breath_single_effect(self, *args)
-
-        self.disable_notify = False
 
 
 class RazerKraken71V2(__RazerDevice):
@@ -124,13 +89,7 @@ class RazerKraken71V2(__RazerDevice):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/729/729_kraken_71_v2.png"
 
     def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
         self.suspend_args.clear()
-
         self.suspend_args['effect'] = self.zone["backlight"]["effect"]
         if self.suspend_args['effect'] == "breathDual":
             self.suspend_args['args'] = self.zone["backlight"]["colors"][0:6]
@@ -139,21 +98,12 @@ class RazerKraken71V2(__RazerDevice):
         else:
             self.suspend_args['args'] = self.zone["backlight"]["colors"][0:3]
 
-        self.disable_notify = True
         _dbus_chroma.set_none_effect(self)
-        self.disable_notify = False
 
     def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-
         effect = self.suspend_args.get('effect', '')
         args = self.suspend_args.get('args', [])
 
-        self.disable_notify = True
         if effect == 'spectrum':
             _dbus_chroma.set_spectrum_effect(self)
         elif effect == 'static':
@@ -164,8 +114,6 @@ class RazerKraken71V2(__RazerDevice):
             _dbus_chroma.set_breath_dual_effect(self, *args)
         elif effect == 'breathTriple':
             _dbus_chroma.set_breath_triple_effect(self, *args)
-
-        self.disable_notify = False
 
 
 class RazerKrakenUltimate(__RazerDevice):
@@ -184,13 +132,7 @@ class RazerKrakenUltimate(__RazerDevice):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1603/rzr_kraken_ultimate_render01_2019_resized.png"
 
     def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
         self.suspend_args.clear()
-
         self.suspend_args['effect'] = self.zone["backlight"]["effect"]
         if self.suspend_args['effect'] == "breathDual":
             self.suspend_args['args'] = self.zone["backlight"]["colors"][0:6]
@@ -199,21 +141,12 @@ class RazerKrakenUltimate(__RazerDevice):
         else:
             self.suspend_args['args'] = self.zone["backlight"]["colors"][0:3]
 
-        self.disable_notify = True
         _dbus_chroma.set_none_effect(self)
-        self.disable_notify = False
 
     def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-
         effect = self.suspend_args.get('effect', '')
         args = self.suspend_args.get('args', [])
 
-        self.disable_notify = True
         if effect == 'spectrum':
             _dbus_chroma.set_spectrum_effect(self)
         elif effect == 'static':
@@ -224,8 +157,6 @@ class RazerKrakenUltimate(__RazerDevice):
             _dbus_chroma.set_breath_dual_effect(self, *args)
         elif effect == 'breathTriple':
             _dbus_chroma.set_breath_triple_effect(self, *args)
-
-        self.disable_notify = False
 
 
 class RazerKrakenKittyEdition(__RazerDeviceBrightnessSuspend):

--- a/daemon/openrazer_daemon/hardware/headsets.py
+++ b/daemon/openrazer_daemon/hardware/headsets.py
@@ -22,17 +22,6 @@ class RazerKraken71(__RazerDevice):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/229/229_kraken_71.png"
 
-    @staticmethod
-    def decode_bitfield(bitfield):
-        return {
-            'state': (bitfield & 0x01) == 0x01,
-            'breathing1': (bitfield & 0x02) == 0x02,
-            'spectrum': (bitfield & 0x04) == 0x04,
-            'sync': (bitfield & 0x08) == 0x08,
-            'breathing2': (bitfield & 0x10) == 0x10,
-            'breathing3': (bitfield & 0x20) == 0x20,
-        }
-
     def _suspend_device(self):
         """
         Suspend the device
@@ -84,17 +73,6 @@ class RazerKraken71Chroma(__RazerDevice):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/280/280_kraken_71_chroma.png"
 
-    @staticmethod
-    def decode_bitfield(bitfield):
-        return {
-            'state': (bitfield & 0x01) == 0x01,
-            'breathing1': (bitfield & 0x02) == 0x02,
-            'spectrum': (bitfield & 0x04) == 0x04,
-            'sync': (bitfield & 0x08) == 0x08,
-            'breathing2': (bitfield & 0x10) == 0x10,
-            'breathing3': (bitfield & 0x20) == 0x20,
-        }
-
     def _suspend_device(self):
         """
         Suspend the device
@@ -144,17 +122,6 @@ class RazerKraken71V2(__RazerDevice):
                'set_custom_kraken']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/729/729_kraken_71_v2.png"
-
-    @staticmethod
-    def decode_bitfield(bitfield):
-        return {
-            'state': (bitfield & 0x01) == 0x01,
-            'breathing1': (bitfield & 0x02) == 0x02,
-            'spectrum': (bitfield & 0x04) == 0x04,
-            'sync': (bitfield & 0x08) == 0x08,
-            'breathing2': (bitfield & 0x10) == 0x10,
-            'breathing3': (bitfield & 0x20) == 0x20,
-        }
 
     def _suspend_device(self):
         """
@@ -215,17 +182,6 @@ class RazerKrakenUltimate(__RazerDevice):
                'set_custom_kraken']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1603/rzr_kraken_ultimate_render01_2019_resized.png"
-
-    @staticmethod
-    def decode_bitfield(bitfield):
-        return {
-            'state': (bitfield & 0x01) == 0x01,
-            'breathing1': (bitfield & 0x02) == 0x02,
-            'spectrum': (bitfield & 0x04) == 0x04,
-            'sync': (bitfield & 0x08) == 0x08,
-            'breathing2': (bitfield & 0x10) == 0x10,
-            'breathing3': (bitfield & 0x20) == 0x20,
-        }
 
     def _suspend_device(self):
         """

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -4,7 +4,7 @@
 Mouse class
 """
 import re
-from openrazer_daemon.hardware.device_base import RazerDeviceBrightnessSuspend as __RazerDeviceBrightnessSuspend, RazerDeviceSpecialBrightnessSuspend as __RazerDeviceSpecialBrightnessSuspend, RazerDevice as __RazerDevice
+from openrazer_daemon.hardware.device_base import RazerDeviceBrightnessSuspend as __RazerDeviceBrightnessSuspend, RazerDevice as __RazerDevice
 from openrazer_daemon.misc.battery_notifier import BatteryManager as _BatteryManager
 # TODO replace with plain import
 from openrazer_daemon.dbus_services.dbus_methods.deathadder_chroma import get_logo_brightness as _da_get_logo_brightness, set_logo_brightness as _da_set_logo_brightness, \
@@ -17,7 +17,7 @@ from openrazer_daemon.dbus_services.dbus_methods.lanceheadte import get_left_bri
     set_left_brightness as _set_left_brightness, set_right_brightness as _set_right_brightness
 
 
-class RazerViperMini(__RazerDeviceSpecialBrightnessSuspend):
+class RazerViperMini(__RazerDevice):
     """
     Class for the Razer Viper Mini
     """
@@ -39,7 +39,7 @@ class RazerViperMini(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 8500
 
 
-class RazerLanceheadWirelessWired(__RazerDeviceSpecialBrightnessSuspend):
+class RazerLanceheadWirelessWired(__RazerDevice):
     """
     Class for the Razer Lancehead Wireless (Wired)
     """
@@ -94,7 +94,7 @@ class RazerLanceheadWirelessReceiver(RazerLanceheadWirelessWired):
         self._battery_manager.close()
 
 
-class RazerLanceheadWired(__RazerDeviceSpecialBrightnessSuspend):
+class RazerLanceheadWired(__RazerDevice):
     """
     Class for the Razer Lancehead (Wired)
     """
@@ -149,7 +149,7 @@ class RazerLanceheadWireless(RazerLanceheadWired):
         self._battery_manager.close()
 
 
-class RazerDeathAdderEssentialWhiteEdition(__RazerDeviceSpecialBrightnessSuspend):
+class RazerDeathAdderEssentialWhiteEdition(__RazerDevice):
     """
     Class for the Razer DeathAdder Essential (White Edition)
     """
@@ -171,7 +171,7 @@ class RazerDeathAdderEssentialWhiteEdition(__RazerDeviceSpecialBrightnessSuspend
     DPI_MAX = 6400
 
 
-class RazerAbyssusEliteDVaEdition(__RazerDeviceSpecialBrightnessSuspend):
+class RazerAbyssusEliteDVaEdition(__RazerDevice):
     """
     Class for the Razer Abyssus Elite (D.Va Edition)
     """
@@ -191,7 +191,7 @@ class RazerAbyssusEliteDVaEdition(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 7200
 
 
-class RazerAbyssusEssential(__RazerDeviceSpecialBrightnessSuspend):
+class RazerAbyssusEssential(__RazerDevice):
     """
     Class for the Razer Abyssus Essential
     """
@@ -211,7 +211,7 @@ class RazerAbyssusEssential(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 7200
 
 
-class RazerLanceheadTE(__RazerDeviceSpecialBrightnessSuspend):
+class RazerLanceheadTE(__RazerDevice):
     """
     Class for the Razer Lancehead Tournament Edition
     """
@@ -381,7 +381,7 @@ class RazerOrochiWired(__RazerDeviceBrightnessSuspend):
     DPI_MAX = 8200
 
 
-class RazerDeathAdderChroma(__RazerDeviceSpecialBrightnessSuspend):
+class RazerDeathAdderChroma(__RazerDevice):
     """
     Class for the Razer DeathAdder Chroma
     """
@@ -397,7 +397,7 @@ class RazerDeathAdderChroma(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 10000
 
 
-class RazerDeathAdder2000(__RazerDeviceSpecialBrightnessSuspend):
+class RazerDeathAdder2000(__RazerDevice):
     """
     Class for the Razer DeathAdder 2000
     """
@@ -413,7 +413,7 @@ class RazerDeathAdder2000(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 2000
 
 
-class RazerDeathAdder2013(__RazerDeviceSpecialBrightnessSuspend):
+class RazerDeathAdder2013(__RazerDevice):
     """
     Class for the Razer DeathAdder 2013
     """
@@ -487,7 +487,7 @@ class RazerNaga2012(__RazerDevice):
     DPI_MAX = 5600
 
 
-class RazerNagaChroma(__RazerDeviceSpecialBrightnessSuspend):
+class RazerNagaChroma(__RazerDevice):
     """
     Class for the Razer Naga Chroma
     """
@@ -532,7 +532,7 @@ class RazerNagaChroma(__RazerDeviceSpecialBrightnessSuspend):
         # self.key_manager.close()
 
 
-class RazerNagaTrinity(__RazerDeviceSpecialBrightnessSuspend):
+class RazerNagaTrinity(__RazerDevice):
     """
     Class for the Razer Naga Trinity
     """
@@ -615,7 +615,7 @@ class RazerTaipan(__RazerDevice):
     DPI_MAX = 8200
 
 
-class RazerDeathAdderElite(__RazerDeviceSpecialBrightnessSuspend):
+class RazerDeathAdderElite(__RazerDevice):
     """
     Class for the Razer DeathAdder Elite
     """
@@ -690,7 +690,7 @@ class RazerDeathAdder3_5GBlack(__RazerDevice):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/products/33/razer-deathadder-be-gallery-3.png"
 
 
-class RazerMamba2012Wireless(__RazerDeviceSpecialBrightnessSuspend):
+class RazerMamba2012Wireless(__RazerDevice):
     """
     Class for the Razer Mamba 2012 (Wireless)
     """
@@ -737,7 +737,7 @@ class RazerMamba2012Wired(__RazerDevice):
     DPI_MAX = 6400
 
 
-class RazerMambaWirelessWired(__RazerDeviceSpecialBrightnessSuspend):
+class RazerMambaWirelessWired(__RazerDevice):
     """
     Class for the Razer Mamba Wireless (Wired)
     """
@@ -803,7 +803,7 @@ class RazerNaga2014(__RazerDevice):
     DPI_MAX = 8200
 
 
-class RazerOrochi2011(__RazerDeviceSpecialBrightnessSuspend):
+class RazerOrochi2011(__RazerDevice):
     """
     Class for the Razer Orochi 2011
     """
@@ -819,7 +819,7 @@ class RazerOrochi2011(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 4000
 
 
-class RazerAbyssusV2(__RazerDeviceSpecialBrightnessSuspend):
+class RazerAbyssusV2(__RazerDevice):
     """
     Class for the Razer Abyssus V2
     """
@@ -863,7 +863,7 @@ class RazerAbyssus2000(__RazerDevice):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1277/1277_abyssus_2000.png"
 
 
-class RazerDeathAdder3500(__RazerDeviceSpecialBrightnessSuspend):
+class RazerDeathAdder3500(__RazerDevice):
     """
     Class for the Razer DeathAdder 3500
     """
@@ -879,7 +879,7 @@ class RazerDeathAdder3500(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 3500
 
 
-class RazerViperUltimateWired(__RazerDeviceSpecialBrightnessSuspend):
+class RazerViperUltimateWired(__RazerDevice):
     """
     Class for the Razer Viper Ultimate (Wired)
     """
@@ -929,7 +929,7 @@ class RazerViperUltimateWireless(RazerViperUltimateWired):
         self._battery_manager.close()
 
 
-class RazerViper(__RazerDeviceSpecialBrightnessSuspend):
+class RazerViper(__RazerDevice):
     """
     Class for the Razer Viper
     """
@@ -951,7 +951,7 @@ class RazerViper(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 16000
 
 
-class RazerDeathAdderEssential(__RazerDeviceSpecialBrightnessSuspend):
+class RazerDeathAdderEssential(__RazerDevice):
     """
     Class for the Razer DeathAdder Essential
     """
@@ -970,7 +970,7 @@ class RazerDeathAdderEssential(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1385/1385_deathadderessential.png"
 
 
-class RazerDeathAdderEssential2021(__RazerDeviceSpecialBrightnessSuspend):
+class RazerDeathAdderEssential2021(__RazerDevice):
     """
     Class for the Razer DeathAdder Essential (2021)
     """
@@ -986,7 +986,7 @@ class RazerDeathAdderEssential2021(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1385/1385_deathadderessential.png"
 
 
-class RazerMambaElite(__RazerDeviceSpecialBrightnessSuspend):
+class RazerMambaElite(__RazerDevice):
     """
     Class for the Razer Mamba Elite
     """
@@ -1017,7 +1017,7 @@ class RazerMambaElite(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1390/1390_mamba_elite.png"
 
 
-class RazerNagaLeftHanded2020(__RazerDeviceSpecialBrightnessSuspend):
+class RazerNagaLeftHanded2020(__RazerDevice):
     """
     Class for the Razer Naga Left Handed Edition 2020
     """
@@ -1119,7 +1119,7 @@ class RazerDeathAdder1800(__RazerDevice):
     DEVICE_IMAGE = "https://rzrwarranty.s3.amazonaws.com/a7daf40ad78c9584a693e310effa956019cdcd081391f93f71a7cd36d3dc577e.png"
 
 
-class RazerBasilisk(__RazerDeviceSpecialBrightnessSuspend):
+class RazerBasilisk(__RazerDevice):
     """
     Class for the Razer Basilisk
     """
@@ -1143,7 +1143,7 @@ class RazerBasilisk(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 16000
 
 
-class RazerBasiliskEssential(__RazerDeviceSpecialBrightnessSuspend):
+class RazerBasiliskEssential(__RazerDevice):
     """
     Class for the Razer Basilisk Essential
     """
@@ -1165,7 +1165,7 @@ class RazerBasiliskEssential(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 6400
 
 
-class RazerBasiliskUltimateWired(__RazerDeviceSpecialBrightnessSuspend):
+class RazerBasiliskUltimateWired(__RazerDevice):
     """
     Class for the Razer Basilisk Ultimate
     """
@@ -1243,7 +1243,7 @@ class RazerBasiliskUltimateReceiver(RazerBasiliskUltimateWired):
         self._battery_manager.close()
 
 
-class RazerBasiliskV2(__RazerDeviceSpecialBrightnessSuspend):
+class RazerBasiliskV2(__RazerDevice):
     """
     Class for the Razer Basilisk V2
     """
@@ -1267,7 +1267,7 @@ class RazerBasiliskV2(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 20000
 
 
-class RazerBasiliskV3(__RazerDeviceSpecialBrightnessSuspend):
+class RazerBasiliskV3(__RazerDevice):
     """
     Class for the Razer Basilisk V3
     """
@@ -1301,7 +1301,7 @@ class RazerBasiliskV3(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 26000
 
 
-class RazerDeathAdderV2(__RazerDeviceSpecialBrightnessSuspend):
+class RazerDeathAdderV2(__RazerDevice):
     """
     Class for the Razer DeathAdder V2
     """
@@ -1324,7 +1324,7 @@ class RazerDeathAdderV2(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 20000
 
 
-class RazerDeathAdderV2ProWired(__RazerDeviceSpecialBrightnessSuspend):
+class RazerDeathAdderV2ProWired(__RazerDevice):
     """
     Class for the Razer DeathAdder V2 Pro (Wired)
     """
@@ -1484,7 +1484,7 @@ class RazerOrochiV2Bluetooth(RazerOrochiV2Receiver):
     USB_PID = 0x0095
 
 
-class RazerNagaX(__RazerDeviceSpecialBrightnessSuspend):
+class RazerNagaX(__RazerDevice):
     """
     Class for the Razer Naga X
     """
@@ -1514,7 +1514,7 @@ class RazerNagaX(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://dl.razerzone.com/src/3993-1-EN-V2.png"
 
 
-class RazerDeathAdderV2Mini(__RazerDeviceSpecialBrightnessSuspend):
+class RazerDeathAdderV2Mini(__RazerDevice):
     """
     Class for the Razer DeathAdder V2 Mini
     """
@@ -1559,7 +1559,7 @@ class RazerViper8KHz(__RazerDevice):
     POLL_RATES = [125, 500, 1000, 2000, 4000, 8000]
 
 
-class RazerNagaEpicChromaWired(__RazerDeviceSpecialBrightnessSuspend):
+class RazerNagaEpicChromaWired(__RazerDevice):
     """
     Class for the Razer Naga Epic Chroma (Wired)
     """

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -38,31 +38,6 @@ class RazerViperMini(__RazerDeviceSpecialBrightnessSuspend):
 
     DPI_MAX = 8500
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args['brightness'] = _da_get_logo_brightness(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        self.disable_notify = False
-
 
 class RazerLanceheadWirelessWired(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -93,38 +68,6 @@ class RazerLanceheadWirelessWired(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1205/1205_lancehead.png"
 
     DPI_MAX = 16000
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self), _get_left_brightness(self), _get_right_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        _set_left_brightness(self, 0)
-        _set_right_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[1]
-        left_row_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[2]
-        right_row_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[3]
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        _set_left_brightness(self, left_row_brightness)
-        _set_right_brightness(self, right_row_brightness)
-        self.disable_notify = False
 
 
 class RazerLanceheadWirelessReceiver(RazerLanceheadWirelessWired):
@@ -181,38 +124,6 @@ class RazerLanceheadWired(__RazerDeviceSpecialBrightnessSuspend):
 
     DPI_MAX = 16000
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self), _get_left_brightness(self), _get_right_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        _set_left_brightness(self, 0)
-        _set_right_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[1]
-        left_row_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[2]
-        right_row_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[3]
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        _set_left_brightness(self, left_row_brightness)
-        _set_right_brightness(self, right_row_brightness)
-        self.disable_notify = False
-
 
 class RazerLanceheadWireless(RazerLanceheadWired):
     """
@@ -259,32 +170,6 @@ class RazerDeathAdderEssentialWhiteEdition(__RazerDeviceSpecialBrightnessSuspend
 
     DPI_MAX = 6400
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100))[1]
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
-
 
 class RazerAbyssusEliteDVaEdition(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -305,31 +190,6 @@ class RazerAbyssusEliteDVaEdition(__RazerDeviceSpecialBrightnessSuspend):
 
     DPI_MAX = 7200
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args['brightness'] = _da_get_logo_brightness(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        self.disable_notify = False
-
 
 class RazerAbyssusEssential(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -349,29 +209,6 @@ class RazerAbyssusEssential(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1290/1290_abyssusessential.png"
 
     DPI_MAX = 7200
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args['brightness'] = _da_get_logo_brightness(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        self.disable_notify = False
 
 
 class RazerLanceheadTE(__RazerDeviceSpecialBrightnessSuspend):
@@ -401,38 +238,6 @@ class RazerLanceheadTE(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1203/1206_lanceheadte.png"
 
     DPI_MAX = 16000
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self), _get_left_brightness(self), _get_right_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        _set_left_brightness(self, 0)
-        _set_right_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[1]
-        left_row_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[2]
-        right_row_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[3]
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        _set_left_brightness(self, left_row_brightness)
-        _set_right_brightness(self, right_row_brightness)
-        self.disable_notify = False
 
 
 class RazerMambaChromaWireless(__RazerDeviceBrightnessSuspend):
@@ -515,12 +320,6 @@ class RazerAbyssus(__RazerDevice):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/274/abyssus2014_500x500.png"
 
-    def _resume_device(self):
-        self.logger.debug("Abyssus doesn't have suspend/resume")
-
-    def _suspend_device(self):
-        self.logger.debug("Abyssus doesn't have suspend/resume")
-
 
 class RazerImperator(__RazerDevice):
     """
@@ -534,12 +333,6 @@ class RazerImperator(__RazerDevice):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/215/215_imperator.png"
 
     DPI_MAX = 6400
-
-    def _resume_device(self):
-        self.logger.debug("Imperator doesn't have suspend/resume")
-
-    def _suspend_device(self):
-        self.logger.debug("Imperator doesn't have suspend/resume")
 
 
 class RazerOuroboros(__RazerDevice):
@@ -556,32 +349,6 @@ class RazerOuroboros(__RazerDevice):
 
     DPI_MAX = 8200
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = _da_get_scroll_brightness(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        scroll_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
-
 
 class RazerOrochi2013(__RazerDevice):
     """
@@ -595,12 +362,6 @@ class RazerOrochi2013(__RazerDevice):
     DPI_MAX = 6400
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/612/612_orochi_2015.png"
-
-    def _resume_device(self):
-        self.logger.debug("Orochi doesn't have suspend/resume")
-
-    def _suspend_device(self):
-        self.logger.debug("Orochi doesn't have suspend/resume")
 
 
 class RazerOrochiWired(__RazerDeviceBrightnessSuspend):
@@ -635,44 +396,6 @@ class RazerDeathAdderChroma(__RazerDeviceSpecialBrightnessSuspend):
 
     DPI_MAX = 10000
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Set brightness to max and LEDs to on, on startup
-        _da_set_logo_brightness(self, 100)
-        _da_set_scroll_brightness(self, 100)
-        _da_set_logo_active(self, True)
-        _da_set_scroll_active(self, True)
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100))[1]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
-
 
 class RazerDeathAdder2000(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -689,44 +412,6 @@ class RazerDeathAdder2000(__RazerDeviceSpecialBrightnessSuspend):
 
     DPI_MAX = 2000
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Set brightness to max and LEDs to on, on startup
-        _da_set_logo_brightness(self, 100)
-        _da_set_scroll_brightness(self, 100)
-        _da_set_logo_active(self, True)
-        _da_set_scroll_active(self, True)
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100))[1]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
-
 
 class RazerDeathAdder2013(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -741,42 +426,6 @@ class RazerDeathAdder2013(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/561/561_deathadder_classic.png"
 
     DPI_MAX = 6400
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Set brightness to max and LEDs to on, on startup
-        _da_set_logo_active(self, True)
-        _da_set_scroll_active(self, True)
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['active'] = (_da_get_logo_active(self), _da_get_scroll_active(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_active(self, False)
-        _da_set_scroll_active(self, False)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_active = self.suspend_args.get('active', (True, True))[0]
-        scroll_active = self.suspend_args.get('active', (True, True))[1]
-
-        self.disable_notify = True
-        _da_set_logo_active(self, logo_active)
-        _da_set_scroll_active(self, scroll_active)
-        self.disable_notify = False
 
 
 class RazerNagaHexV2(__RazerDeviceBrightnessSuspend):
@@ -820,38 +469,6 @@ class RazerNagaHexV2(__RazerDeviceBrightnessSuspend):
 
         # self.key_manager.close()
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self), _get_backlight_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        _set_backlight_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100, 100))[1]
-        backlight_brightness = self.suspend_args.get('brightness', (100, 100, 100))[2]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        _set_backlight_brightness(self, backlight_brightness)
-        self.disable_notify = False
-
 
 class RazerNaga2012(__RazerDevice):
     """
@@ -868,38 +485,6 @@ class RazerNaga2012(__RazerDevice):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/products/39/razer-naga-gallery-4.png"
 
     DPI_MAX = 5600
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['active'] = (_da_get_logo_active(self), _da_get_scroll_active(self), _da_get_backlight_active(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_active(self, False)
-        _da_set_scroll_active(self, False)
-        _da_set_backlight_active(self, False)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_active = self.suspend_args.get('active', (True, True, True))[0]
-        scroll_active = self.suspend_args.get('active', (True, True, True))[1]
-        backlight_active = self.suspend_args.get('active', (True, True, True))[2]
-
-        self.disable_notify = True
-        _da_set_logo_active(self, logo_active)
-        _da_set_scroll_active(self, scroll_active)
-        _da_set_backlight_active(self, backlight_active)
-        self.disable_notify = False
 
 
 class RazerNagaChroma(__RazerDeviceSpecialBrightnessSuspend):
@@ -995,35 +580,6 @@ class RazerNagaHex(__RazerDevice):
 
     DPI_MAX = 5600
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['active'] = (_da_get_logo_active(self), _da_get_scroll_active(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_active(self, False)
-        _da_set_scroll_active(self, False)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_active = self.suspend_args.get('active', (True, True))[0]
-        scroll_active = self.suspend_args.get('active', (True, True))[1]
-
-        self.disable_notify = True
-        _da_set_logo_active(self, logo_active)
-        _da_set_scroll_active(self, scroll_active)
-        self.disable_notify = False
-
 
 class RazerNagaHexRed(__RazerDevice):
     """
@@ -1041,35 +597,6 @@ class RazerNagaHexRed(__RazerDevice):
 
     DPI_MAX = 5600
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['active'] = (_da_get_logo_active(self), _da_get_scroll_active(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_active(self, False)
-        _da_set_scroll_active(self, False)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_active = self.suspend_args.get('active', (True, True))[0]
-        scroll_active = self.suspend_args.get('active', (True, True))[1]
-
-        self.disable_notify = True
-        _da_set_logo_active(self, logo_active)
-        _da_set_scroll_active(self, scroll_active)
-        self.disable_notify = False
-
 
 class RazerTaipan(__RazerDevice):
     """
@@ -1086,35 +613,6 @@ class RazerTaipan(__RazerDevice):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/19/19_taipan.png"
 
     DPI_MAX = 8200
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['active'] = (_da_get_logo_active(self), _da_get_scroll_active(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_active(self, False)
-        _da_set_scroll_active(self, False)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_active = self.suspend_args.get('active', (True, True))[0]
-        scroll_active = self.suspend_args.get('active', (True, True))[1]
-
-        self.disable_notify = True
-        _da_set_logo_active(self, logo_active)
-        _da_set_scroll_active(self, scroll_active)
-        self.disable_notify = False
 
 
 class RazerDeathAdderElite(__RazerDeviceSpecialBrightnessSuspend):
@@ -1139,35 +637,6 @@ class RazerDeathAdderElite(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/724/724_deathadderelite_500x500.png"
 
     DPI_MAX = 16000
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100))[1]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
 
 
 class RazerDiamondbackChroma(__RazerDeviceBrightnessSuspend):
@@ -1204,35 +673,6 @@ class RazerDeathAdder3_5G(__RazerDevice):
 
     DEVICE_IMAGE = "https://assets2.razerzone.com/images/da10m/carousel/razer-death-adder-gallery-04.png"
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['active'] = (_da_get_logo_active(self), _da_get_scroll_active(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_active(self, False)
-        _da_set_scroll_active(self, False)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_active = self.suspend_args.get('active', (True, True))[0]
-        scroll_active = self.suspend_args.get('active', (True, True))[1]
-
-        self.disable_notify = True
-        _da_set_logo_active(self, logo_active)
-        _da_set_scroll_active(self, scroll_active)
-        self.disable_notify = False
-
 
 class RazerDeathAdder3_5GBlack(__RazerDevice):
     """
@@ -1248,12 +688,6 @@ class RazerDeathAdder3_5GBlack(__RazerDevice):
     DPI_MAX = 3500
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/products/33/razer-deathadder-be-gallery-3.png"
-
-    def _resume_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
-
-    def _suspend_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
 
 
 class RazerMamba2012Wireless(__RazerDeviceSpecialBrightnessSuspend):
@@ -1286,32 +720,6 @@ class RazerMamba2012Wireless(__RazerDeviceSpecialBrightnessSuspend):
 
         self._battery_manager.close()
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = _da_get_scroll_brightness(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        scroll_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
-
 
 class RazerMamba2012Wired(__RazerDevice):
     """
@@ -1327,32 +735,6 @@ class RazerMamba2012Wired(__RazerDevice):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/192/192_mamba_2012.png"
 
     DPI_MAX = 6400
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = _da_get_scroll_brightness(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        scroll_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
 
 
 class RazerMambaWirelessWired(__RazerDeviceSpecialBrightnessSuspend):
@@ -1377,32 +759,6 @@ class RazerMambaWirelessWired(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1404/1404_mamba_wireless.png"
 
     DPI_MAX = 16000
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100))[1]
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
 
 
 class RazerMambaWirelessReceiver(RazerMambaWirelessWired):
@@ -1446,38 +802,6 @@ class RazerNaga2014(__RazerDevice):
 
     DPI_MAX = 8200
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['active'] = (_da_get_logo_active(self), _da_get_scroll_active(self), _da_get_backlight_active(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_active(self, False)
-        _da_set_scroll_active(self, False)
-        _da_set_backlight_active(self, False)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_active = self.suspend_args.get('active', (True, True, True))[0]
-        scroll_active = self.suspend_args.get('active', (True, True, True))[1]
-        backlight_active = self.suspend_args.get('active', (True, True, True))[2]
-
-        self.disable_notify = True
-        _da_set_logo_active(self, logo_active)
-        _da_set_scroll_active(self, scroll_active)
-        _da_set_backlight_active(self, backlight_active)
-        self.disable_notify = False
-
 
 class RazerOrochi2011(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -1493,35 +817,6 @@ class RazerOrochi2011(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/612/612_orochi_2015.png"
 
     DPI_MAX = 4000
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['active'] = (_da_get_logo_active(self), _da_get_scroll_active(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_active(self, False)
-        _da_set_scroll_active(self, False)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_active = self.suspend_args.get('active', (True, True))[0]
-        scroll_active = self.suspend_args.get('active', (True, True))[1]
-
-        self.disable_notify = True
-        _da_set_logo_active(self, logo_active)
-        _da_set_scroll_active(self, scroll_active)
-        self.disable_notify = False
 
 
 class RazerAbyssusV2(__RazerDeviceSpecialBrightnessSuspend):
@@ -1539,44 +834,6 @@ class RazerAbyssusV2(__RazerDeviceSpecialBrightnessSuspend):
 
     DPI_MAX = 5000
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Set brightness to max and LEDs to on, on startup
-        _da_set_logo_brightness(self, 100)
-        _da_set_scroll_brightness(self, 100)
-        _da_set_logo_active(self, True)
-        _da_set_scroll_active(self, True)
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100))[1]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
-
 
 class RazerAbyssus1800(__RazerDevice):
     """
@@ -1591,32 +848,6 @@ class RazerAbyssus1800(__RazerDevice):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1277/1277_abyssus_2000.png"
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current logo state, store it for later and then set the logo to off
-        """
-        self.suspend_args.clear()
-        self.suspend_args['active'] = _da_get_logo_active(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_active(self, False)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known logo state and then set it
-        """
-        logo_active = self.suspend_args.get('active', True)
-
-        self.disable_notify = True
-        _da_set_logo_active(self, logo_active)
-        self.disable_notify = False
-
 
 class RazerAbyssus2000(__RazerDevice):
     """
@@ -1630,32 +861,6 @@ class RazerAbyssus2000(__RazerDevice):
     DPI_MAX = 2000
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1277/1277_abyssus_2000.png"
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current logo state, store it for later and then set the logo to off
-        """
-        self.suspend_args.clear()
-        self.suspend_args['active'] = _da_get_logo_active(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_active(self, False)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known logo state and then set it
-        """
-        logo_active = self.suspend_args.get('active', True)
-
-        self.disable_notify = True
-        _da_set_logo_active(self, logo_active)
-        self.disable_notify = False
 
 
 class RazerDeathAdder3500(__RazerDeviceSpecialBrightnessSuspend):
@@ -1672,44 +877,6 @@ class RazerDeathAdder3500(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/561/561_deathadder_classic.png"
 
     DPI_MAX = 3500
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Set brightness to max and LEDs to on, on startup
-        _da_set_logo_brightness(self, 100)
-        _da_set_scroll_brightness(self, 100)
-        _da_set_logo_active(self, True)
-        _da_set_scroll_active(self, True)
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100))[1]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
 
 
 class RazerViperUltimateWired(__RazerDeviceSpecialBrightnessSuspend):
@@ -1734,31 +901,6 @@ class RazerViperUltimateWired(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1577/ee_photo.png"
 
     DPI_MAX = 20000
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = _da_get_logo_brightness(self)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        self.disable_notify = False
 
 
 class RazerViperUltimateWireless(RazerViperUltimateWired):
@@ -1808,31 +950,6 @@ class RazerViper(__RazerDeviceSpecialBrightnessSuspend):
 
     DPI_MAX = 16000
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = _da_get_logo_brightness(self)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        self.disable_notify = False
-
 
 class RazerDeathAdderEssential(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -1852,34 +969,6 @@ class RazerDeathAdderEssential(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1385/1385_deathadderessential.png"
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self))
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100))[1]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
-
 
 class RazerDeathAdderEssential2021(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -1895,31 +984,6 @@ class RazerDeathAdderEssential2021(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 6400
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1385/1385_deathadderessential.png"
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = _da_get_logo_brightness(self)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        self.disable_notify = False
 
 
 class RazerMambaElite(__RazerDeviceSpecialBrightnessSuspend):
@@ -1951,43 +1015,6 @@ class RazerMambaElite(__RazerDeviceSpecialBrightnessSuspend):
     DPI_MAX = 16000
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1390/1390_mamba_elite.png"
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (
-            _da_get_logo_brightness(self),
-            _da_get_scroll_brightness(self),
-            _get_left_brightness(self),
-            _get_right_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        _set_left_brightness(self, 0)
-        _set_right_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[1]
-        left_row_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[2]
-        right_row_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[3]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        _set_left_brightness(self, left_row_brightness)
-        _set_right_brightness(self, right_row_brightness)
-        self.disable_notify = False
 
 
 class RazerNagaLeftHanded2020(__RazerDeviceSpecialBrightnessSuspend):
@@ -2021,39 +1048,6 @@ class RazerNagaLeftHanded2020(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://rzrwarranty.s3.amazonaws.com/cee694cd7526df413008167b7566af310985321b20c57f3dc42e5cbd773f2417.png"
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (
-            _da_get_logo_brightness(self),
-            _da_get_scroll_brightness(self),
-            _get_right_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        _set_right_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100, 100))[1]
-        right_row_brightness = self.suspend_args.get('brightness', (100, 100, 100))[2]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        _set_right_brightness(self, right_row_brightness)
-        self.disable_notify = False
-
 
 class RazerNagaProWired(__RazerDeviceBrightnessSuspend):
     """
@@ -2085,40 +1079,6 @@ class RazerNagaProWired(__RazerDeviceBrightnessSuspend):
     DPI_MAX = 20000
 
     DEVICE_IMAGE = "https://hybrismediaprod.blob.core.windows.net/sys-master-phoenix-images-container/hfd/ha6/9080569528350/razer-naga-pro-500x500.png"
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (
-            _da_get_logo_brightness(self),
-            _da_get_scroll_brightness(self),
-            _get_backlight_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        _set_backlight_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-        Get the last known brightness and then set the brightness
-        """
-
-        logo_brightness = self.suspend_args.get('brightness', (100, 100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100, 100))[1]
-        backlight_brightness = self.suspend_args.get('brightness', (100, 100, 100))[2]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        _set_backlight_brightness(self, backlight_brightness)
-        self.disable_notify = False
 
 
 class RazerNagaProWireless(RazerNagaProWired):
@@ -2158,32 +1118,6 @@ class RazerDeathAdder1800(__RazerDevice):
 
     DEVICE_IMAGE = "https://rzrwarranty.s3.amazonaws.com/a7daf40ad78c9584a693e310effa956019cdcd081391f93f71a7cd36d3dc577e.png"
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current logo state, store it for later and then set the logo to off
-        """
-        self.suspend_args.clear()
-        self.suspend_args['active'] = _da_get_logo_active(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_active(self, False)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known logo state and then set it
-        """
-        logo_active = self.suspend_args.get('active', True)
-
-        self.disable_notify = True
-        _da_set_logo_active(self, logo_active)
-        self.disable_notify = False
-
 
 class RazerBasilisk(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -2208,35 +1142,6 @@ class RazerBasilisk(__RazerDeviceSpecialBrightnessSuspend):
 
     DPI_MAX = 16000
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100))[1]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
-
 
 class RazerBasiliskEssential(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -2258,32 +1163,6 @@ class RazerBasiliskEssential(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://hybrismediaprod.blob.core.windows.net/sys-master-phoenix-images-container/h19/h61/9080617500702/Basilisk-Essential-500x500.png"
 
     DPI_MAX = 6400
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = _da_get_logo_brightness(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        self.disable_notify = False
 
 
 class RazerBasiliskUltimateWired(__RazerDeviceSpecialBrightnessSuspend):
@@ -2340,39 +1219,6 @@ class RazerBasiliskUltimateWired(__RazerDeviceSpecialBrightnessSuspend):
 
     DPI_MAX = 20000
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(
-            self), _get_left_brightness(self), _get_right_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        _set_left_brightness(self, 0)
-        _set_right_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[1]
-        left_row_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[2]
-        right_row_brightness = self.suspend_args.get('brightness', (100, 100, 100, 100))[3]
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        _set_left_brightness(self, left_row_brightness)
-        _set_right_brightness(self, right_row_brightness)
-        self.disable_notify = False
-
 
 class RazerBasiliskUltimateReceiver(RazerBasiliskUltimateWired):
     USB_PID = 0x0088
@@ -2420,35 +1266,6 @@ class RazerBasiliskV2(__RazerDeviceSpecialBrightnessSuspend):
 
     DPI_MAX = 20000
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100))[1]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
-
 
 class RazerBasiliskV3(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -2483,38 +1300,6 @@ class RazerBasiliskV3(__RazerDeviceSpecialBrightnessSuspend):
 
     DPI_MAX = 26000
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self), _get_backlight_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        _set_backlight_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100, 100))[1]
-        backlight_brightness = self.suspend_args.get('brightness', (100, 100, 100))[2]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        _set_backlight_brightness(self, backlight_brightness)
-        self.disable_notify = False
-
 
 class RazerDeathAdderV2(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -2537,35 +1322,6 @@ class RazerDeathAdderV2(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1612/1612_razerdeathadderv2.png"
 
     DPI_MAX = 20000
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_logo_brightness(self), _da_get_scroll_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        _da_set_scroll_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', (100, 100))[0]
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100))[1]
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        _da_set_scroll_brightness(self, scroll_brightness)
-        self.disable_notify = False
 
 
 class RazerDeathAdderV2ProWired(__RazerDeviceSpecialBrightnessSuspend):
@@ -2590,31 +1346,6 @@ class RazerDeathAdderV2ProWired(__RazerDeviceSpecialBrightnessSuspend):
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/1714/comp_1_00000.png"
 
     DPI_MAX = 20000
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = _da_get_logo_brightness(self)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        self.disable_notify = False
 
 
 class RazerDeathAdderV2ProWireless(RazerDeathAdderV2ProWired):
@@ -2675,12 +1406,6 @@ class RazerAtherisReceiver(__RazerDevice):
 
         self._battery_manager.close()
 
-    def _resume_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
-
-    def _suspend_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
-
 
 class RazerBasiliskXHyperSpeed(__RazerDevice):
     """
@@ -2716,12 +1441,6 @@ class RazerBasiliskXHyperSpeed(__RazerDevice):
 
         self._battery_manager.close()
 
-    def _resume_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
-
-    def _suspend_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
-
 
 class RazerOrochiV2Receiver(__RazerDevice):
     """
@@ -2756,12 +1475,6 @@ class RazerOrochiV2Receiver(__RazerDevice):
         super()._close()
 
         self._battery_manager.close()
-
-    def _resume_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
-
-    def _suspend_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
 
 
 class RazerOrochiV2Bluetooth(RazerOrochiV2Receiver):
@@ -2800,33 +1513,6 @@ class RazerNagaX(__RazerDeviceSpecialBrightnessSuspend):
 
     DEVICE_IMAGE = "https://dl.razerzone.com/src/3993-1-EN-V2.png"
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = (_da_get_scroll_brightness(self), _get_left_brightness(self))
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_scroll_brightness(self, 0)
-        _set_left_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-        Get the last known brightness and then set the brightness
-        """
-        scroll_brightness = self.suspend_args.get('brightness', (100, 100))[0]
-        left_row_brightness = self.suspend_args.get('brightness', (100, 100))[1]
-
-        self.disable_notify = True
-        _da_set_scroll_brightness(self, scroll_brightness)
-        _set_left_brightness(self, left_row_brightness)
-        self.disable_notify = False
-
 
 class RazerDeathAdderV2Mini(__RazerDeviceSpecialBrightnessSuspend):
     """
@@ -2851,32 +1537,6 @@ class RazerDeathAdderV2Mini(__RazerDeviceSpecialBrightnessSuspend):
 
     DPI_MAX = 8500
 
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = _da_get_logo_brightness(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        self.disable_notify = False
-
 
 class RazerViper8KHz(__RazerDevice):
     """
@@ -2897,32 +1557,6 @@ class RazerViper8KHz(__RazerDevice):
     DPI_MAX = 20000
 
     POLL_RATES = [125, 500, 1000, 2000, 4000, 8000]
-
-    def _suspend_device(self):
-        """
-        Suspend the device
-
-        Get the current brightness level, store it for later and then set the brightness to 0
-        """
-        self.suspend_args.clear()
-        self.suspend_args['brightness'] = _da_get_logo_brightness(self)
-
-        # Todo make it context?
-        self.disable_notify = True
-        _da_set_logo_brightness(self, 0)
-        self.disable_notify = False
-
-    def _resume_device(self):
-        """
-        Resume the device
-
-        Get the last known brightness and then set the brightness
-        """
-        logo_brightness = self.suspend_args.get('brightness', 100)
-
-        self.disable_notify = True
-        _da_set_logo_brightness(self, logo_brightness)
-        self.disable_notify = False
 
 
 class RazerNagaEpicChromaWired(__RazerDeviceSpecialBrightnessSuspend):
@@ -3004,12 +1638,6 @@ class RazerProClickReceiver(__RazerDevice):
 
         self._battery_manager.close()
 
-    def _resume_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
-
-    def _suspend_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
-
 
 class RazerProClickWired(RazerProClickReceiver):
     """
@@ -3050,12 +1678,6 @@ class RazerDeathAdderV2XHyperSpeed(__RazerDevice):
 
         self._battery_manager.close()
 
-    def _resume_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
-
-    def _suspend_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
-
 
 class RazerViperV2ProWired(__RazerDevice):
     """
@@ -3088,12 +1710,6 @@ class RazerViperV2ProWired(__RazerDevice):
         super()._close()
 
         self._battery_manager.close()
-
-    def _resume_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
-
-    def _suspend_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
 
 
 class RazerViperV2ProWireless(RazerViperV2ProWired):
@@ -3135,12 +1751,6 @@ class RazerDeathAdderV3ProWired(__RazerDevice):
         super()._close()
 
         self._battery_manager.close()
-
-    def _resume_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
-
-    def _suspend_device(self):
-        self.logger.debug("Device doesn't have suspend/resume")
 
 
 class RazerDeathAdderV3ProWireless(RazerDeathAdderV3ProWired):


### PR DESCRIPTION
Since we now have persistence feature we can get rid of most of the custom suspend/resume functions implemented for every single device and use the persistence feature to do the same instead.

Fixes #1932 (and maybe some other issues?)