### PR TITLE
Turn off macro led when turning off macro mode

### DIFF
--- a/daemon/openrazer_daemon/misc/key_event_management.py
+++ b/daemon/openrazer_daemon/misc/key_event_management.py
@@ -423,6 +423,7 @@ class KeyboardKeyManager(object):
                                 # Clear macro
                                 self.dbus_delete_macro(self._current_macro_bind_key)
                         self._recording_macro = False
+                        self._parent.setMacroEffect(0x00)
                         self._parent.setMacroMode(False)
                 # Sets up game mode as when enabling macro keys it stops the key working
                 elif key_name == 'GAMEMODE':


### PR DESCRIPTION
When turning on macro mode, the macro LED starts blinking. But when getting turned off, the LED is never turned off, and would continue blinking endlessly. This simply turns the LED off when macro mode goes off.

Fixes #1587