### PR TITLE
Add 8k option for hyperpolling dongle

### DIFF
--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -1624,7 +1624,7 @@ class RazerHyperPollingWirelessDongle(__RazerDevice):
                'get_battery', 'is_charging', 'get_idle_time', 'set_idle_time', 'set_low_battery_threshold',
                'set_hyperpolling_wireless_dongle_indicator_led_mode', 'set_hyperpolling_wireless_dongle_pair', 'set_hyperpolling_wireless_dongle_unpair']
 
-    POLL_RATES = [125, 500, 1000, 2000, 4000]
+    POLL_RATES = [125, 500, 1000, 2000, 4000, 8000]
 
     DEVICE_IMAGE = "https://dl.razerzone.com/src/6141/6141-1-en-v1.png"  # HyperPolling Wireless Dongle
 


### PR DESCRIPTION
Razer ["unlocked" 8k](https://mysupport.razer.com/app/answers/detail/a_id/6140/~/razer-hyperpolling-wireless-dongle-%7C-rc30-04410-support-%26-faqs) as an option for the hyperpolling dongle. A simple change to add that option. I've tested it with a Viper v2 pro and evhz, which confirmed the change taking affect.

~~My current concern is whether it needs to check for an updated firmware or not, as I updated my mouse before testing.~~