### PR TITLE
Migrate several devices to none/on effects (and breathing mono effect)

### DIFF
--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/bw2013.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/bw2013.py
@@ -7,7 +7,7 @@ from openrazer_daemon.dbus_services import endpoint
 
 
 @endpoint('razer.device.lighting.bw2013', 'setPulsate')
-def bw_set_pulsate(self):
+def bw_set_pulsate(self):  # TODO: Replace by set*BreathMono
     """
     Set pulsate mode
     """
@@ -26,7 +26,7 @@ def bw_set_pulsate(self):
 
 
 @endpoint('razer.device.lighting.bw2013', 'setStatic')
-def bw_set_static(self):
+def bw_set_static(self):  # TODO: Replace by set*On
     """
     Set static mode
     """

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/deathadder_chroma.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/deathadder_chroma.py
@@ -3,39 +3,6 @@
 from openrazer_daemon.dbus_services import endpoint
 
 
-def set_led_effect_common(self, zone: str, effect: str) -> None:
-    driver_path = self.get_driver_path(zone + '_led_effect')
-
-    with open(driver_path, 'w') as driver_file:
-        driver_file.write(effect)
-
-
-@endpoint('razer.device.lighting.backlight', 'getBacklightActive', out_sig='b')
-def get_backlight_active(self):
-    """
-    Get if the backlight is lit up
-    """
-    self.logger.debug("DBus call get_backlight_active")
-
-    return self.zone["backlight"]["active"]
-
-
-@endpoint('razer.device.lighting.backlight', 'setBacklightActive', in_sig='b')
-def set_backlight_active(self, active):
-    """
-    Get if the backlight is lit up
-    """
-    self.logger.debug("DBus call set_backlight_active")
-
-    # remember status
-    self.set_persistence("backlight", "active", bool(active))
-
-    driver_path = self.get_driver_path('backlight_led_state')
-
-    with open(driver_path, 'w') as driver_file:
-        driver_file.write('1' if active else '0')
-
-
 @endpoint('razer.device.lighting.backlight', 'getBacklightBrightness', out_sig='d')
 def get_backlight_brightness(self):
     """
@@ -136,58 +103,6 @@ def set_logo_brightness(self, brightness):
     self.send_effect_event('setBrightness', brightness)
 
 
-@endpoint('razer.device.lighting.logo', 'setLogoStaticMono')
-def set_logo_static_mono(self):
-    """
-    Set the device to static colour
-    """
-    self.logger.debug("DBus call set_logo_static_mono")
-
-    # Notify others
-    self.send_effect_event('setStatic')
-
-    set_led_effect_common(self, 'logo', '0')
-
-
-@endpoint('razer.device.lighting.logo', 'setLogoPulsateMono')
-def set_logo_pulsate_mono(self):
-    """
-    Set the device to pulsate
-    """
-    self.logger.debug("DBus call set_logo_pulsate_mono")
-
-    # Notify others
-    self.send_effect_event('setPulsate')
-
-    set_led_effect_common(self, 'logo', '2')
-
-
-@endpoint('razer.device.lighting.scroll', 'getScrollActive', out_sig='b')
-def get_scroll_active(self):
-    """
-    Get if the scroll is light up
-    """
-    self.logger.debug("DBus call get_scroll_active")
-
-    return self.zone["scroll"]["active"]
-
-
-@endpoint('razer.device.lighting.scroll', 'setScrollActive', in_sig='b')
-def set_scroll_active(self, active):
-    """
-    Get if the scroll is light up
-    """
-    self.logger.debug("DBus call set_scroll_active")
-
-    # remember status
-    self.set_persistence("scroll", "active", bool(active))
-
-    driver_path = self.get_driver_path('scroll_led_state')
-
-    with open(driver_path, 'w') as driver_file:
-        driver_file.write('1' if active else '0')
-
-
 @endpoint('razer.device.lighting.scroll', 'getScrollBrightness', out_sig='d')
 def get_scroll_brightness(self):
     """
@@ -223,29 +138,3 @@ def set_scroll_brightness(self, brightness):
 
     # Notify others
     self.send_effect_event('setBrightness', brightness)
-
-
-@endpoint('razer.device.lighting.scroll', 'setScrollStaticMono')
-def set_scroll_static_mono(self):
-    """
-    Set the device to static colour
-    """
-    self.logger.debug("DBus call set_scroll_static_mono")
-
-    # Notify others
-    self.send_effect_event('setStatic')
-
-    set_led_effect_common(self, 'scroll', '0')
-
-
-@endpoint('razer.device.lighting.scroll', 'setScrollPulsateMono')
-def set_scroll_pulsate_mono(self):
-    """
-    Set the device to pulsate
-    """
-    self.logger.debug("DBus call set_scroll_pulsate_mono")
-
-    # Notify others
-    self.send_effect_event('setPulsate')
-
-    set_led_effect_common(self, 'scroll', '2')

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/nagahexv2.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/nagahexv2.py
@@ -129,6 +129,25 @@ def set_logo_reactive(self, red, green, blue, speed):
         driver_file.write(payload)
 
 
+@endpoint('razer.device.lighting.logo', 'setLogoBreathMono')
+def set_logo_breath_mono(self):
+    """
+    Set the device to mono colour breathing effect
+    """
+    self.logger.debug("DBus call set_logo_breath_mono")
+
+    # Notify others
+    self.send_effect_event('setBreathMono')
+
+    # remember effect
+    self.set_persistence("logo", "effect", 'breathMono')
+
+    driver_path = self.get_driver_path('logo_matrix_effect_breath')
+
+    with open(driver_path, 'wb') as driver_file:
+        driver_file.write(b'1')
+
+
 @endpoint('razer.device.lighting.logo', 'setLogoBreathRandom')
 def set_logo_breath_random(self):
     """
@@ -373,6 +392,25 @@ def set_scroll_reactive(self, red, green, blue, speed):
 
     with open(driver_path, 'wb') as driver_file:
         driver_file.write(payload)
+
+
+@endpoint('razer.device.lighting.scroll', 'setScrollBreathMono')
+def set_scroll_breath_mono(self):
+    """
+    Set the device to mono colour breathing effect
+    """
+    self.logger.debug("DBus call set_scroll_breath_mono")
+
+    # Notify others
+    self.send_effect_event('setBreathMono')
+
+    # remember effect
+    self.set_persistence("scroll", "effect", 'breathMono')
+
+    driver_path = self.get_driver_path('scroll_matrix_effect_breath')
+
+    with open(driver_path, 'wb') as driver_file:
+        driver_file.write(b'1')
 
 
 @endpoint('razer.device.lighting.scroll', 'setScrollBreathRandom')

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -835,7 +835,7 @@ class RazerAbyssus1800(__RazerDevice):
     USB_VID = 0x1532
     USB_PID = 0x0020
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy_byte', 'set_dpi_xy_byte', 'get_poll_rate', 'set_poll_rate',
-               'get_logo_active', 'set_logo_active']
+               'set_logo_none', 'set_logo_on']
 
     DPI_MAX = 1800
 
@@ -1105,7 +1105,7 @@ class RazerDeathAdder1800(__RazerDevice):
     USB_VID = 0x1532
     USB_PID = 0x0038
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy_byte', 'set_dpi_xy_byte', 'get_poll_rate', 'set_poll_rate',
-               'get_logo_active', 'set_logo_active']
+               'set_logo_none', 'set_logo_on']
 
     DPI_MAX = 1800
 

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -333,7 +333,7 @@ class RazerOuroboros(__RazerDevice):
     USB_VID = 0x1532
     USB_PID = 0x0032
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy',
-               'get_poll_rate', 'set_poll_rate', 'set_scroll_active', 'get_scroll_active', 'get_scroll_brightness', 'set_scroll_brightness',
+               'get_poll_rate', 'set_poll_rate', 'set_scroll_none', 'set_scroll_on', 'get_scroll_brightness', 'set_scroll_brightness',
                'get_battery', 'is_charging', 'set_idle_time', 'set_low_battery_threshold']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/26/26_ouroboros.png"

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -347,8 +347,8 @@ class RazerOrochi2013(__RazerDevice):
     """
     USB_VID = 0x1532
     USB_PID = 0x0039
