### PR TITLE
Fix Razer BlackWidow V4 75% Fn+KEY combinations not working

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -192,6 +192,20 @@ static const struct razer_key_translation chroma_keys_5[] = {
     { 0 }
 };
 
+// Razer BlackWidow V4 75%
+static const struct razer_key_translation chroma_keys_6[] = {
+    { KEY_F9, RAZER_MACRO_KEY },
+    { KEY_F10, RAZER_GAME_KEY },
+    { KEY_F11, RAZER_BRIGHTNESS_DOWN },
+    { KEY_F12, RAZER_BRIGHTNESS_UP },
+    { KEY_P, KEY_SYSRQ },
+    { KEY_PAGEUP, KEY_HOME },
+    { KEY_PAGEDOWN, KEY_END },
+    { KEY_INSERT, KEY_PAUSE },
+    { KEY_DELETE, KEY_SLEEP },
+    { 0 }
+};
+
 /**
  * Essentially search through the struct array above.
  */
@@ -3426,7 +3440,6 @@ static int razer_event(struct hid_device *hdev, struct hid_field *field, struct 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_X:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_PRO:
-    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_75PCT:
     case USB_DEVICE_ID_RAZER_HUNTSMAN_V2:
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2:
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRED:
@@ -3435,6 +3448,10 @@ static int razer_event(struct hid_device *hdev, struct hid_field *field, struct 
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRELESS:
     case USB_DEVICE_ID_RAZER_ORNATA_V3_TENKEYLESS:
         translation = find_translation(chroma_keys_5, usage->code);
+        break;
+
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_75PCT:
+        translation = find_translation(chroma_keys_6, usage->code);
         break;
 
     default:


### PR DESCRIPTION
Fixes #2299 

When adding support by observing other commits, I missed Fn keys and used the same translation map as other keyboards.

This pull request fixes that by adding another key translation map, dedicated to the BlackWidow V4 75%.

Everything should work but there are still some cases I haven't been able to test, Brightness+/- works regardless of loaded driver. Macros are too confusing to test. Pause doesn't show up as anything in evtest, so not sure about this one.