### PR TITLE
Replace notify2 dependency used in battery notifier

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,7 +107,7 @@ set your PYTHONPATH so you can run from sources.
 For Debian/Ubuntu install the following packages to be able to run the daemon:
 
 ```
-apt-get install -y python3 python3-daemonize python3-dbus python3-gi python3-notify2 python3-numpy python3-pyudev python3-setproctitle
+apt-get install -y libnotify-bin python3 python3-daemonize python3-dbus python3-gi python3-numpy python3-pyudev python3-setproctitle
 ```
 
 #### RedHat/Fedora
@@ -115,7 +115,7 @@ apt-get install -y python3 python3-daemonize python3-dbus python3-gi python3-not
 For RedHat/Fedora install the following packages to be able to run the daemon:
 
 ```
-dnf install -y python3 python3-daemonize python3-dbus python3-notify2 python3-numpy python3-pyudev python3-setproctitle
+dnf install -y libnotify python3 python3-daemonize python3-dbus python3-numpy python3-pyudev python3-setproctitle
 ```
 
 #### Test the daemon

--- a/debian/control
+++ b/debian/control
@@ -65,9 +65,9 @@ Depends: ${misc:Depends},
          python3-gi,
          python3-pyudev,
          python3-setproctitle,
-         python3-notify2,
          python3-daemonize (>= 2.4.0),
          gir1.2-glib-2.0,
+         libnotify-bin,
          xautomation,
          dbus-session-bus
 Recommends: python3-openrazer (= ${binary:Version})


### PR DESCRIPTION
The website https://notify2.readthedocs.io/en/latest/ states "notify2 is deprecated". Furthermore there seems to be a race condition during startup if the notification dbus service is not yet available which can happen during login when everything is starting up.

Replace the code, as suggested by notify2 docs by just simply calling notify-send (from libnotify package) to achieve the same functionality.

Fixes #2280