-    METHODS = ['get_device_type_mouse', 'get_dpi_xy', 'set_dpi_xy',
-               'get_poll_rate', 'set_poll_rate', 'set_scroll_active', 'get_scroll_active', 'max_dpi']
+    METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy',
+               'get_poll_rate', 'set_poll_rate', 'set_scroll_none', 'set_scroll_on']
 
     DPI_MAX = 6400
 

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -362,10 +362,10 @@ class RazerOrochiWired(__RazerDevice):
     USB_VID = 0x1532
     USB_PID = 0x0048
     METHODS = ['get_device_type_mouse',
-               'get_scroll_brightness', 'set_scroll_brightness',
+               'get_scroll_brightness', 'set_scroll_brightness', 'set_scroll_none', 'set_scroll_on',
                'set_backlight_static', 'set_backlight_spectrum', 'set_backlight_reactive', 'set_backlight_none', 'set_backlight_breath_random',
                'set_backlight_breath_single', 'set_backlight_breath_dual', 'set_idle_time', 'set_low_battery_threshold',
-               'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'set_scroll_active', 'get_scroll_active',
+               'max_dpi', 'get_dpi_xy', 'set_dpi_xy',
                'get_poll_rate', 'set_poll_rate']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/612/612_orochi_2015.png"

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -473,7 +473,7 @@ class RazerNaga2012(__RazerDevice):
     USB_PID = 0x002E
     DEDICATED_MACRO_KEYS = True
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy_byte', 'set_dpi_xy_byte', 'get_poll_rate', 'set_poll_rate',
-               'get_logo_active', 'set_logo_active', 'get_scroll_active', 'set_scroll_active', 'set_backlight_active', 'get_backlight_active']
+               'set_logo_none', 'set_logo_on', 'set_scroll_none', 'set_scroll_on', 'set_backlight_none', 'set_backlight_on']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/products/39/razer-naga-gallery-4.png"
 
@@ -789,7 +789,7 @@ class RazerNaga2014(__RazerDevice):
     USB_PID = 0x0040
     DEDICATED_MACRO_KEYS = True
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate',
-               'get_logo_active', 'set_logo_active', 'get_scroll_active', 'set_scroll_active', 'set_backlight_active', 'get_backlight_active']
+               'set_logo_none', 'set_logo_on', 'set_scroll_none', 'set_scroll_on', 'set_backlight_none', 'set_backlight_on']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/227/227_razer_naga_2014.png"
 

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -849,7 +849,7 @@ class RazerAbyssus2000(__RazerDevice):
     USB_VID = 0x1532
     USB_PID = 0x005E
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate',
-               'get_logo_active', 'set_logo_active']
+               'set_logo_none', 'set_logo_on']
 
     DPI_MAX = 2000
 

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -307,7 +307,7 @@ class RazerAbyssus(__RazerDevice):
     """
     USB_VID = 0x1532
     USB_PID = 0x0042
-    METHODS = ['get_device_type_mouse', 'set_logo_active', 'get_logo_active', 'get_poll_rate', 'set_poll_rate']
+    METHODS = ['get_device_type_mouse', 'set_logo_none', 'set_logo_on', 'get_poll_rate', 'set_poll_rate']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/274/abyssus2014_500x500.png"
 

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -567,7 +567,7 @@ class RazerNagaHex(__RazerDevice):
     USB_PID = 0x0041
     DEDICATED_MACRO_KEYS = True
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy_byte', 'set_dpi_xy_byte', 'get_poll_rate', 'set_poll_rate',
-               'get_logo_active', 'set_logo_active', 'get_scroll_active', 'set_scroll_active']
+               'set_logo_none', 'set_logo_on', 'set_scroll_none', 'set_scroll_on']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/23/23_naga_hex.png"
 
@@ -584,7 +584,7 @@ class RazerNagaHexRed(__RazerDevice):
     USB_PID = 0x0036
     DEDICATED_MACRO_KEYS = True
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy_byte', 'set_dpi_xy_byte', 'get_poll_rate', 'set_poll_rate',
-               'get_logo_active', 'set_logo_active', 'get_scroll_active', 'set_scroll_active']
+               'set_logo_none', 'set_logo_on', 'set_scroll_none', 'set_scroll_on']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/products/12/razer-naga-hex-gallery-12.png"
 
@@ -601,7 +601,7 @@ class RazerTaipan(__RazerDevice):
     USB_PID = 0x0034
     DEDICATED_MACRO_KEYS = True
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate',
-               'get_logo_active', 'set_logo_active', 'get_scroll_active', 'set_scroll_active']
+               'set_logo_none', 'set_logo_on', 'set_scroll_none', 'set_scroll_on']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/19/19_taipan.png"
 

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -804,8 +804,8 @@ class RazerOrochi2011(__RazerDevice):
     USB_PID = 0x0013
     EVENT_FILE_REGEX = re.compile(r'.*Razer_Orochi-if01-event-kbd')
 
-    METHODS = ['get_device_type_mouse', 'set_logo_active', 'get_logo_active', 'set_scroll_active', 'get_scroll_active',
-               'max_dpi', 'get_dpi_xy_byte', 'set_dpi_xy_byte', 'get_poll_rate', 'set_poll_rate']
+    METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy_byte', 'set_dpi_xy_byte', 'get_poll_rate', 'set_poll_rate',
+               'set_logo_none', 'set_logo_on', 'set_scroll_none', 'set_scroll_on']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/612/612_orochi_2015.png"
 

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -318,8 +318,8 @@ class RazerImperator(__RazerDevice):
     """
     USB_VID = 0x1532
     USB_PID = 0x002F
