### PR TITLE
Apply driver mode to fix scroll click for Basilisk V3 X HyperSpeed

### DIFF
--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -1923,6 +1923,7 @@ class RazerBasiliskV3XHyperSpeed(__RazerDevice):
                'set_scroll_wave', 'set_scroll_static', 'set_scroll_spectrum', 'set_scroll_none', 'set_scroll_reactive', 'set_scroll_breath_random', 'set_scroll_breath_single', 'set_scroll_breath_dual']
 
     DEVICE_IMAGE = "https://dl.razerzone.com/src2/9766/9766-1-en-v1.png"
+    DRIVER_MODE = True
 
     DPI_MAX = 18000
 


### PR DESCRIPTION
After changes in #2416 are merged, **Basilisk V3 X HyperSpeed** could be the first mouse to use driver mode, since it apparently fixes the middle scroll click not registering at all.  _Weird, you'd think a 'standard' mouse would!?_

It might be a specific firmware version problem. Not sure.

Fixes #2428
Fixes #2454

Requires rebasing after #2416 is in master.