### PR TITLE
Fix persistence for lighting on/off state

### DIFF
--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -268,7 +268,7 @@ class RazerDevice(DBusService):
 
                     # zone active status
                     try:
-                        self.zone[i]["active"] = bool(self.persistence[self.storage_name][i + '_active'])
+                        self.zone[i]["active"] = self.persistence.getboolean(self.storage_name, i + '_active')
                     except KeyError:
                         pass
 


### PR DESCRIPTION
The persistence file stored the active state for lighting as `True` or `False` and then converted these strings using `bool()`. This  will always give back true, causing lighting to be re-enabled whenever the daemon is restarted.

This should fix #1963, since I was having the same issue with my mouse.