-    METHODS = ['get_device_type_mouse', 'set_logo_active', 'get_logo_active', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy',
-               'get_poll_rate', 'set_poll_rate', 'set_scroll_active', 'get_scroll_active']
+    METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate',
+               'set_logo_none', 'set_logo_on', 'set_scroll_none', 'set_scroll_on']
 
     DEVICE_IMAGE = "https://assets.razerzone.com/eeimages/support/products/215/215_imperator.png"
 

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -659,7 +659,7 @@ class RazerDeathAdder3_5G(__RazerDevice):
     DEDICATED_MACRO_KEYS = True
     METHODS = ['get_device_type_mouse',
                'get_poll_rate', 'set_poll_rate', 'get_dpi_xy', 'set_dpi_xy', 'available_dpi', 'max_dpi',
-               'get_logo_active', 'set_logo_active', 'get_scroll_active', 'set_scroll_active']
+               'set_logo_none', 'set_logo_on', 'set_scroll_none', 'set_scroll_on']
 
     AVAILABLE_DPI = [450, 900, 1800, 3500]
     DPI_MAX = 3500

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -396,8 +396,8 @@ class RazerDeathAdder2000(__RazerDevice):
     USB_VID = 0x1532
     USB_PID = 0x004F
     METHODS = ['get_device_type_mouse',
-               'set_logo_active', 'get_logo_active', 'get_logo_brightness', 'set_logo_brightness', 'set_logo_static_mono', 'set_logo_pulsate_mono',
-               'set_scroll_active', 'get_scroll_active', 'get_scroll_brightness', 'set_scroll_brightness', 'set_scroll_static_mono', 'set_scroll_pulsate_mono',
+               'get_logo_brightness', 'set_logo_brightness', 'set_logo_none', 'set_logo_on', 'set_logo_breath_mono',
+               'get_scroll_brightness', 'set_scroll_brightness', 'set_scroll_none', 'set_scroll_on', 'set_scroll_breath_mono',
                'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate']
 
     DEVICE_IMAGE = "https://assets2.razerzone.com/images/da10m/carousel/razer-death-adder-gallery-09.png"

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -1313,8 +1313,6 @@ static ssize_t razer_attr_read_poll_rate(struct device *dev, struct device_attri
     struct razer_report response = {0};
     unsigned short polling_rate = 0;
 
-    request = razer_chroma_misc_get_polling_rate();
-
     switch(device->usb_pid) {
     case USB_DEVICE_ID_RAZER_DEATHADDER_3_5G:
     case USB_DEVICE_ID_RAZER_DEATHADDER_3_5G_BLACK:
@@ -1347,6 +1345,7 @@ static ssize_t razer_attr_read_poll_rate(struct device *dev, struct device_attri
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_MINI:
+        request = razer_chroma_misc_get_polling_rate();
         request.transaction_id.id = 0x3f;
         break;
 
@@ -1371,6 +1370,7 @@ static ssize_t razer_attr_read_poll_rate(struct device *dev, struct device_attri
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_MINI_RECEIVER:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_LITE:
+        request = razer_chroma_misc_get_polling_rate();
         request.transaction_id.id = 0x1f;
         break;
 
@@ -1408,6 +1408,7 @@ static ssize_t razer_attr_read_poll_rate(struct device *dev, struct device_attri
         return sprintf(buf, "%d\n", polling_rate);
 
     default:
+        request = razer_chroma_misc_get_polling_rate();
         request.transaction_id.id = 0xFF;
         break;
     }
@@ -1445,8 +1446,6 @@ static ssize_t razer_attr_write_poll_rate(struct device *dev, struct device_attr
     struct razer_report request = {0};
     struct razer_report response = {0};
 
-    request = razer_chroma_misc_set_polling_rate(polling_rate);
-
     switch(device->usb_pid) {
     case USB_DEVICE_ID_RAZER_DEATHADDER_3_5G:
     case USB_DEVICE_ID_RAZER_DEATHADDER_3_5G_BLACK:
@@ -1476,6 +1475,7 @@ static ssize_t razer_attr_write_poll_rate(struct device *dev, struct device_attr
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_MINI:
+        request = razer_chroma_misc_set_polling_rate(polling_rate);
         request.transaction_id.id = 0x3f;
         break;
 
@@ -1502,6 +1502,7 @@ static ssize_t razer_attr_write_poll_rate(struct device *dev, struct device_attr
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_MINI_RECEIVER:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_LITE:
+        request = razer_chroma_misc_set_polling_rate(polling_rate);
         request.transaction_id.id = 0x1f;
         break;
 
@@ -1515,6 +1516,7 @@ static ssize_t razer_attr_write_poll_rate(struct device *dev, struct device_attr
         break;
 
     default:
+        request = razer_chroma_misc_set_polling_rate(polling_rate);
         request.transaction_id.id = 0xFF;
         break;
     }
@@ -2576,6 +2578,10 @@ static ssize_t razer_attr_write_matrix_custom_frame(struct device *dev, struct d
             request = razer_chroma_extended_matrix_set_custom_frame2(row_id, start_col, stop_col, (unsigned char*)&buf[offset], 0);
             request.transaction_id.id = 0x1f;
             break;
+
+        default:
+            printk(KERN_WARNING "razermouse: matrix_custom_frame not supported for this model\n");
+            return -EINVAL;
         }
 
         razer_send_payload(device, &request, &response);

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -3726,6 +3726,7 @@ static ssize_t razer_attr_write_matrix_effect_none_common(struct device *dev, st
     case USB_DEVICE_ID_RAZER_TAIPAN:
     case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
     case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, false);
         request.transaction_id.id = 0x3F;
         break;
@@ -3838,6 +3839,7 @@ static ssize_t razer_attr_write_matrix_effect_on_common(struct device *dev, stru
     case USB_DEVICE_ID_RAZER_TAIPAN:
     case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
     case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, true);
         request.transaction_id.id = 0x3F;
         break;
@@ -5252,7 +5254,8 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             break;
 
         case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_state);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_on);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_none);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
             break;
@@ -6194,7 +6197,8 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
             break;
 
         case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
-            device_remove_file(&hdev->dev, &dev_attr_logo_led_state);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_on);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_none);
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
             device_remove_file(&hdev->dev, &dev_attr_dpi);
             break;

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -4054,22 +4054,6 @@ static ssize_t razer_attr_write_right_matrix_effect_none(struct device *dev, str
 }
 
 /**
- * Write device file "backlight_led_state"
- */
-static ssize_t razer_attr_write_backlight_led_state(struct device *dev, struct device_attribute *attr, const char *buf, size_t count)
-{
-    return razer_attr_write_led_state(dev, attr, buf, count, BACKLIGHT_LED);
-}
-
-/**
- * Read device file "backlight_led_state"
- */
-static ssize_t razer_attr_read_backlight_led_state(struct device *dev, struct device_attribute *attr, char *buf)
-{
-    return razer_attr_read_led_state(dev, attr, buf, BACKLIGHT_LED);
-}
-
-/**
  * Write device file "backlight_mode_wave" (for extended mouse matrix effects)
  *
  * Wave effect mode is activated whenever the file is written to
@@ -4292,7 +4276,6 @@ static DEVICE_ATTR(right_matrix_effect_none,        0220, NULL,                 
 // For old-school led commands
 // matrix_brightness should mostly be called backlight_led_brightness (but it's too much work now for old devices)
 static DEVICE_ATTR(backlight_led_brightness,        0660, razer_attr_read_backlight_led_brightness, razer_attr_write_backlight_led_brightness);
-static DEVICE_ATTR(backlight_led_state,             0660, razer_attr_read_backlight_led_state,      razer_attr_write_backlight_led_state);
 // For "extended" matrix effects
 static DEVICE_ATTR(backlight_matrix_effect_wave,        0220, NULL,                         razer_attr_write_backlight_matrix_effect_wave);
 static DEVICE_ATTR(backlight_matrix_effect_spectrum,    0220, NULL,                         razer_attr_write_backlight_matrix_effect_spectrum);
@@ -5160,9 +5143,6 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
         case USB_DEVICE_ID_RAZER_NAGA_2012:
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_state); // TODO: remove
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_state); // TODO: remove
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_backlight_led_state); // TODO: remove
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_none);
@@ -6095,9 +6075,6 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
         case USB_DEVICE_ID_RAZER_NAGA_2012:
             device_remove_file(&hdev->dev, &dev_attr_dpi);
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
-            device_remove_file(&hdev->dev, &dev_attr_scroll_led_state); // TODO: remove
-            device_remove_file(&hdev->dev, &dev_attr_logo_led_state); // TODO: remove
-            device_remove_file(&hdev->dev, &dev_attr_backlight_led_state); // TODO: remove
             device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
             device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_none);

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -3733,6 +3733,16 @@ static ssize_t razer_attr_write_matrix_effect_none_common(struct device *dev, st
         request.transaction_id.id = 0x3F;
         break;
 
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+        if (led_id == SCROLL_WHEEL_LED) {
+            request = razer_chroma_standard_set_led_state(VARSTORE, led_id, false);
+            request.transaction_id.id = 0x3F;
+        } else {
+            request = razer_chroma_standard_matrix_effect_none();
+            request.transaction_id.id = 0xFF;
+        }
+        break;
+
     case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
     case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
         request = razer_chroma_mouse_extended_matrix_effect_none(VARSTORE, led_id);
@@ -3787,7 +3797,6 @@ static ssize_t razer_attr_write_matrix_effect_none_common(struct device *dev, st
     case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
     case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
     case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
-    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
     case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
         request = razer_chroma_standard_matrix_effect_none();
         request.transaction_id.id = 0xFF;
@@ -3844,6 +3853,7 @@ static ssize_t razer_attr_write_matrix_effect_on_common(struct device *dev, stru
     case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
     case USB_DEVICE_ID_RAZER_OUROBOROS:
     case USB_DEVICE_ID_RAZER_OROCHI_2013:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, true);
         request.transaction_id.id = 0x3F;
         break;
@@ -5120,7 +5130,8 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             break;
 
         case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_state);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_brightness);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
@@ -6065,7 +6076,8 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
             break;
 
         case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
-            device_remove_file(&hdev->dev, &dev_attr_scroll_led_state);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             device_remove_file(&hdev->dev, &dev_attr_scroll_led_brightness);
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
             device_remove_file(&hdev->dev, &dev_attr_dpi);

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -2974,148 +2974,6 @@ static ssize_t razer_attr_write_backlight_led_brightness(struct device *dev, str
 }
 
 /**
- * Write device file "scroll_led_state"
- */
-static ssize_t razer_attr_write_led_state(struct device *dev, struct device_attribute *attr, const char *buf, size_t count, unsigned char led_id)
-{
-    struct razer_mouse_device *device = dev_get_drvdata(dev);
-    unsigned char enabled = (unsigned char)simple_strtoul(buf, NULL, 10);
-    struct razer_report request = {0};
-    struct razer_report response = {0};
-
-    switch (device->usb_pid) {
-    default:
-        request = razer_chroma_standard_set_led_state(VARSTORE, led_id, enabled);
-        request.transaction_id.id = 0x3F;
-        break;
-    }
-
-    razer_send_payload(device, &request, &response);
-
-    return count;
-}
-
-/**
- * Write device file "scroll_led_state"
- */
-static ssize_t razer_attr_write_scroll_led_state(struct device *dev, struct device_attribute *attr, const char *buf, size_t count)
-{
-    return razer_attr_write_led_state(dev, attr, buf, count, SCROLL_WHEEL_LED);
-}
-
-/**
- * Common function to handle sysfs read led_state for a given led
- */
-static ssize_t razer_attr_read_led_state(struct device *dev, struct device_attribute *attr, char *buf, unsigned char led_id)
-{
-    struct razer_mouse_device *device = dev_get_drvdata(dev);
-    struct razer_report request = {0};
-    struct razer_report response = {0};
-
-    switch (device->usb_pid) {
-    default:
-        request = razer_chroma_standard_get_led_state(VARSTORE, led_id);
-        request.transaction_id.id = 0x3F;
-        break;
-    }
-
-    razer_send_payload(device, &request, &response);
-
-    return sprintf(buf, "%d\n", response.arguments[2]);
-}
-
-/**
- * Read device file "scroll_led_state"
- */
-static ssize_t razer_attr_read_scroll_led_state(struct device *dev, struct device_attribute *attr, char *buf)
-{
-    return razer_attr_read_led_state(dev, attr, buf, SCROLL_WHEEL_LED);
-}
-
-/**
- * Write device file "logo_led_state"
- */
-static ssize_t razer_attr_write_logo_led_state(struct device *dev, struct device_attribute *attr, const char *buf, size_t count)
-{
-    return razer_attr_write_led_state(dev, attr, buf, count, LOGO_LED);
-}
-
-/**
- * Read device file "logo_led_state"
- */
-static ssize_t razer_attr_read_logo_led_state(struct device *dev, struct device_attribute *attr, char *buf)
-{
-    return razer_attr_read_led_state(dev, attr, buf, LOGO_LED);
-}
-
-/**
- * Common function to handle sysfs write effect for a given led
- */
-static ssize_t razer_attr_write_led_effect(struct device *dev, struct device_attribute *attr, const char *buf, size_t count, unsigned char led_id)
-{
-    struct razer_mouse_device *device = dev_get_drvdata(dev);
-    unsigned char effect = (unsigned char)simple_strtoul(buf, NULL, 10);
-    struct razer_report request = {0};
-    struct razer_report response = {0};
-
-    request = razer_chroma_standard_set_led_effect(VARSTORE, led_id, effect);
-    request.transaction_id.id = 0x3F;
-
-    razer_send_payload(device, &request, &response);
-
-    return count;
-}
-
-/**
- * Common function to handle sysfs read effect for a given led
- */
-static ssize_t razer_attr_read_led_effect(struct device *dev, struct device_attribute *attr, char *buf, unsigned char led_id)
-{
-    struct razer_mouse_device *device = dev_get_drvdata(dev);
-    struct razer_report request = {0};
-    struct razer_report response = {0};
-
-    request = razer_chroma_standard_get_led_effect(VARSTORE, led_id);
-    request.transaction_id.id = 0x3F;
-
-    razer_send_payload(device, &request, &response);
-
-    return sprintf(buf, "%d\n", response.arguments[2]);
-}
-
-/**
- * Write device file "scroll_led_effect"
- */
-static ssize_t razer_attr_write_scroll_led_effect(struct device *dev, struct device_attribute *attr, const char *buf, size_t count)
-{
-    return razer_attr_write_led_effect(dev, attr, buf, count, SCROLL_WHEEL_LED);
-}
-
-/**
- * Read device file "scroll_led_effect"
- */
-static ssize_t razer_attr_read_scroll_led_effect(struct device *dev, struct device_attribute *attr, char *buf)
-{
-    return razer_attr_read_led_effect(dev, attr, buf, SCROLL_WHEEL_LED);
-}
-
-/**
- * Write device file "logo_led_effect"
- */
-static ssize_t razer_attr_write_logo_led_effect(struct device *dev, struct device_attribute *attr, const char *buf, size_t count)
-{
-    return razer_attr_write_led_effect(dev, attr, buf, count, LOGO_LED);
-}
-
-/**
- * Read device file "logo_led_effect"
- */
-static ssize_t razer_attr_read_logo_led_effect(struct device *dev, struct device_attribute *attr, char *buf)
-{
-    return razer_attr_read_led_effect(dev, attr, buf, LOGO_LED);
-}
-
-/**
  * Common function to handle sysfs write matrix_effect_wave for a given led
  */
 static ssize_t razer_attr_write_matrix_effect_wave_common(struct device *dev, struct device_attribute *attr, const char *buf, size_t count, unsigned char led_id)
@@ -3391,6 +3249,16 @@ static ssize_t razer_attr_write_matrix_effect_breath_common(struct device *dev, 
         razer_send_payload(device, &request, &response);
 
         request = razer_chroma_standard_set_led_rgb(VARSTORE, led_id, (struct razer_rgb*)&buf[0]);
+        request.transaction_id.id = 0x3F;
+        razer_send_payload(device, &request, &response);
+
+        request = razer_chroma_standard_set_led_effect(VARSTORE, led_id, CLASSIC_EFFECT_BREATHING);
+        request.transaction_id.id = 0x3F;
+        break;
+
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+        /* Mono-color breath effect */
+        request = razer_chroma_standard_set_led_state(VARSTORE, led_id, true);
         request.transaction_id.id = 0x3F;
         razer_send_payload(device, &request, &response);
 
@@ -3729,6 +3597,7 @@ static ssize_t razer_attr_write_matrix_effect_none_common(struct device *dev, st
     case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
     case USB_DEVICE_ID_RAZER_OUROBOROS:
     case USB_DEVICE_ID_RAZER_OROCHI_2013:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, false);
         request.transaction_id.id = 0x3F;
         break;
@@ -3855,6 +3724,16 @@ static ssize_t razer_attr_write_matrix_effect_on_common(struct device *dev, stru
     case USB_DEVICE_ID_RAZER_OROCHI_2013:
     case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, true);
+        request.transaction_id.id = 0x3F;
+        break;
+
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+        /* Could also be called a mono-color static effect */
+        request = razer_chroma_standard_set_led_state(VARSTORE, led_id, true);
+        request.transaction_id.id = 0x3F;
+        razer_send_payload(device, &request, &response);
+
+        request = razer_chroma_standard_set_led_effect(VARSTORE, led_id, CLASSIC_EFFECT_STATIC);
         request.transaction_id.id = 0x3F;
         break;
 
@@ -4238,9 +4117,6 @@ static DEVICE_ATTR(matrix_effect_reactive,    0220, NULL,                       
 static DEVICE_ATTR(matrix_effect_breath,      0220, NULL,                                  razer_attr_write_matrix_effect_breath);
 
 static DEVICE_ATTR(scroll_led_brightness,     0660, razer_attr_read_scroll_led_brightness, razer_attr_write_scroll_led_brightness);
-// For old-school led commands
-static DEVICE_ATTR(scroll_led_state,          0660, razer_attr_read_scroll_led_state,      razer_attr_write_scroll_led_state);
-static DEVICE_ATTR(scroll_led_effect,         0660, razer_attr_read_scroll_led_effect,     razer_attr_write_scroll_led_effect);
 // For "extended" matrix effects
 static DEVICE_ATTR(scroll_matrix_effect_wave,        0220, NULL,                           razer_attr_write_scroll_matrix_effect_wave);
 static DEVICE_ATTR(scroll_matrix_effect_spectrum,    0220, NULL,                           razer_attr_write_scroll_matrix_effect_spectrum);
@@ -4252,9 +4128,6 @@ static DEVICE_ATTR(scroll_matrix_effect_none,        0220, NULL,                
 static DEVICE_ATTR(scroll_matrix_effect_on,          0220, NULL,                           razer_attr_write_scroll_matrix_effect_on);
 
 static DEVICE_ATTR(logo_led_brightness,       0660, razer_attr_read_logo_led_brightness,   razer_attr_write_logo_led_brightness);
-// For old-school led commands
-static DEVICE_ATTR(logo_led_state,            0660, razer_attr_read_logo_led_state,        razer_attr_write_logo_led_state);
-static DEVICE_ATTR(logo_led_effect,           0660, razer_attr_read_logo_led_effect,       razer_attr_write_logo_led_effect);
 // For "extended" matrix effects
 static DEVICE_ATTR(logo_matrix_effect_wave,        0220, NULL,                             razer_attr_write_logo_matrix_effect_wave);
 static DEVICE_ATTR(logo_matrix_effect_spectrum,    0220, NULL,                             razer_attr_write_logo_matrix_effect_spectrum);
@@ -5242,11 +5115,13 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_brightness);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_state);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_effect);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_breath);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_brightness);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_state);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_effect);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_breath);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_none);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_on);
             break;
 
         case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
