### PR TITLE
daemon: Add dpi notifications

### DIFF
--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -1098,7 +1098,7 @@ class RazerDevice(DBusService):
         """
         Initializes the DpiManager using the provided name
         """
-        self._dpi_manager = _DpiManager(self, self._device_number, self.getDeviceName()) # pylint: disable=no-member
+        self._dpi_manager = _DpiManager(self, self._device_number, self.getDeviceName())  # pylint: disable=no-member
         self._dpi_manager.active = self.config.getboolean('Startup', 'dpi_notifier', fallback=False)
 
     def get_vid_pid(self):

--- a/daemon/openrazer_daemon/misc/battery_notifier.py
+++ b/daemon/openrazer_daemon/misc/battery_notifier.py
@@ -113,7 +113,7 @@ class BatteryNotifier(threading.Thread):
 
 class BatteryManager(object):
     """
-    Class which manages the overall process of notifing battery levels
+    Class which manages the overall process of notifying battery levels
     """
 
     def __init__(self, parent, device_number, device_name):

--- a/daemon/openrazer_daemon/misc/dpi_notifier.py
+++ b/daemon/openrazer_daemon/misc/dpi_notifier.py
@@ -115,4 +115,3 @@ class DpiManager:
             self._dpi_thread.event.set()
         else:
             self._dpi_thread.event.clear()
-

--- a/daemon/openrazer_daemon/misc/dpi_notifier.py
+++ b/daemon/openrazer_daemon/misc/dpi_notifier.py
@@ -54,17 +54,6 @@ class DpiNotifier(threading.Thread):
 
         self._last_dpi = dpi
 
-        # Sometimes due to various issues we don't get the percentage correctly.
-        # Just ignore them and don't show a bogus notification.
-        # See also: https://github.com/openrazer/openrazer/issues/2122
-        # if battery_level in (0.0, -1.0):
-        #     self._logger.debug("Got bogus battery value: {0}, ignoring.".format(battery_level))
-        #     # Since we don't update _last_notify_time here we're going to retry very soon again.
-        #     # Sleep a bit so we don't spam the device with requests.
-        #     time.sleep(10)
-        #     return
-        # Update the last notified time so that we alert in the configured frequency.
-
         title = self._device_name
         message = "DPI is {0}".format(dpi)
         self._logger.debug("{0} DPI at {1}".format(self._device_name, dpi))
@@ -87,7 +76,7 @@ class DpiNotifier(threading.Thread):
 
 class DpiManager:
     """
-    Class which manages the overall process of notifing battery levels
+    Manages the overall process of notifying dpi changes
     """
 
     def __init__(self, parent, device_number, device_name):

--- a/daemon/openrazer_daemon/misc/dpi_notifier.py
+++ b/daemon/openrazer_daemon/misc/dpi_notifier.py
@@ -1,0 +1,129 @@
+import logging
+import threading
+import datetime
+import time
+import subprocess
+
+
+class DpiNotifier(threading.Thread):
+    """
+    Thread to notify about dpi changes
+    """
+
+    def __init__(self, parent, device_id, device_name):
+        super().__init__()
+        self._logger = logging.getLogger('razer.device{0}.dpinotifier'.format(device_id))
+
+        self.event = threading.Event()
+
+        self._shutdown = False
+        self._device_name = device_name
+
+        self._get_dpi_xy_func = parent.getDPI
+        self._last_dpi = self._get_dpi_xy_func()
+        self._last_notify_time = datetime.datetime(1970, 1, 1)
+
+    @property
+    def shutdown(self):
+        """
+        Get the shutdown flag
+        """
+        return self._shutdown
+
+    @shutdown.setter
+    def shutdown(self, value):
+        """
+        Set the shutdown flag
+
+        :param value: Shutdown
+        :type value: bool
+        """
+        self._shutdown = value
+
+    def show_notification(self, summary: str, message: str) -> None:
+        try:
+            subprocess.run(["notify-send", "-a", "OpenRazer", "-t", "4000", summary, message],
+                           check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        except subprocess.CalledProcessError as e:
+            self._logger.warning(f"Failed to show notification: {e.output.strip()}")
+
+    def notify_dpi(self):
+        dpi = self._get_dpi_xy_func()
+        if dpi == self._last_dpi:
+            return
+
+        self._last_dpi = dpi
+
+        # Sometimes due to various issues we don't get the percentage correctly.
+        # Just ignore them and don't show a bogus notification.
+        # See also: https://github.com/openrazer/openrazer/issues/2122
+        # if battery_level in (0.0, -1.0):
+        #     self._logger.debug("Got bogus battery value: {0}, ignoring.".format(battery_level))
+        #     # Since we don't update _last_notify_time here we're going to retry very soon again.
+        #     # Sleep a bit so we don't spam the device with requests.
+        #     time.sleep(10)
+        #     return
+        # Update the last notified time so that we alert in the configured frequency.
+
+        title = self._device_name
+        message = "DPI is {0}".format(dpi)
+        self._logger.debug("{0} DPI at {1}".format(self._device_name, dpi))
+
+        self.show_notification(summary=title, message=message)
+
+    def run(self):
+        """
+        Main thread function
+        """
+
+        while not self._shutdown:
+            if self.event.is_set():
+                self.notify_dpi()
+
+            time.sleep(0.1)
+
+        self._logger.debug("Shutting down dpi notifier")
+
+
+class DpiManager:
+    """
+    Class which manages the overall process of notifing battery levels
+    """
+
+    def __init__(self, parent, device_number, device_name):
+        self._logger = logging.getLogger('razer.device{0}.dpimanager'.format(device_number))
+        self._parent = parent
+
+        self._dpi_thread = DpiNotifier(parent, device_number, device_name)
+
+        self._dpi_thread.start()
+
+        self._is_closed = False
+
+    def close(self):
+        """
+        Close the manager, stop ripple thread
+        """
+        if not self._is_closed:
+            self._logger.debug("Closing Dpi Manager")
+            self._is_closed = True
+
+            self._dpi_thread.shutdown = True
+            self._dpi_thread.join(timeout=2)
+            if self._dpi_thread.is_alive():
+                self._logger.error("Could not stop DpiNotifier thread")
+
+    def __del__(self):
+        self.close()
+
+    @property
+    def active(self):
+        return self._dpi_thread.event.is_set()
+
+    @active.setter
+    def active(self, value):
+        if value:
+            self._dpi_thread.event.set()
+        else:
+            self._dpi_thread.event.clear()
+

--- a/daemon/resources/razer.conf
+++ b/daemon/resources/razer.conf
@@ -19,6 +19,9 @@ battery_notifier_freq = 600
 # Battery notifications appear when device reaches this percentage
 battery_notifier_percent = 33
 
+# DPI notifier
+dpi_notifier = True
+
 # Apply effects saved to disk when daemon starts
 restore_persistence = False
 


### PR DESCRIPTION
This is an attempt to copy the current behavior of Razer Synapse in Windows when you change your DPI:
<img width="371" height="165" alt="dpi-down" src="https://github.com/user-attachments/assets/f78f361a-9d45-4019-b39f-887bf870f5a0" />
<img width="365" height="158" alt="dpi-up" src="https://github.com/user-attachments/assets/8f34eea2-ab0b-48bd-83bc-07e23983f0c6" />

Example of the behavior of this implementation:
<img width="313" height="108" alt="image" src="https://github.com/user-attachments/assets/081326b5-fc5c-435b-98da-b386cfeeb003" />

I basically copied the implementation of `BatteryManager` and `BatteryNotifier` so this was a quick draft. It would be awesome to get some input on this.
