### PR TITLE
Add `persistence_dual_boot_quirk` to razer.conf

### DIFF
--- a/daemon/openrazer_daemon/daemon.py
+++ b/daemon/openrazer_daemon/daemon.py
@@ -283,6 +283,7 @@ class RazerDaemon(DBusService):
             'sync_effects_enabled': True,
             'devices_off_on_screensaver': True,
             'restore_persistence': True,
+            'persistence_dual_boot_quirk': False,
         }
 
         if config_file is not None and os.path.exists(config_file):

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -326,6 +326,11 @@ class RazerDevice(DBusService):
         if self.config.getboolean('Startup', "restore_persistence") is True:
             self.restore_effect()
 
+            # Some devices need setting a second time after encountering Razer Synapse on Windows
+            if self.config.getboolean('Startup', "persistence_dual_boot_quirk") is True:
+                self.logger.debug("Restoring effect persistence again (dual boot quirk)")
+                self.restore_effect()
+
     def send_effect_event(self, effect_name, *args):
         """
         Send effect event

--- a/daemon/resources/man/razer.conf.5
+++ b/daemon/resources/man/razer.conf.5
@@ -66,6 +66,11 @@ This flag specifies what battery percentage the device should reach before sendi
 This flag specifies whether effects saved in persistence.\&conf should be applied when the daemon starts.\&
 .PP
 .RE
+\fBpersistence_dual_boot_quirk\fR \fIbool\fR
+.RS 4
+This flag specifies whether the persisted effect is applied twice to address a quirk with newer devices that were last changed by Razer Synapse on Windows.\& Only applicable with restore_persistence = True.\&
+.PP
+.RE
 .SH SEE ALSO
 .PP
 \fBopenrazer-daemon\fR(8)

--- a/daemon/resources/man/razer.conf.5.scd
+++ b/daemon/resources/man/razer.conf.5.scd
@@ -45,6 +45,9 @@ The *[Startup]* section in the configuration file contains values to be used dur
 *restore_persistence* _bool_
 	This flag specifies whether effects saved in persistence.conf should be applied when the daemon starts.
 
+*persistence_dual_boot_quirk* _bool_
+	This flag specifies whether the persisted effect is applied twice to address a quirk with newer devices that were last changed by Razer Synapse on Windows. Only applicable with restore_persistence = True.
+
 # SEE ALSO
 
 *openrazer-daemon*(8)

--- a/daemon/resources/razer.conf
+++ b/daemon/resources/razer.conf
@@ -21,3 +21,6 @@ battery_notifier_percent = 33
 
 # Apply effects saved to disk when daemon starts
 restore_persistence = False
+
+# Enable this if you dual boot with Windows and the effect isn't restored. Requires restore_persistence = True
+persistence_dual_boot_quirk = False


### PR DESCRIPTION
It seems a handful of newer devices' have quirky firmware behaviour after having an encounter with Razer Synapse (for users dual booting with Windows) when restoring the persisted effect. Even though we send the request and got no error, the device physically didn't change its lighting, but it'll work by sending a second time.

Up to now, the user needs to go into a frontend to manually re-apply their effect. Should they run into this scenario, they can now turn this option on for a quality of life _"now it just works!"_.

Fixes #1807 (Basilisk V3)
Fixes #2066 (Huntsman V2 TKL)

This is an opt-in setting, since not all hardware will want `restore_effect()` twice -- for instance, the older era of hardware have a nice fade effect, and wireless devices risk timeout errors.