@@ -6188,11 +6063,13 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
             device_remove_file(&hdev->dev, &dev_attr_dpi);
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
             device_remove_file(&hdev->dev, &dev_attr_scroll_led_brightness);
-            device_remove_file(&hdev->dev, &dev_attr_scroll_led_state);
-            device_remove_file(&hdev->dev, &dev_attr_scroll_led_effect);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_breath);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
             device_remove_file(&hdev->dev, &dev_attr_logo_led_brightness);
-            device_remove_file(&hdev->dev, &dev_attr_logo_led_state);
-            device_remove_file(&hdev->dev, &dev_attr_logo_led_effect);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_breath);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_none);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_on);
             break;
 
         case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -3750,6 +3750,7 @@ static ssize_t razer_attr_write_matrix_effect_none_common(struct device *dev, st
     case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
     case USB_DEVICE_ID_RAZER_NAGA_2012:
     case USB_DEVICE_ID_RAZER_ABYSSUS:
+    case USB_DEVICE_ID_RAZER_IMPERATOR:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, false);
         request.transaction_id.id = 0x3F;
         break;
@@ -3846,6 +3847,7 @@ static ssize_t razer_attr_write_matrix_effect_on_common(struct device *dev, stru
     switch (device->usb_pid) {
     case USB_DEVICE_ID_RAZER_NAGA_2012:
     case USB_DEVICE_ID_RAZER_ABYSSUS:
+    case USB_DEVICE_ID_RAZER_IMPERATOR:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, true);
         request.transaction_id.id = 0x3F;
         break;
@@ -5079,8 +5081,10 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             break;
 
         case USB_DEVICE_ID_RAZER_IMPERATOR:
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_state);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_state);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_on);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_none);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
             break;
