### PR TITLE
Fix for Blackwidow V4 Pro causing kernel panic

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -3708,10 +3708,7 @@ static int razer_raw_event_bitfield(struct hid_device *hdev, struct razer_kbd_de
             // data of size 22 starting with 0x01 is a bit field so we need to handle that separately
             if (size == 22) {
                 if (write_bitfield) {
-                    if (cur_value < (sizeof(bitfield) * BITS_PER_BYTE)) {
-                        // value fits the bit field, so we can use that
-                        set_bit(cur_value, (unsigned long*) bitfield);
-                    } else {
+                    if (cur_value >= sizeof(bitfield) * BITS_PER_BYTE) {
                         // value does not fit the bit field, so we need extra handling
                         int report_extra = 1;
 


### PR DESCRIPTION
Using macro, side, or left hand roller button with the Blackwidow V4 Pro can cause a kernel panic. Removing the branch that allows for bit setting within `razer_raw_event_bitfield` without any kind of filter, stops this from happening.

When testing, everything else works on the Blackwidow V4 Pro - volume, and media buttons. Left hand buttons seem to work most of the time (a problem for another day), but way better than kernel panics.

Closes #2377

Note: First time writing a kernel driver, and also first time working on this code base. This worked _for me_, but please let me know if I'm breaking something I shouldn't be.