### PR TITLE
Keybinding for FN key for DeathStalker V2 Pro TKL (wired, wireless)

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -181,7 +181,7 @@ static const struct razer_key_translation chroma_keys_5[] = {
 };
 
 // Razer DeathStalker V2 Pro TKL
-  static const struct razer_key_translation chroma_keys_6[] = {
+static const struct razer_key_translation chroma_keys_6[] = {
     { KEY_F9, RAZER_MACRO_KEY },
     { KEY_F10, RAZER_GAME_KEY },
     { KEY_F11, RAZER_BRIGHTNESS_DOWN },
@@ -191,7 +191,7 @@ static const struct razer_key_translation chroma_keys_5[] = {
     { KEY_PAGEUP, KEY_PAUSE },
     { KEY_PAGEDOWN, KEY_SLEEP },
     { 0 }
-  };
+};
 
 /**
  * Essentially search through the struct array above.

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -180,6 +180,20 @@ static const struct razer_key_translation chroma_keys_5[] = {
     { 0 }
 };
 
+// Razer DeathStalker V2 Pro TKL
+  static const struct razer_key_translation chroma_keys_6[] = {
+      { KEY_F9, RAZER_MACRO_KEY },
+      { KEY_F10, RAZER_GAME_KEY },
+      { KEY_F11, RAZER_BRIGHTNESS_DOWN },
+      { KEY_F12, RAZER_BRIGHTNESS_UP },
+      { KEY_INSERT, KEY_SYSRQ },
+      { KEY_HOME, KEY_SCROLLLOCK },
+      { KEY_PAGEUP, KEY_PAUSE },
+      { KEY_PAGEDOWN, KEY_SLEEP },
+      // TODO - Add KEY_CONTEXT_MENU when we figure out what it is supposed to be doing
+      { 0 }
+  };
+
 /**
  * Essentially search through the struct array above.
  */
@@ -3036,9 +3050,12 @@ static int razer_event(struct hid_device *hdev, struct hid_field *field, struct 
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2:
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRELESS:
+        translation = find_translation(chroma_keys_5, usage->code);
+        break;
+
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRED:
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRELESS:
-        translation = find_translation(chroma_keys_5, usage->code);
+        translation = find_translation(chroma_keys_6, usage->code);
         break;
 
     default:

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -182,16 +182,15 @@ static const struct razer_key_translation chroma_keys_5[] = {
 
 // Razer DeathStalker V2 Pro TKL
   static const struct razer_key_translation chroma_keys_6[] = {
-      { KEY_F9, RAZER_MACRO_KEY },
-      { KEY_F10, RAZER_GAME_KEY },
-      { KEY_F11, RAZER_BRIGHTNESS_DOWN },
-      { KEY_F12, RAZER_BRIGHTNESS_UP },
-      { KEY_INSERT, KEY_SYSRQ },
-      { KEY_HOME, KEY_SCROLLLOCK },
-      { KEY_PAGEUP, KEY_PAUSE },
-      { KEY_PAGEDOWN, KEY_SLEEP },
-      // TODO - Add KEY_CONTEXT_MENU when we figure out what it is supposed to be doing
-      { 0 }
+    { KEY_F9, RAZER_MACRO_KEY },
+    { KEY_F10, RAZER_GAME_KEY },
+    { KEY_F11, RAZER_BRIGHTNESS_DOWN },
+    { KEY_F12, RAZER_BRIGHTNESS_UP },
+    { KEY_INSERT, KEY_SYSRQ },
+    { KEY_HOME, KEY_SCROLLLOCK },
+    { KEY_PAGEUP, KEY_PAUSE },
+    { KEY_PAGEDOWN, KEY_SLEEP },
+    { 0 }
   };
 
 /**


### PR DESCRIPTION
Today i've found that cant use PrnScn + ScrLk + Pause buttons on my Razer DeathStalker V2 Pro TKL keyboard.
With a few dig inside ive found that repo not have bindings for this keys (even daily build).
So ive create this PR which already tested on my side at Ubuntu 22.04. 
Would be cool if community also get this.
This binding equal with official bindings for this keyboard.