### PR TITLE
daemon: notify for new effect when calling setCustom/setKeyRow

### DIFF
--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/chroma_keyboard.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/chroma_keyboard.py
@@ -545,15 +545,9 @@ def set_custom_effect(self):
     """
     Set the device to use custom LED matrix
     """
-    # TODO uncomment
-    # self.logger.debug("DBus call set_custom_effect")
+    self.send_effect_event('setCustom')
 
-    driver_path = self.get_driver_path('matrix_effect_custom')
-
-    payload = b'1'
-
-    with open(driver_path, 'wb') as driver_file:
-        driver_file.write(payload)
+    self._set_custom_effect()
 
 
 @endpoint('razer.device.lighting.chroma', 'setKeyRow', in_sig='ay', byte_arrays=True)
@@ -570,14 +564,9 @@ def set_key_row(self, payload):
     :param payload: Binary payload
     :type payload: bytes
     """
+    self.send_effect_event('setCustom')
 
-    # TODO uncomment
-    # self.logger.debug("DBus call set_key_row")
-
-    driver_path = self.get_driver_path('matrix_custom_frame')
-
-    with open(driver_path, 'wb') as driver_file:
-        driver_file.write(payload)
+    self._set_key_row(payload)
 
 
 @endpoint('razer.device.lighting.custom', 'setRipple', in_sig='yyyd')

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -1015,6 +1015,39 @@ class RazerDevice(DBusService):
 
             mode_file.write(bytes([mode_id, param]))
 
+    def _set_custom_effect(self):
+        """
+        Set the device to use custom LED matrix
+        """
+        # self.logger.debug("DBus call _set_custom_effect")
+
+        driver_path = self.get_driver_path('matrix_effect_custom')
+
+        payload = b'1'
+
+        with open(driver_path, 'wb') as driver_file:
+            driver_file.write(payload)
+
+    def _set_key_row(self, payload):
+        """
+        Set the RGB matrix on the device
+
+        Byte array like
+        [1, 255, 255, 00, 255, 255, 00, 255, 255, 00, 255, 255, 00, 255, 255, 00, 255, 255, 00, 255, 255, 00, 255, 255, 00,
+            255, 255, 00, 255, 255, 00, 255, 255, 00, 255, 255, 00, 255, 255, 00, 255, 255, 00, 255, 00, 00]
+
+        First byte is row, on firefly its always 1, on keyboard its 0-5
+        Then its 3byte groups of RGB
+        :param payload: Binary payload
+        :type payload: bytes
+        """
+        # self.logger.debug("DBus call set_key_row")
+
+        driver_path = self.get_driver_path('matrix_custom_frame')
+
+        with open(driver_path, 'wb') as driver_file:
+            driver_file.write(payload)
+
     def get_vid_pid(self):
         """
         Get the usb VID PID

--- a/daemon/openrazer_daemon/misc/ripple_effect.py
+++ b/daemon/openrazer_daemon/misc/ripple_effect.py
@@ -206,13 +206,13 @@ class RippleManager(object):
         :param payload: Binary payload
         :type payload: bytes
         """
-        self._parent.setKeyRow(payload)
+        self._parent._set_key_row(payload)
 
     def refresh_keyboard(self):
         """
         Refresh the keyboard
         """
-        self._parent.setCustom()
+        self._parent._set_custom_effect()
 
     def notify(self, msg):
         """


### PR DESCRIPTION
The RippleManager needs to know when to stop itself and since this happens via the notify mechanism, we do need to tell the ripple to stop when someone wants to set a custom effect.

However we need to make sure to not stop when ripple is itself using the APIs, to make a 'private' version of setKeyRow and setCustom that doesn't have the notify code, and only add the notify to the public DBus-accessible function.

Fixes #1714

---
(note to myself: merge https://github.com/z3ntu/RazerGenie/commits/custom-effect-set-fix after this patch is merged)