### PR TITLE
driver: Replace now removed hrtimer_init function with hrtimer_setup (Fixes builds with Kernel 6.15)

### DIFF
--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -4938,8 +4938,12 @@ static void razer_mouse_init(struct razer_mouse_device *dev, struct usb_interfac
     dev->da3_5g.poll = 1; // Poll rate 1000
 
     // Setup tilt wheel HWHEEL emulation
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+    hrtimer_setup(&dev->repeat_timer, wheel_tilt_repeat, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+#else
     hrtimer_init(&dev->repeat_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
     dev->repeat_timer.function = wheel_tilt_repeat;
+#endif
     dev->tilt_hwheel = 1;
     dev->tilt_repeat_delay = 250;
     dev->tilt_repeat = 33;


### PR DESCRIPTION
This fixes compilation on Kernel 6.15 (rc builds at the moment)

From my brief poking around:
hrtimer_init was deprecated in favour of  hrtimer_setup when it was added in Kernel 6.13. It is now removed as of Kernel 6.15. 

This commit ifdef's the new function for Kernel 6.13+ and keeps the original code for older kernels.

For context see: https://github.com/torvalds/linux/commit/908a1d775422ba2e27a5e33d0c130b522419e121 and https://github.com/torvalds/linux/commit/9779489a31d77a7b9cb6f20d2d2caced4e29dbe6

From my local testing on 6.15 I am not seeing any differences in behaviour but some testing on other kernel versions is a good idea, luckily the change is a relatively small one.