### PR TITLE
Fix build failure on 6.4

### DIFF
--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -4848,7 +4848,8 @@ static void tilt_hwheel_stop(struct razer_mouse_device *rdev)
  */
 static int dev_is_on_bus(struct device *dev, void *data)
 {
-    return (dev->bus == data);
+    const struct bus_type *bus = data;
+    return dev->bus == bus;
 }
 
 /**
@@ -4875,7 +4876,7 @@ struct usb_interface *find_intf_with_proto(struct usb_device *usbdev, u8 proto)
  */
 static struct razer_mouse_device *find_mouse(struct hid_device *hdev)
 {
-    struct bus_type *hid_bus_type = hdev->dev.bus;
+    const struct bus_type *hid_bus_type = hdev->dev.bus;
     struct usb_interface *intf = to_usb_interface(hdev->dev.parent);
     struct usb_device *usbdev = interface_to_usbdev(intf);
     struct usb_interface *m_intf = find_intf_with_proto(usbdev, USB_INTERFACE_PROTOCOL_MOUSE);
@@ -4885,7 +4886,7 @@ static struct razer_mouse_device *find_mouse(struct hid_device *hdev)
     if (!m_intf)
         return NULL;
 
-    dev = device_find_child(&m_intf->dev, hid_bus_type, dev_is_on_bus);
+    dev = device_find_child(&m_intf->dev, (void *)hid_bus_type, dev_is_on_bus);
     if (!dev)
         return NULL;
 


### PR DESCRIPTION
https://github.com/torvalds/linux/commit/d492cc2573a08352c48a66d3e3f312a15fb3f363

The commit linked above changes struct bus_type to const struct bus_type, which causes the build to fail on 6.4-rc1. device_find_child expects hid_bus_type to be a void * which makes the build fail again, so I changed it to &hid_bus_type and voila, it works.

I don't even know how to program in C so this is a bit rough. There's probably a better way to do this that doesn't involve including linux/version.h, I'd be happy to make any changes.