### PR TITLE
Remove timestamp from manpages

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -26,6 +26,6 @@ ubuntu_install: purge_pycache manpages install-resources
 
 manpages:
 	@install -m 644 -D -v resources/man/razer.conf.5 $(DESTDIR)$(PREFIX)/share/man/man5/razer.conf.5
-	@gzip $(DESTDIR)$(PREFIX)/share/man/man5/razer.conf.5
+	@gzip -n $(DESTDIR)$(PREFIX)/share/man/man5/razer.conf.5
 	@install -m 644 -D -v resources/man/openrazer-daemon.8 $(DESTDIR)$(PREFIX)/share/man/man8/openrazer-daemon.8
-	@gzip $(DESTDIR)$(PREFIX)/share/man/man8/openrazer-daemon.8
+	@gzip -n $(DESTDIR)$(PREFIX)/share/man/man8/openrazer-daemon.8


### PR DESCRIPTION
`openrazer-daemon` [is not reproducible in Arch Linux](https://reproducible.archlinux.org/api/v0/builds/534888/diffoscope) because the build time gets appended in the header of the compressed manpages. The package in Debian is reproducible because strip-nondeterminism is run by default.

The [recommended solution](https://wiki.debian.org/ReproducibleBuilds/TimestampsInGzipHeaders) is to pass `-n` or `--no-name` to `gzip`. This PR just does that, no other changes.

