### PR TITLE
pylib: Use PREFIX for installing Python modules

### DIFF
--- a/pylib/Makefile
+++ b/pylib/Makefile
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 DESTDIR?=/
+PREFIX?=/usr
 
 purge_pycache:
 	@find -name '__pycache__' | xargs rm -rf
 
 install: purge_pycache
-	python3 setup.py install --prefix=/usr --root=$(DESTDIR)
+	python3 setup.py install --prefix=$(PREFIX) --root=$(DESTDIR)
 
 ubuntu_install: purge_pycache
-	python3 setup.py install --prefix=/usr --root=$(DESTDIR) --no-compile --install-layout=deb
+	python3 setup.py install --prefix=$(PREFIX) --root=$(DESTDIR) --no-compile --install-layout=deb


### PR DESCRIPTION
While this was already done for the daemon in 2017 in 7ff65b59 ("Respect $PREFIX when installing the daemon"), it's now time to do it for pylib as well.

@lah7 Any concerns? Code looks the same as in `daemon/Makefile` and I can't think of a reason pylib should ignore PREFIX. I guess just an oversight (and nobody cared so far)