@@ -6012,8 +6016,10 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
             break;
 
         case USB_DEVICE_ID_RAZER_IMPERATOR:
-            device_remove_file(&hdev->dev, &dev_attr_logo_led_state);
-            device_remove_file(&hdev->dev, &dev_attr_scroll_led_state);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_on);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_none);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
             device_remove_file(&hdev->dev, &dev_attr_dpi);
             break;

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -3724,6 +3724,8 @@ static ssize_t razer_attr_write_matrix_effect_none_common(struct device *dev, st
     case USB_DEVICE_ID_RAZER_NAGA_HEX:
     case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
     case USB_DEVICE_ID_RAZER_TAIPAN:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, false);
         request.transaction_id.id = 0x3F;
         break;
@@ -3834,6 +3836,8 @@ static ssize_t razer_attr_write_matrix_effect_on_common(struct device *dev, stru
     case USB_DEVICE_ID_RAZER_NAGA_HEX:
     case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
     case USB_DEVICE_ID_RAZER_TAIPAN:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, true);
         request.transaction_id.id = 0x3F;
         break;
@@ -5241,7 +5245,8 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
 
         case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
         case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_state);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_on);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_none);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
             break;
@@ -6182,7 +6187,8 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
 
         case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
         case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
-            device_remove_file(&hdev->dev, &dev_attr_logo_led_state);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_on);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_none);
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
             device_remove_file(&hdev->dev, &dev_attr_dpi);
             break;

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -3749,6 +3749,7 @@ static ssize_t razer_attr_write_matrix_effect_none_common(struct device *dev, st
     case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
     case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
     case USB_DEVICE_ID_RAZER_NAGA_2012:
+    case USB_DEVICE_ID_RAZER_ABYSSUS:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, false);
         request.transaction_id.id = 0x3F;
         break;
@@ -3844,6 +3845,7 @@ static ssize_t razer_attr_write_matrix_effect_on_common(struct device *dev, stru
 
     switch (device->usb_pid) {
     case USB_DEVICE_ID_RAZER_NAGA_2012:
+    case USB_DEVICE_ID_RAZER_ABYSSUS:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, true);
         request.transaction_id.id = 0x3F;
         break;
@@ -5071,7 +5073,8 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             break;
 
         case USB_DEVICE_ID_RAZER_ABYSSUS:
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_state);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_on);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_none);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
             break;
 
@@ -6003,7 +6006,8 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
             break;
 
         case USB_DEVICE_ID_RAZER_ABYSSUS:
-            device_remove_file(&hdev->dev, &dev_attr_logo_led_state);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_on);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_none);
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
             break;
 

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -3751,6 +3751,9 @@ static ssize_t razer_attr_write_matrix_effect_none_common(struct device *dev, st
     case USB_DEVICE_ID_RAZER_NAGA_2012:
     case USB_DEVICE_ID_RAZER_ABYSSUS:
     case USB_DEVICE_ID_RAZER_IMPERATOR:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
+    case USB_DEVICE_ID_RAZER_TAIPAN:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, false);
         request.transaction_id.id = 0x3F;
         break;
@@ -3848,6 +3851,9 @@ static ssize_t razer_attr_write_matrix_effect_on_common(struct device *dev, stru
     case USB_DEVICE_ID_RAZER_NAGA_2012:
     case USB_DEVICE_ID_RAZER_ABYSSUS:
     case USB_DEVICE_ID_RAZER_IMPERATOR:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
+    case USB_DEVICE_ID_RAZER_TAIPAN:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, true);
         request.transaction_id.id = 0x3F;
         break;
@@ -5133,13 +5139,15 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_device_idle_time);
             break;
 
-        case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
         case USB_DEVICE_ID_RAZER_NAGA_HEX:
