### PR TITLE
added BW Ultimate 2012 to chroma_keys_2 in razer_event()

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -3445,6 +3445,7 @@ static int razer_event(struct hid_device *hdev, struct hid_field *field, struct 
     }
 
     switch (device->usb_pid) {
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2012:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_STEALTH_EDITION:
         translation = find_translation(chroma_keys_2, usage->code);
         break;


### PR DESCRIPTION
BlackWidow Ultimate 2012 used the default chroma_keys case, which is the wrong type as chroma_keys_2 is the right one.