### PR TITLE
Remove "None" effect for Basilisk V3

### DIFF
--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -1152,11 +1152,11 @@ class RazerBasiliskV3(__RazerDevice):
                'get_scroll_acceleration', 'set_scroll_acceleration',
                'get_scroll_smart_reel', 'set_scroll_smart_reel',
                # All LEDs (partial support)
-               'set_static_effect', 'set_wave_effect', 'set_spectrum_effect', 'set_none_effect',
+               'set_static_effect', 'set_wave_effect', 'set_spectrum_effect',
                # Logo (partial support)
-               'set_logo_wave', 'set_logo_static', 'set_logo_spectrum', 'set_logo_none',
+               'set_logo_wave', 'set_logo_static', 'set_logo_spectrum',
                # Scroll wheel (partial support)
-               'set_scroll_wave', 'set_scroll_static', 'set_scroll_spectrum', 'set_scroll_none',
+               'set_scroll_wave', 'set_scroll_static', 'set_scroll_spectrum',
                # Can set custom matrix effects
                'set_custom_effect', 'set_key_row']
 

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -737,7 +737,6 @@ static ssize_t razer_attr_write_matrix_effect_none(struct device *dev, struct de
     struct razer_report response = {0};
 
     switch (device->usb_pid) {
-    case USB_DEVICE_ID_RAZER_BASILISK_V3:
     case USB_DEVICE_ID_RAZER_COBRA_PRO:
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_WIRELESS:
@@ -3707,7 +3706,6 @@ static ssize_t razer_attr_write_matrix_effect_none_common(struct device *dev, st
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_WIRED:
     case USB_DEVICE_ID_RAZER_BASILISK_V2:
-    case USB_DEVICE_ID_RAZER_BASILISK_V3:
     case USB_DEVICE_ID_RAZER_COBRA_PRO:
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_WIRELESS:
@@ -4812,19 +4810,16 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_wave);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_spectrum);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_static);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_none);
 
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_led_brightness);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_wave);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_spectrum);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_static);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
 
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_brightness);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_wave);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_spectrum);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_static);
-            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_none);
 
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_custom);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_custom_frame);
@@ -5742,19 +5737,16 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
             device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_wave);
             device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_spectrum);
             device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_static);
-            device_remove_file(&hdev->dev, &dev_attr_logo_matrix_effect_none);
 
             device_remove_file(&hdev->dev, &dev_attr_scroll_led_brightness);
             device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_wave);
             device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_spectrum);
             device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_static);
-            device_remove_file(&hdev->dev, &dev_attr_scroll_matrix_effect_none);
 
             device_remove_file(&hdev->dev, &dev_attr_matrix_brightness);
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_wave);
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_spectrum);
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_static);
-            device_remove_file(&hdev->dev, &dev_attr_matrix_effect_none);
 
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_custom);
             device_remove_file(&hdev->dev, &dev_attr_matrix_custom_frame);

--- a/pylib/openrazer/_fake_driver/razerbasiliskv3.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskv3.cfg
@@ -10,21 +10,18 @@ files = rw,device_mode,0x0000
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,logo_led_brightness,0
-        w,logo_matrix_effect_none
         w,logo_matrix_effect_spectrum
         w,logo_matrix_effect_static
         w,logo_matrix_effect_wave
         rw,matrix_brightness,0
         w,matrix_custom_frame
         w,matrix_effect_custom
-        w,matrix_effect_none
         w,matrix_effect_spectrum
         w,matrix_effect_static
         w,matrix_effect_wave
         rw,poll_rate,500
         rw,scroll_acceleration,0
         rw,scroll_led_brightness,0
-        w,scroll_matrix_effect_none
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave


### PR DESCRIPTION
Setting the "None" effect causes this mouse to enter a buggy state. If the computer was rebooted while the "None" is set, the mouse won't be detected again until it is physically replugged.

Some users found that a firmware update solved it, while others reported a factory reset (on Synapse) works. Ultimately, the firmware is stable when none of the "None" effects are set.

Better to prevent this situation from happening by removing the effect.

Fixes #2049
Addresses #1767, #1844