+        case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
         case USB_DEVICE_ID_RAZER_TAIPAN:
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_state);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_state);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_on);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_none);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             break;
 
         case USB_DEVICE_ID_RAZER_NAGA_2014:
@@ -6073,8 +6081,10 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
         case USB_DEVICE_ID_RAZER_TAIPAN:
             device_remove_file(&hdev->dev, &dev_attr_dpi);
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
-            device_remove_file(&hdev->dev, &dev_attr_scroll_led_state);
-            device_remove_file(&hdev->dev, &dev_attr_logo_led_state);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_on);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_none);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             break;
 
         case USB_DEVICE_ID_RAZER_NAGA_2014:

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -2954,20 +2954,6 @@ static ssize_t razer_attr_write_led_state(struct device *dev, struct device_attr
     struct razer_report response = {0};
 
     switch (device->usb_pid) {
-    case USB_DEVICE_ID_RAZER_DEATHADDER_3_5G:
-        switch (led_id) {
-        case SCROLL_WHEEL_LED:
-            deathadder3_5g_set_scroll_led_state(device, enabled);
-            break;
-        case LOGO_LED:
-            deathadder3_5g_set_logo_led_state(device, enabled);
-            break;
-        default:
-            printk(KERN_WARNING "razermouse: Invalid led_id for led_state on this model\n");
-            return -EINVAL;
-        }
-        return count;
-
     case USB_DEVICE_ID_RAZER_OROCHI_2011:
         switch (led_id) {
         case SCROLL_WHEEL_LED:
@@ -3021,27 +3007,6 @@ static ssize_t razer_attr_read_led_state(struct device *dev, struct device_attri
     struct razer_report response = {0};
 
     switch (device->usb_pid) {
-    case USB_DEVICE_ID_RAZER_DEATHADDER_3_5G:
-        switch (led_id) {
-        case SCROLL_WHEEL_LED:
-            if((device->da3_5g.leds & 0x02) == 0x02) {
-                return sprintf(buf, "1\n");
-            } else {
-                return sprintf(buf, "0\n");
-            }
-            break;
-        case LOGO_LED:
-            if((device->da3_5g.leds & 0x01) == 0x01) {
-                return sprintf(buf, "1\n");
-            } else {
-                return sprintf(buf, "0\n");
-            }
-            break;
-        default:
-            printk(KERN_WARNING "razermouse: Invalid led_id for led_state on this model\n");
-            return -EINVAL;
-        }
-
     case USB_DEVICE_ID_RAZER_OROCHI_2011:
         switch (led_id) {
         case SCROLL_WHEEL_LED:
@@ -3742,6 +3707,20 @@ static ssize_t razer_attr_write_matrix_effect_none_common(struct device *dev, st
     struct razer_report response = {0};
 
     switch (device->usb_pid) {
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3_5G:
+        switch (led_id) {
+        case SCROLL_WHEEL_LED:
+            deathadder3_5g_set_scroll_led_state(device, false);
+            break;
+        case LOGO_LED:
+            deathadder3_5g_set_logo_led_state(device, false);
+            break;
+        default:
+            printk(KERN_WARNING "razermouse: Invalid led_id on this model\n");
+            return -EINVAL;
+        }
+        return count;
+
     case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
     case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
     case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
@@ -3848,6 +3827,20 @@ static ssize_t razer_attr_write_matrix_effect_on_common(struct device *dev, stru
     struct razer_report response = {0};
 
     switch (device->usb_pid) {
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3_5G:
+        switch (led_id) {
+        case SCROLL_WHEEL_LED:
+            deathadder3_5g_set_scroll_led_state(device, true);
+            break;
+        case LOGO_LED:
+            deathadder3_5g_set_logo_led_state(device, true);
+            break;
+        default:
+            printk(KERN_WARNING "razermouse: Invalid led_id on this model\n");
+            return -EINVAL;
+        }
+        return count;
+
     case USB_DEVICE_ID_RAZER_NAGA_2012:
     case USB_DEVICE_ID_RAZER_ABYSSUS:
     case USB_DEVICE_ID_RAZER_IMPERATOR:
@@ -5169,8 +5162,10 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
         case USB_DEVICE_ID_RAZER_DEATHADDER_3_5G:
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_state);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_state);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_on);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_none);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             break;
 
         case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
@@ -6106,8 +6101,10 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
         case USB_DEVICE_ID_RAZER_DEATHADDER_3_5G:
             device_remove_file(&hdev->dev, &dev_attr_dpi);
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
-            device_remove_file(&hdev->dev, &dev_attr_scroll_led_state);
-            device_remove_file(&hdev->dev, &dev_attr_logo_led_state);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_on);
+            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_none);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             break;
 
         case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -3727,6 +3727,7 @@ static ssize_t razer_attr_write_matrix_effect_none_common(struct device *dev, st
     case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
     case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
     case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, false);
         request.transaction_id.id = 0x3F;
         break;
@@ -3840,6 +3841,7 @@ static ssize_t razer_attr_write_matrix_effect_on_common(struct device *dev, stru
     case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
     case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
     case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, true);
         request.transaction_id.id = 0x3F;
         break;
@@ -5088,7 +5090,8 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_low_threshold);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_device_idle_time);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_brightness);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_state);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_level);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_status);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
@@ -6031,7 +6034,8 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
             device_remove_file(&hdev->dev, &dev_attr_charge_low_threshold);
             device_remove_file(&hdev->dev, &dev_attr_device_idle_time);
             device_remove_file(&hdev->dev, &dev_attr_scroll_led_brightness);
-            device_remove_file(&hdev->dev, &dev_attr_scroll_led_state);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             device_remove_file(&hdev->dev, &dev_attr_charge_level);
             device_remove_file(&hdev->dev, &dev_attr_charge_status);
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -3728,6 +3728,7 @@ static ssize_t razer_attr_write_matrix_effect_none_common(struct device *dev, st
     case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
     case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
     case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_OROCHI_2013:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, false);
         request.transaction_id.id = 0x3F;
         break;
@@ -3842,6 +3843,7 @@ static ssize_t razer_attr_write_matrix_effect_on_common(struct device *dev, stru
     case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
     case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
     case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_OROCHI_2013:
         request = razer_chroma_standard_set_led_state(VARSTORE, led_id, true);
         request.transaction_id.id = 0x3F;
         break;
@@ -5111,7 +5113,8 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             break;
 
         case USB_DEVICE_ID_RAZER_OROCHI_2013:
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_state);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
             break;
@@ -6055,7 +6058,8 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
             break;
 
         case USB_DEVICE_ID_RAZER_OROCHI_2013:
-            device_remove_file(&hdev->dev, &dev_attr_scroll_led_state);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_on);
+            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
             device_remove_file(&hdev->dev, &dev_attr_dpi);
             break;

--- a/pylib/openrazer/_fake_driver/razerabyssus1800.cfg
+++ b/pylib/openrazer/_fake_driver/razerabyssus1800.cfg
@@ -8,6 +8,7 @@ files = rw,device_mode,0x0000
         r,device_type,%(name)s
         rw,dpi,30:30
         r,firmware_version,v1.0
-        rw,logo_led_state,0
+        w,logo_matrix_effect_none
+        w,logo_matrix_effect_on
         rw,poll_rate,500
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerabyssus2000.cfg
+++ b/pylib/openrazer/_fake_driver/razerabyssus2000.cfg
@@ -8,6 +8,7 @@ files = rw,device_mode,0x0000
         r,device_type,%(name)s
         rw,dpi,800:800
         r,firmware_version,v1.0
-        rw,logo_led_state,0
+        w,logo_matrix_effect_none
+        w,logo_matrix_effect_on
         rw,poll_rate,500
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerabyssus2014.cfg
+++ b/pylib/openrazer/_fake_driver/razerabyssus2014.cfg
@@ -7,6 +7,7 @@ files = rw,device_mode,0x0000
         r,device_serial,XX0000000042
         r,device_type,%(name)s
         r,firmware_version,v1.0
