### PR TITLE
WIP: use hid_device to find razer control interface

### DIFF
--- a/driver/razercommon.c
+++ b/driver/razercommon.c
@@ -118,6 +118,35 @@ int razer_get_usb_response(struct usb_device *usb_dev, uint report_index, struct
     return result;
 }
 
+int razer_get_hid_response(struct hid_device *hdev, struct razer_report* request_report, struct razer_report* response_report, ulong wait_min, ulong wait_max)
+{
+    char *buf;
+    int result = 0;
+
+    uint size = RAZER_USB_REPORT_LEN;
+
+    buf = kmemdup(request_report, size, GFP_KERNEL);
+
+    hid_hw_raw_request(hdev, 0, buf, size + 1, HID_FEATURE_REPORT, HID_REQ_SET_REPORT);
+
+    kfree(buf);
+
+    // Wait
+    usleep_range(wait_min, wait_max);
+
+    buf = kzalloc(sizeof(struct razer_report), GFP_KERNEL);
+    if (buf == NULL)
+        return -ENOMEM;
+
+    hid_hw_raw_request(hdev, 0, buf, size + 1, HID_FEATURE_REPORT, HID_REQ_GET_REPORT);
+
+    memcpy(response_report, buf, sizeof(struct razer_report));
+
+    kfree(buf);
+
+    return result;
+}
+
 /**
  * Calculate the checksum for the usb message
  *

--- a/driver/razercommon.h
+++ b/driver/razercommon.h
@@ -8,6 +8,7 @@
 #define DRIVER_RAZERCOMMON_H_
 
 #include <linux/usb/input.h>
+#include <linux/hid.h>
 
 #define DRIVER_VERSION "3.5.1"
 #define DRIVER_LICENSE "GPL v2"
@@ -151,6 +152,7 @@ struct razer_key_translation {
 int razer_send_control_msg(struct usb_device *usb_dev,void const *data, unsigned int report_index, unsigned long wait_min, unsigned long wait_max);
 int razer_send_control_msg_old_device(struct usb_device *usb_dev,void const *data, uint report_value, uint report_index, uint report_size, ulong wait_min, ulong wait_max);
 int razer_get_usb_response(struct usb_device *usb_dev, unsigned int report_index, struct razer_report* request_report, unsigned int response_index, struct razer_report* response_report, unsigned long wait_min, unsigned long wait_max);
+int razer_get_hid_response(struct hid_device *hdev, struct razer_report* request_report, struct razer_report* response_report, ulong wait_min, ulong wait_max);
 int razer_send_argb_msg(struct usb_device* usb_dev, unsigned char channel, unsigned char size, void const* data);
 unsigned char razer_calculate_crc(struct razer_report *report);
 struct razer_report get_razer_report(unsigned char command_class, unsigned char command_id, unsigned char data_size);


### PR DESCRIPTION
* use hid_device to find / identity razer control interface
* use hid_hw_raw_request instead of usb_control_msg

I haven't actually tried this, I'd love to get some feedback if this could get merged before I continue.

This will change the sysfs path, not sure if the daemon can handle this.

Goal of this PR:

* Preparations to remove device specific code, razer_check_control_interface could be replaced by a function that only uses the HID descriptor. I'd propose to do this in another PR
* Use HID implementation from Linux