### PR TITLE
Fix persistence for devices with UNKWN00000000xxxx serial number

### DIFF
--- a/daemon/openrazer_daemon/daemon.py
+++ b/daemon/openrazer_daemon/daemon.py
@@ -90,6 +90,9 @@ class RazerDaemon(DBusService):
         self._persistence.status = {"changed": False}
         self.read_persistence(persistence_file)
 
+        # map of vid+pid to counter for serial numbers for unknown devices
+        self._unknown_serial_counter: dict[tuple[int, int], int] = {}
+
         # Check for plugdev group
         if not self._check_plugdev_group():
             self.logger.critical("User is not a member of the plugdev group")
@@ -492,7 +495,8 @@ class RazerDaemon(DBusService):
                     razer_device = device_class(device_path=sys_path, device_number=device_number, config=self._config,
                                                 persistence=self._persistence, testing=self._test_dir is not None,
                                                 additional_interfaces=sorted(additional_interfaces),
-                                                additional_methods=[])
+                                                additional_methods=[],
+                                                unknown_serial_counter=self._unknown_serial_counter)
 
                     # Wireless devices sometimes don't listen
                     count = 0
@@ -530,7 +534,8 @@ class RazerDaemon(DBusService):
                 self.logger.info('Found valid device.%d: %s', device_number, sys_name)
                 razer_device = device_class(device_path=sys_path, device_number=device_number, config=self._config,
                                             persistence=self._persistence, testing=self._test_dir is not None,
-                                            additional_interfaces=None, additional_methods=[])
+                                            additional_interfaces=None, additional_methods=[],
+                                            unknown_serial_counter=self._unknown_serial_counter)
 
                 # Its a udev event so currently the device hasn't been chmodded yet
                 time.sleep(0.2)

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -11,7 +11,6 @@ import inspect
 import logging
 import time
 import json
-import random
 
 from openrazer_daemon.dbus_services.service import DBusService
 import openrazer_daemon.dbus_services.dbus_methods
@@ -47,13 +46,16 @@ class RazerDevice(DBusService):
 
     DEVICE_IMAGE = None
 
-    def __init__(self, device_path, device_number, config, persistence, testing, additional_interfaces, additional_methods):
+    def __init__(self, device_path, device_number, config, persistence, testing, additional_interfaces, additional_methods, unknown_serial_counter):
 
         self.logger = logging.getLogger('razer.device{0}'.format(device_number))
         self.logger.info("Initialising device.%d %s", device_number, self.__class__.__name__)
 
         # Serial cache
         self._serial = None
+
+        # map of vid+pid to counter for serial numbers for unknown devices
+        self._unknown_serial_counter: dict[tuple[int, int], int] = unknown_serial_counter
 
         # Local storage key name
         self.storage_name = "UnknownDevice"
@@ -986,9 +988,12 @@ class RazerDevice(DBusService):
             # - "As printed in the D cover"
             # - hex: 01 01 01 01 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16
             if not re.fullmatch(r"[A-Z]+[\dA-Z]+", serial):
-                self.logger.warning("Invalid serial number found, using a random one.")
+                self.logger.warning("Invalid serial number found, using a generated one.")
                 self.logger.warning("Original value: %s" % serial)
-                serial = 'UNKWN{0:012}'.format(random.randint(0, 4096))
+                vid, pid = self.get_vid_pid()
+                idx = self._unknown_serial_counter.get((vid, pid), 0)
+                self._unknown_serial_counter[(vid, pid)] = idx + 1
+                serial = "UNKNOWN_{0:04X}{1:04X}_{2:04d}".format(vid, pid, idx)
 
             self._serial = serial.replace(' ', '_')
 


### PR DESCRIPTION
- Replace randomly generated (UNKWN00000000xxxx) serial number for unknown devices (Default string, etc.) with a serial number generated by the unique device ID in the last element of the device path.  This way the device will always get the same (unique) serial number and persistence will work correctly.
- Original version worked fine, but since serial number was randomly generated on each startup, persistence did not work and the `persistence.conf` file fills up with settings from all the randomly generated serial numbers over time.

### ToDo:
- [x] Modify to use USB VID/PID to generate ID for unknown devices.  Serial number may not be consistent over reboots for some devices.  Add 1 character sequence number to account for multiple instances of the same device.
    - Ex:  `UNKNOWN1532001A` for `1532:001A`