-        rw,logo_led_state,0
+        w,logo_matrix_effect_none
+        w,logo_matrix_effect_on
         rw,poll_rate,500
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadder1800.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadder1800.cfg
@@ -8,6 +8,7 @@ files = rw,device_mode,0x0000
         r,device_type,%(name)s
         rw,dpi,30:30
         r,firmware_version,v1.0
-        rw,logo_led_state,0
+        w,logo_matrix_effect_none
+        w,logo_matrix_effect_on
         rw,poll_rate,500
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadder2000.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadder2000.cfg
@@ -9,10 +9,12 @@ files = rw,device_mode,0x0000
         rw,dpi,800:800
         r,firmware_version,v1.0
         rw,logo_led_brightness,0
-        rw,logo_led_effect,0
-        rw,logo_led_state,0
+        w,logo_matrix_effect_breath
+        w,logo_matrix_effect_none
+        w,logo_matrix_effect_on
         rw,poll_rate,500
         rw,scroll_led_brightness,0
-        rw,scroll_led_effect,0
-        rw,scroll_led_state,0
+        w,scroll_matrix_effect_breath
+        w,scroll_matrix_effect_none
+        w,scroll_matrix_effect_on
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadder3.5g.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadder3.5g.cfg
@@ -8,7 +8,9 @@ files = rw,device_mode,0x0000
         r,device_type,%(name)s
         rw,dpi,800:800
         r,firmware_version,v1.0
-        rw,logo_led_state,0
+        w,logo_matrix_effect_none
+        w,logo_matrix_effect_on
         rw,poll_rate,500
-        rw,scroll_led_state,0
+        w,scroll_matrix_effect_none
+        w,scroll_matrix_effect_on
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerimperator2012.cfg
+++ b/pylib/openrazer/_fake_driver/razerimperator2012.cfg
@@ -8,7 +8,9 @@ files = rw,device_mode,0x0000
         r,device_type,%(name)s
         rw,dpi,800:800
         r,firmware_version,v1.0
-        rw,logo_led_state,0
+        w,logo_matrix_effect_none
+        w,logo_matrix_effect_on
         rw,poll_rate,500
-        rw,scroll_led_state,0
+        w,scroll_matrix_effect_none
+        w,scroll_matrix_effect_on
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernaga2012.cfg
+++ b/pylib/openrazer/_fake_driver/razernaga2012.cfg
@@ -3,19 +3,16 @@
 [device]
 dir_name = 0003:1532:002E.0001
 name = Razer Naga 2012
-files = rw,backlight_led_state,0
-        w,backlight_matrix_effect_none
+files = w,backlight_matrix_effect_none
         w,backlight_matrix_effect_on
         rw,device_mode,0x0000
         r,device_serial,XX000000002E
         r,device_type,%(name)s
         rw,dpi,30:30
         r,firmware_version,v1.0
-        rw,logo_led_state,0
         w,logo_matrix_effect_none
         w,logo_matrix_effect_on
         rw,poll_rate,500
-        rw,scroll_led_state,0
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernaga2014.cfg
+++ b/pylib/openrazer/_fake_driver/razernaga2014.cfg
@@ -3,19 +3,16 @@
 [device]
 dir_name = 0003:1532:0040.0001
 name = Razer Naga 2014
-files = rw,backlight_led_state,0
-        w,backlight_matrix_effect_none
+files = w,backlight_matrix_effect_none
         w,backlight_matrix_effect_on
         rw,device_mode,0x0000
         r,device_serial,XX0000000040
         r,device_type,%(name)s
         rw,dpi,800:800
         r,firmware_version,v1.0
-        rw,logo_led_state,0
         w,logo_matrix_effect_none
         w,logo_matrix_effect_on
         rw,poll_rate,500
-        rw,scroll_led_state,0
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
         rw,tilt_hwheel,0

--- a/pylib/openrazer/_fake_driver/razernagahex.cfg
+++ b/pylib/openrazer/_fake_driver/razernagahex.cfg
@@ -8,7 +8,9 @@ files = rw,device_mode,0x0000
         r,device_type,%(name)s
         rw,dpi,30:30
         r,firmware_version,v1.0
-        rw,logo_led_state,0
+        w,logo_matrix_effect_none
+        w,logo_matrix_effect_on
         rw,poll_rate,500
-        rw,scroll_led_state,0
+        w,scroll_matrix_effect_none
+        w,scroll_matrix_effect_on
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernagahexred.cfg
+++ b/pylib/openrazer/_fake_driver/razernagahexred.cfg
@@ -8,7 +8,9 @@ files = rw,device_mode,0x0000
         r,device_type,%(name)s
         rw,dpi,30:30
         r,firmware_version,v1.0
-        rw,logo_led_state,0
+        w,logo_matrix_effect_none
+        w,logo_matrix_effect_on
         rw,poll_rate,500
-        rw,scroll_led_state,0
+        w,scroll_matrix_effect_none
+        w,scroll_matrix_effect_on
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerorochi2011.cfg
+++ b/pylib/openrazer/_fake_driver/razerorochi2011.cfg
@@ -8,7 +8,9 @@ files = rw,device_mode,0x0000
         r,device_type,%(name)s
         rw,dpi,30:30
         r,firmware_version,v1.0
-        rw,logo_led_state,0
+        w,logo_matrix_effect_none
+        w,logo_matrix_effect_on
         rw,poll_rate,500
-        rw,scroll_led_state,0
+        w,scroll_matrix_effect_none
+        w,scroll_matrix_effect_on
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerorochi2013.cfg
+++ b/pylib/openrazer/_fake_driver/razerorochi2013.cfg
@@ -9,5 +9,6 @@ files = rw,device_mode,0x0000
         rw,dpi,800:800
         r,firmware_version,v1.0
         rw,poll_rate,500
-        rw,scroll_led_state,0
+        w,scroll_matrix_effect_none
+        w,scroll_matrix_effect_on
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerorochiwired.cfg
+++ b/pylib/openrazer/_fake_driver/razerorochiwired.cfg
@@ -17,5 +17,6 @@ files = w,backlight_matrix_effect_breath
         r,firmware_version,v1.0
         rw,poll_rate,500
         rw,scroll_led_brightness,0
-        rw,scroll_led_state,0
+        w,scroll_matrix_effect_none
+        w,scroll_matrix_effect_on
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerouroboros.cfg
+++ b/pylib/openrazer/_fake_driver/razerouroboros.cfg
@@ -14,5 +14,6 @@ files = r,charge_level,255
         r,firmware_version,v1.0
         rw,poll_rate,500
         rw,scroll_led_brightness,0
-        rw,scroll_led_state,0
+        w,scroll_matrix_effect_none
+        w,scroll_matrix_effect_on
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razertaipan.cfg
+++ b/pylib/openrazer/_fake_driver/razertaipan.cfg
@@ -8,7 +8,9 @@ files = rw,device_mode,0x0000
         r,device_type,%(name)s
         rw,dpi,800:800
         r,firmware_version,v1.0
-        rw,logo_led_state,0
+        w,logo_matrix_effect_none
+        w,logo_matrix_effect_on
         rw,poll_rate,500
-        rw,scroll_led_state,0
+        w,scroll_matrix_effect_none
+        w,scroll_matrix_effect_on
         r,version,1.0.0

--- a/pylib/openrazer/client/devices/__init__.py
+++ b/pylib/openrazer/client/devices/__init__.py
@@ -119,6 +119,7 @@ class RazerDevice(object):
             'lighting_logo_breath_single': self._has_feature('razer.device.lighting.logo', 'setLogoBreathSingle'),
             'lighting_logo_breath_dual': self._has_feature('razer.device.lighting.logo', 'setLogoBreathDual'),
             'lighting_logo_breath_random': self._has_feature('razer.device.lighting.logo', 'setLogoBreathRandom'),
+            'lighting_logo_breath_mono': self._has_feature('razer.device.lighting.logo', 'setLogoBreathMono'),
 
             'lighting_scroll': self._has_feature('razer.device.lighting.scroll'),
             'lighting_scroll_active': self._has_feature('razer.device.lighting.scroll', 'setScrollActive'),
@@ -134,6 +135,7 @@ class RazerDevice(object):
             'lighting_scroll_breath_single': self._has_feature('razer.device.lighting.scroll', 'setScrollBreathSingle'),
             'lighting_scroll_breath_dual': self._has_feature('razer.device.lighting.scroll', 'setScrollBreathDual'),
             'lighting_scroll_breath_random': self._has_feature('razer.device.lighting.scroll', 'setScrollBreathRandom'),
+            'lighting_scroll_breath_mono': self._has_feature('razer.device.lighting.scroll', 'setScrollBreathMono'),
 
             'lighting_left': self._has_feature('razer.device.lighting.left'),
             'lighting_left_active': self._has_feature('razer.device.lighting.left', 'setLeftActive'),
@@ -146,6 +148,7 @@ class RazerDevice(object):
             'lighting_left_breath_single': self._has_feature('razer.device.lighting.left', 'setLeftBreathSingle'),
             'lighting_left_breath_dual': self._has_feature('razer.device.lighting.left', 'setLeftBreathDual'),
             'lighting_left_breath_random': self._has_feature('razer.device.lighting.left', 'setLeftBreathRandom'),
+            'lighting_left_breath_mono': self._has_feature('razer.device.lighting.left', 'setLeftBreathMono'),
 
             'lighting_right': self._has_feature('razer.device.lighting.right'),
             'lighting_right_active': self._has_feature('razer.device.lighting.right', 'setRightActive'),
@@ -158,6 +161,7 @@ class RazerDevice(object):
             'lighting_right_breath_single': self._has_feature('razer.device.lighting.right', 'setRightBreathSingle'),
             'lighting_right_breath_dual': self._has_feature('razer.device.lighting.right', 'setRightBreathDual'),
             'lighting_right_breath_random': self._has_feature('razer.device.lighting.right', 'setRightBreathRandom'),
+            'lighting_right_breath_mono': self._has_feature('razer.device.lighting.right', 'setRightBreathMono'),
 
             'lighting_backlight': self._has_feature('razer.device.lighting.backlight'),
             'lighting_backlight_active': self._has_feature('razer.device.lighting.backlight', 'setBacklightActive'),
@@ -171,6 +175,7 @@ class RazerDevice(object):
             'lighting_backlight_breath_single': self._has_feature('razer.device.lighting.backlight', 'setBacklightBreathSingle'),
             'lighting_backlight_breath_dual': self._has_feature('razer.device.lighting.backlight', 'setBacklightBreathDual'),
             'lighting_backlight_breath_random': self._has_feature('razer.device.lighting.backlight', 'setBacklightBreathRandom'),
+            'lighting_backlight_breath_mono': self._has_feature('razer.device.lighting.backlight', 'setBacklightBreathMono'),
 
             'lighting_profile_led_red': self._has_feature('razer.device.lighting.profile_led', 'setRedLED'),
             'lighting_profile_led_green': self._has_feature('razer.device.lighting.profile_led', 'setGreenLED'),
@@ -187,6 +192,7 @@ class RazerDevice(object):
             'lighting_charging_breath_single': self._has_feature('razer.device.lighting.charging', 'setChargingBreathSingle'),
             'lighting_charging_breath_dual': self._has_feature('razer.device.lighting.charging', 'setChargingBreathDual'),
             'lighting_charging_breath_random': self._has_feature('razer.device.lighting.charging', 'setChargingBreathRandom'),
+            'lighting_charging_breath_mono': self._has_feature('razer.device.lighting.charging', 'setChargingBreathMono'),
 
             'lighting_fast_charging': self._has_feature('razer.device.lighting.fast_charging'),
             'lighting_fast_charging_active': self._has_feature('razer.device.lighting.fast_charging', 'setFastChargingActive'),
@@ -198,6 +204,7 @@ class RazerDevice(object):
             'lighting_fast_charging_breath_single': self._has_feature('razer.device.lighting.fast_charging', 'setFastChargingBreathSingle'),
             'lighting_fast_charging_breath_dual': self._has_feature('razer.device.lighting.fast_charging', 'setFastChargingBreathDual'),
             'lighting_fast_charging_breath_random': self._has_feature('razer.device.lighting.fast_charging', 'setFastChargingBreathRandom'),
+            'lighting_fast_charging_breath_mono': self._has_feature('razer.device.lighting.fast_charging', 'setFastChargingBreathMono'),
 
             'lighting_fully_charged': self._has_feature('razer.device.lighting.fully_charged'),
             'lighting_fully_charged_active': self._has_feature('razer.device.lighting.fully_charged', 'setFullyChargedActive'),
@@ -209,6 +216,7 @@ class RazerDevice(object):
             'lighting_fully_charged_breath_single': self._has_feature('razer.device.lighting.fully_charged', 'setFullyChargedBreathSingle'),
             'lighting_fully_charged_breath_dual': self._has_feature('razer.device.lighting.fully_charged', 'setFullyChargedBreathDual'),
             'lighting_fully_charged_breath_random': self._has_feature('razer.device.lighting.fully_charged', 'setFullyChargedBreathRandom'),
+            'lighting_fully_charged_breath_mono': self._has_feature('razer.device.lighting.fully_charged', 'setFullyChargedBreathMono'),
         }
 
         # Nasty hack to convert dbus.Int32 into native

--- a/pylib/openrazer/client/fx.py
+++ b/pylib/openrazer/client/fx.py
@@ -981,6 +981,22 @@ class SingleLed(BaseRazerFX):
             return True
         return False
 
+    def breath_mono(self) -> bool:
+        """
+        Breath effect - mono colour
+
+        :return: True if success, False otherwise
+        :rtype: bool
+
+        :raises ValueError: If parameters are invalid
+        """
+
+        if self._shas('breath_mono'):
+            self._getattr('set#BreathMono')()
+
+            return True
+        return False
+
 
 class MiscLighting(BaseRazerFX):
     def __init__(self, serial: str, capabilities: dict, daemon_dbus=None):

--- a/scripts/ci/test-daemon.py
+++ b/scripts/ci/test-daemon.py
@@ -133,7 +133,7 @@ def test_sysfs_consistency(d):
             # There are two implementations with different sysfs files
             check_any_sysfs([f"lighting_{prefix}_{effect}"], [f"{prefix}_matrix_effect_{effect}", f"{prefix}_led_effect"])
 
-        check_sysfs(f"lighting_{prefix}_breath_single", f"{prefix}_matrix_effect_breath")
+        check_any_sysfs([f"lighting_{prefix}_breath_single", f"lighting_{prefix}_breath_mono"], [f"{prefix}_matrix_effect_breath"])
 
 
 def test_ripple_capable(d):


### PR DESCRIPTION
Now that the major UIs support this effect, let's update the daemon to use those new methods.

---

~~^^ above commit message is for the future. To be merged when polychromatic and RazerGenie have new releases~~

**On** effect

* [x] https://github.com/polychromatic/polychromatic/pull/482 (https://github.com/polychromatic/polychromatic/commit/dcbd3a82cc567c893ae03d3a5dc153ffc001c15d)
* [x] https://github.com/z3ntu/libopenrazer/commit/1f25aab0f2df81acdd36e0a405229463d31c2c6d

**Breath mono-color** effect

* [x] https://github.com/polychromatic/polychromatic/pull/486
* [x] https://github.com/z3ntu/RazerGenie/commit/03e241b1224b6ec13bae97014a0882298fcf1b4f
* [x] https://github.com/z3ntu/libopenrazer/commit/143d51b38d3612a6775c65fcf1e56815d72c6aa9

CC @lah7 
