### PR TITLE
Remove 'defaults' for transaction ID

### DIFF
--- a/driver/razeraccessory_driver.c
+++ b/driver/razeraccessory_driver.c
@@ -1068,9 +1068,29 @@ static ssize_t razer_attr_read_firmware_version(struct device *dev, struct devic
         request.transaction_id.id = 0x1F;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_FIREFLY_HYPERFLUX:
+    case USB_DEVICE_ID_RAZER_MOUSE_DOCK:
+    case USB_DEVICE_ID_RAZER_CORE:
+    case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+    case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+    case USB_DEVICE_ID_RAZER_FIREFLY:
+    case USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA:
+    case USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA_EXTENDED:
+    case USB_DEVICE_ID_RAZER_FIREFLY_V2:
+    case USB_DEVICE_ID_RAZER_STRIDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA_3XL:
+    case USB_DEVICE_ID_RAZER_FIREFLY_V2_PRO:
+    case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+    case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+    case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+    case USB_DEVICE_ID_RAZER_RAPTOR_27:
+    case USB_DEVICE_ID_RAZER_CHROMA_ADDRESSABLE_RGB_CONTROLLER:
         request.transaction_id.id = 0x3F;
         break;
+
+    default:
+        printk(KERN_WARNING "razeraccessory: Unknown device\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1106,9 +1126,29 @@ static ssize_t razer_attr_write_device_mode(struct device *dev, struct device_at
         request.transaction_id.id = 0x1F;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_FIREFLY_HYPERFLUX:
+    case USB_DEVICE_ID_RAZER_MOUSE_DOCK:
+    case USB_DEVICE_ID_RAZER_CORE:
+    case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+    case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+    case USB_DEVICE_ID_RAZER_FIREFLY:
+    case USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA:
+    case USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA_EXTENDED:
+    case USB_DEVICE_ID_RAZER_FIREFLY_V2:
+    case USB_DEVICE_ID_RAZER_STRIDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA_3XL:
+    case USB_DEVICE_ID_RAZER_FIREFLY_V2_PRO:
+    case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+    case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+    case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+    case USB_DEVICE_ID_RAZER_RAPTOR_27:
+    case USB_DEVICE_ID_RAZER_CHROMA_ADDRESSABLE_RGB_CONTROLLER:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razeraccessory: Unknown device\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1155,9 +1195,29 @@ static ssize_t razer_attr_read_device_mode(struct device *dev, struct device_att
         request.transaction_id.id = 0x1F;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_FIREFLY_HYPERFLUX:
+    case USB_DEVICE_ID_RAZER_MOUSE_DOCK:
+    case USB_DEVICE_ID_RAZER_CORE:
+    case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+    case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+    case USB_DEVICE_ID_RAZER_FIREFLY:
+    case USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA:
+    case USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA_EXTENDED:
+    case USB_DEVICE_ID_RAZER_FIREFLY_V2:
+    case USB_DEVICE_ID_RAZER_STRIDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA_3XL:
+    case USB_DEVICE_ID_RAZER_FIREFLY_V2_PRO:
+    case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+    case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+    case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+    case USB_DEVICE_ID_RAZER_RAPTOR_27:
+    case USB_DEVICE_ID_RAZER_CHROMA_ADDRESSABLE_RGB_CONTROLLER:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razeraccessory: Unknown device\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1310,12 +1370,24 @@ static ssize_t razer_attr_read_matrix_brightness(struct device *dev, struct devi
         brightness = sum / 6;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_CORE:
+    case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
+    case USB_DEVICE_ID_RAZER_NOMMO_PRO:
+    case USB_DEVICE_ID_RAZER_FIREFLY:
+    case USB_DEVICE_ID_RAZER_CHROMA_MUG:
+    case USB_DEVICE_ID_RAZER_CHROMA_BASE:
+    case USB_DEVICE_ID_RAZER_CHROMA_HDK:
+    case USB_DEVICE_ID_RAZER_LAPTOP_STAND_CHROMA:
+    case USB_DEVICE_ID_RAZER_CORE_X_CHROMA:
         request = razer_chroma_standard_get_led_brightness(VARSTORE, BACKLIGHT_LED);
         request.transaction_id.id = 0xFF;
         razer_send_payload(device, &request, &response);
         brightness = response.arguments[2];
         break;
+
+    default:
+        printk(KERN_WARNING "razeraccessory: Unknown device\n");
+        return -EINVAL;
     }
 
     return sprintf(buf, "%d\n", brightness);
@@ -1365,8 +1437,6 @@ static ssize_t razer_attr_write_set_charge_brightness(struct device *dev, struct
 static ssize_t razer_attr_read_set_charge_brightness(struct device *dev, struct device_attribute *attr, char *buf, int led)
 {
     struct razer_accessory_device *device = dev_get_drvdata(dev);
-    struct razer_report request = {0};
-    struct razer_report response = {0};
     unsigned char brightness = 0;
 
     switch (device->usb_dev->descriptor.idProduct) {
@@ -1375,11 +1445,8 @@ static ssize_t razer_attr_read_set_charge_brightness(struct device *dev, struct 
         break;
 
     default:
-        request = razer_chroma_standard_get_led_brightness(VARSTORE, led);
-        request.transaction_id.id = 0xFF;
-        razer_send_payload(device, &request, &response);
-        brightness = response.arguments[2];
-        break;
+        printk(KERN_WARNING "razeraccessory: Unknown device\n");
+        return -EINVAL;
     }
 
     return sprintf(buf, "%d\n", brightness);

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -484,6 +484,7 @@ static void razer_set_device_mode(struct razer_kbd_device *device, unsigned char
     case USB_DEVICE_ID_RAZER_CYNOSA_LITE:
         request.transaction_id.id = 0x3F;
         break;
+
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_ELITE:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_MINI:
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2:
@@ -500,15 +501,104 @@ static void razer_set_device_mode(struct razer_kbd_device *device, unsigned char
     case USB_DEVICE_ID_RAZER_ORNATA_V3_TENKEYLESS:
         request.transaction_id.id = 0x1F;
         break;
+
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_MINI_WIRELESS:
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRELESS:
         request.transaction_id.id = 0x9F;
         break;
-    default:
+
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2012:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_STEALTH_EDITION:
+    case USB_DEVICE_ID_RAZER_ANANSI:
+    case USB_DEVICE_ID_RAZER_NOSTROMO:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2013:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_STEALTH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_TE_2014:
+    case USB_DEVICE_ID_RAZER_TARTARUS:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_EXPERT:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_QHD:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_ELITE:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN:
+    case USB_DEVICE_ID_RAZER_TARTARUS_V2:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017_FULLHD:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_2018:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_2019:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_ADV_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_EARLY_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2020:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_CYNOSA_V2:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V2_ANALOG:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2020_BASE:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI_JP:
+    case USB_DEVICE_ID_RAZER_BOOK_2020:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V2_TENKEYLESS:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V2:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_BASE_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_BASE_2022:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI_ANALOG:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_17_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_15_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2023:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V3_PRO:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2025:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_TK:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: device_mode not supported for this model\n");
+        return;
     }
 
     razer_send_payload(device, &request, &response);
@@ -533,18 +623,21 @@ static ssize_t razer_attr_read_charge_level(struct device *dev, struct device_at
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRED:
         request.transaction_id.id = 0x1f;
         break;
+
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_MINI_WIRELESS:
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRELESS:
         request.transaction_id.id = 0x9f;
         break;
+
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRED:
         request.transaction_id.id = 0x3f;
         break;
+
     default:
-        request.transaction_id.id = 0xFF;
-        break;
+        printk(KERN_WARNING "razerkbd: charge_level not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -571,18 +664,21 @@ static ssize_t razer_attr_read_charge_status(struct device *dev, struct device_a
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRED:
         request.transaction_id.id = 0x1f;
         break;
+
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_MINI_WIRELESS:
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRELESS:
         request.transaction_id.id = 0x9f;
         break;
+
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRED:
         request.transaction_id.id = 0x3f;
         break;
+
     default:
-        request.transaction_id.id = 0xFF;
-        break;
+        printk(KERN_WARNING "razerkbd: charge_status not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -701,9 +797,71 @@ static ssize_t razer_attr_write_game_led_state(struct device *dev, struct device
         request = razer_chroma_standard_set_led_state(NOSTORE, GAME_LED, enabled);
         request.transaction_id.id = 0x1f;
         break;
-    default:
+
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2012:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_STEALTH_EDITION:
+    case USB_DEVICE_ID_RAZER_ANANSI:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2013:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_STEALTH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_TE_2014:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_EXPERT:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_ORNATA_CHROMA:
+    case USB_DEVICE_ID_RAZER_ORNATA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_ELITE:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ELITE:
+    case USB_DEVICE_ID_RAZER_CYNOSA_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_V2:
+    case USB_DEVICE_ID_RAZER_CYNOSA_CHROMA_PRO:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_LITE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_CYNOSA_LITE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_2019:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_TE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_MINI:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_ORNATA_V2:
+    case USB_DEVICE_ID_RAZER_CYNOSA_V2:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V2_ANALOG:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI_JP:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_MINI_WIRELESS:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI_ANALOG:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_PRO:
+    case USB_DEVICE_ID_RAZER_ORNATA_V3_ALT:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_X:
+    case USB_DEVICE_ID_RAZER_ORNATA_V3_X:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRED:
+    case USB_DEVICE_ID_RAZER_ORNATA_V3:
+    case USB_DEVICE_ID_RAZER_ORNATA_V3_X_ALT:
+    case USB_DEVICE_ID_RAZER_ORNATA_V3_TENKEYLESS:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_75PCT:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V3_PRO:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_TK:
         request = razer_chroma_standard_set_led_state(VARSTORE, GAME_LED, enabled);
         request.transaction_id.id = 0xFF;
+        break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: game_led_state not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -728,9 +886,71 @@ static ssize_t razer_attr_read_game_led_state(struct device *dev, struct device_
         request = razer_chroma_standard_get_led_state(NOSTORE, GAME_LED);
         request.transaction_id.id = 0x1f;
         break;
-    default:
+
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2012:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_STEALTH_EDITION:
+    case USB_DEVICE_ID_RAZER_ANANSI:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2013:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_STEALTH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_TE_2014:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_EXPERT:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_ORNATA_CHROMA:
+    case USB_DEVICE_ID_RAZER_ORNATA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_ELITE:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ELITE:
+    case USB_DEVICE_ID_RAZER_CYNOSA_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_V2:
+    case USB_DEVICE_ID_RAZER_CYNOSA_CHROMA_PRO:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_LITE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_CYNOSA_LITE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_2019:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_TE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_MINI:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_ORNATA_V2:
+    case USB_DEVICE_ID_RAZER_CYNOSA_V2:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V2_ANALOG:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI_JP:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_MINI_WIRELESS:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI_ANALOG:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_PRO:
+    case USB_DEVICE_ID_RAZER_ORNATA_V3_ALT:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_X:
+    case USB_DEVICE_ID_RAZER_ORNATA_V3_X:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRED:
+    case USB_DEVICE_ID_RAZER_ORNATA_V3:
+    case USB_DEVICE_ID_RAZER_ORNATA_V3_X_ALT:
+    case USB_DEVICE_ID_RAZER_ORNATA_V3_TENKEYLESS:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_75PCT:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V3_PRO:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_TK:
         request = razer_chroma_standard_get_led_state(VARSTORE, GAME_LED);
         request.transaction_id.id = 0xFF;
+        break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: game_led_state not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -758,8 +978,10 @@ static ssize_t razer_attr_write_keyswitch_optimization(struct device *dev, struc
         request.transaction_id.id = 0x1f;
         razer_send_payload(device, &request, &response);
         break;
+
     default:
-        return -ENOSYS;
+        printk(KERN_WARNING "razerkbd: keyswitch_optimization not supported for this model\n");
+        return -EINVAL;
     }
 
     return count;
@@ -781,10 +1003,10 @@ static ssize_t razer_attr_read_keyswitch_optimization(struct device *dev, struct
         request = razer_chroma_misc_get_keyswitch_optimization();
         request.transaction_id.id = 0x1f;
         break;
+
     default:
-        request = razer_chroma_misc_get_keyswitch_optimization();
-        request.transaction_id.id = 0xFF;
-        break;
+        printk(KERN_WARNING "razerkbd: keyswitch_optimization not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1356,10 +1578,41 @@ static ssize_t razer_attr_write_macro_led_effect(struct device *dev, struct devi
         request.transaction_id.id = 0xFF;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2012:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_STEALTH_EDITION:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2013:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_STEALTH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_TE_2014:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_EXPERT:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
+    case USB_DEVICE_ID_RAZER_CYNOSA_V2:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V2_ANALOG:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V2_TENKEYLESS:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V2:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_MINI_WIRELESS:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI_ANALOG:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRED:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V3_PRO:
         request = razer_chroma_standard_set_led_effect(VARSTORE, MACRO_LED, enabled);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: macro_led_effect not supported for this model\n");
+        return -EINVAL;
     }
     razer_send_payload(device, &request, &response);
 
@@ -1406,10 +1659,17 @@ static ssize_t razer_attr_write_matrix_effect_pulsate(struct device *dev, struct
         request.transaction_id.id = 0xFF;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_TARTARUS:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_EXPERT:
         request = razer_chroma_standard_set_led_effect(VARSTORE, BACKLIGHT_LED, CLASSIC_EFFECT_BREATHING);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: matrix_effect_pulsate not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1455,10 +1715,18 @@ static ssize_t razer_attr_read_profile_led_red(struct device *dev, struct device
         request = razer_chroma_standard_get_led_state(VARSTORE, BLUE_PROFILE_LED);
         request.transaction_id.id = 0xFF;
         break;
-    default:
+
+    case USB_DEVICE_ID_RAZER_NOSTROMO:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER:
+    case USB_DEVICE_ID_RAZER_TARTARUS:
+    case USB_DEVICE_ID_RAZER_TARTARUS_V2:
         request = razer_chroma_standard_get_led_state(VARSTORE, RED_PROFILE_LED);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: profile_led_red not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1483,10 +1751,18 @@ static ssize_t razer_attr_read_profile_led_green(struct device *dev, struct devi
         request = razer_chroma_standard_get_led_state(VARSTORE, RED_PROFILE_LED);
         request.transaction_id.id = 0xFF;
         break;
-    default:
+
+    case USB_DEVICE_ID_RAZER_NOSTROMO:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER:
+    case USB_DEVICE_ID_RAZER_TARTARUS:
+    case USB_DEVICE_ID_RAZER_TARTARUS_V2:
         request = razer_chroma_standard_get_led_state(VARSTORE, GREEN_PROFILE_LED);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: profile_led_green not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1511,10 +1787,18 @@ static ssize_t razer_attr_read_profile_led_blue(struct device *dev, struct devic
         request = razer_chroma_standard_get_led_state(VARSTORE, GREEN_PROFILE_LED);
         request.transaction_id.id = 0xFF;
         break;
-    default:
+
+    case USB_DEVICE_ID_RAZER_NOSTROMO:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER:
+    case USB_DEVICE_ID_RAZER_TARTARUS:
+    case USB_DEVICE_ID_RAZER_TARTARUS_V2:
         request = razer_chroma_standard_get_led_state(VARSTORE, BLUE_PROFILE_LED);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: profile_led_blue not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1538,10 +1822,18 @@ static ssize_t razer_attr_write_profile_led_red(struct device *dev, struct devic
         request = razer_chroma_standard_set_led_state(VARSTORE, BLUE_PROFILE_LED, enabled);
         request.transaction_id.id = 0xFF;
         break;
-    default:
+
+    case USB_DEVICE_ID_RAZER_NOSTROMO:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER:
+    case USB_DEVICE_ID_RAZER_TARTARUS:
+    case USB_DEVICE_ID_RAZER_TARTARUS_V2:
         request = razer_chroma_standard_set_led_state(VARSTORE, RED_PROFILE_LED, enabled);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: profile_led_red not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1565,10 +1857,18 @@ static ssize_t razer_attr_write_profile_led_green(struct device *dev, struct dev
         request = razer_chroma_standard_set_led_state(VARSTORE, RED_PROFILE_LED, enabled);
         request.transaction_id.id = 0xFF;
         break;
-    default:
+
+    case USB_DEVICE_ID_RAZER_NOSTROMO:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER:
+    case USB_DEVICE_ID_RAZER_TARTARUS:
+    case USB_DEVICE_ID_RAZER_TARTARUS_V2:
         request = razer_chroma_standard_set_led_state(VARSTORE, GREEN_PROFILE_LED, enabled);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: profile_led_green not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1591,10 +1891,18 @@ static ssize_t razer_attr_write_profile_led_blue(struct device *dev, struct devi
         request = razer_chroma_standard_set_led_state(VARSTORE, GREEN_PROFILE_LED, enabled);
         request.transaction_id.id = 0xFF;
         break;
-    default:
+
+    case USB_DEVICE_ID_RAZER_NOSTROMO:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER:
+    case USB_DEVICE_ID_RAZER_TARTARUS:
+    case USB_DEVICE_ID_RAZER_TARTARUS_V2:
         request = razer_chroma_standard_set_led_state(VARSTORE, BLUE_PROFILE_LED, enabled);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: profile_led_blue not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1726,10 +2034,69 @@ static ssize_t razer_attr_write_matrix_effect_none(struct device *dev, struct de
         request.transaction_id.id = 0x3F;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_QHD:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017_FULLHD:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_2018:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_ADV_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_EARLY_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BOOK_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_BASE_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_BASE_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_17_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_15_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2025:
         request = razer_chroma_standard_matrix_effect_none();
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: matrix_effect_none not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1814,10 +2181,56 @@ static ssize_t razer_attr_write_matrix_effect_wave(struct device *dev, struct de
         request.transaction_id.id = 0x9F;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_QHD:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017_FULLHD:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_2018:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_ADV_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_17_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_15_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2025:
         request = razer_chroma_standard_matrix_effect_wave(direction);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: matrix_effect_wave not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1938,10 +2351,66 @@ static ssize_t razer_attr_write_matrix_effect_spectrum(struct device *dev, struc
         request.transaction_id.id = 0x3F;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_QHD:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017_FULLHD:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_2018:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_ADV_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_EARLY_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BOOK_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_BASE_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_17_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_15_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2025:
         request = razer_chroma_standard_matrix_effect_spectrum();
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: matrix_effect_spectrum not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -2023,10 +2492,66 @@ static ssize_t razer_attr_write_matrix_effect_reactive(struct device *dev, struc
         request = razer_chroma_standard_matrix_effect_reactive(speed, (struct razer_rgb*)&buf[1]);
         request.transaction_id.id = 0x3F;
         break;
-    default:
+
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_QHD:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017_FULLHD:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_2018:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_ADV_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_EARLY_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BOOK_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_BASE_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_17_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_15_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2025:
         request = razer_chroma_standard_matrix_effect_reactive(speed, (struct razer_rgb*)&buf[1]);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: matrix_effect_reactive not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -2395,11 +2920,47 @@ static ssize_t razer_attr_write_matrix_effect_starlight(struct device *dev, stru
         }
         break;
 
-    default: // BW2016 can do normal starlight
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
+    case USB_DEVICE_ID_RAZER_BLADE_QHD:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017_FULLHD:
+    case USB_DEVICE_ID_RAZER_BLADE_2018:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_ADV_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_17_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_15_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2024:
         request = razer_chroma_standard_matrix_effect_starlight_single(0x01, &rgb1);
         request.transaction_id.id = 0xFF;
         razer_send_payload(device, &request, &response);
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: matrix_effect_starlight not supported for this model\n");
+        return -EINVAL;
     }
 
     return count;
@@ -2575,7 +3136,59 @@ static ssize_t razer_attr_write_matrix_effect_breath(struct device *dev, struct 
         }
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_QHD:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017_FULLHD:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_2018:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_ADV_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_EARLY_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BOOK_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_BASE_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_17_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_15_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2025:
         switch(count) {
         case 3: // Single colour mode
             request = razer_chroma_standard_matrix_effect_breathing_single((struct razer_rgb*)&buf[0]);
@@ -2597,6 +3210,10 @@ static ssize_t razer_attr_write_matrix_effect_breath(struct device *dev, struct 
             // TODO move default to case 1:. Then default: printk(warning). Also remove pointless buffer
         }
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: matrix_effect_breath not supported for this model\n");
+        return -EINVAL;
     }
 
     return count;
@@ -2752,10 +3369,56 @@ static ssize_t razer_attr_write_matrix_effect_custom(struct device *dev, struct 
         request.transaction_id.id = 0x3F;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_QHD:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017_FULLHD:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_2018:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_ADV_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_17_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_15_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2025:
         request = razer_chroma_standard_matrix_effect_custom_frame(NOSTORE);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: matrix_effect_custom not supported for this model\n");
+        return -EINVAL;
     }
 
     /* See comment in razer_attr_write_matrix_custom_frame for want_response */
@@ -2898,8 +3561,68 @@ static ssize_t razer_attr_write_matrix_brightness(struct device *dev, struct dev
         request.transaction_id.id = 0xFF;
         break;
 
+    case USB_DEVICE_ID_RAZER_ANANSI:
     case USB_DEVICE_ID_RAZER_NOSTROMO:
-    default:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_TARTARUS:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_EXPERT:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_QHD:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017_FULLHD:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_2018:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_ADV_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_EARLY_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BOOK_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_BASE_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_BASE_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_17_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_15_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2025:
         if (is_blade_laptop(device)) {
             request = razer_chroma_misc_set_blade_brightness(brightness);
         } else {
@@ -2907,6 +3630,10 @@ static ssize_t razer_attr_write_matrix_brightness(struct device *dev, struct dev
         }
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: matrix_brightness not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -2992,8 +3719,71 @@ static ssize_t razer_attr_read_matrix_brightness(struct device *dev, struct devi
         request.transaction_id.id = 0xFF;
         break;
 
+    case USB_DEVICE_ID_RAZER_ANANSI:
     case USB_DEVICE_ID_RAZER_NOSTROMO:
-    default:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_TARTARUS:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_EXPERT:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHSTALKER_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
+    case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
+    case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_QHD:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2017_FULLHD:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
+    case USB_DEVICE_ID_RAZER_BLADE_2018:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
+    case USB_DEVICE_ID_RAZER_BLADE_2019_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_ADV_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_EARLY_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BLADE_PRO_EARLY_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2020:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V2_ANALOG:
+    case USB_DEVICE_ID_RAZER_BLADE_LATE_2020_BASE:
+    case USB_DEVICE_ID_RAZER_BOOK_2020:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_BASE_EARLY_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
+    case USB_DEVICE_ID_RAZER_BLADE_15_BASE_2022:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI_ANALOG:
+    case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_17_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2022:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_15_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2023:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2023:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V3_PRO:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_18_2024:
+    case USB_DEVICE_ID_RAZER_BLADE_16_2025:
         if (is_blade_laptop(device)) {
             request = razer_chroma_misc_get_blade_brightness();
         } else {
@@ -3001,6 +3791,10 @@ static ssize_t razer_attr_read_matrix_brightness(struct device *dev, struct devi
         }
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razerkbd: matrix_brightness not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -3176,10 +3970,54 @@ static ssize_t razer_attr_write_matrix_custom_frame(struct device *dev, struct d
             request.transaction_id.id = 0x3F;
             break;
 
-        default:
+        case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
+        case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
+        case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
+        case USB_DEVICE_ID_RAZER_BLADE_QHD:
+        case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
+        case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
+        case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
+        case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
+        case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
+        case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
+        case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
+        case USB_DEVICE_ID_RAZER_BLADE_PRO_2017:
+        case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
+        case USB_DEVICE_ID_RAZER_BLADE_PRO_2017_FULLHD:
+        case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
+        case USB_DEVICE_ID_RAZER_BLADE_2018:
+        case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
+        case USB_DEVICE_ID_RAZER_BLACKWIDOW_ESSENTIAL:
+        case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
+        case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
+        case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
+        case USB_DEVICE_ID_RAZER_BLADE_ADV_LATE_2019:
+        case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
+        case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
+        case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
+        case USB_DEVICE_ID_RAZER_BLADE_PRO_EARLY_2020:
+        case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
+        case USB_DEVICE_ID_RAZER_BLADE_17_PRO_EARLY_2021:
+        case USB_DEVICE_ID_RAZER_BLADE_14_2021:
+        case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
+        case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
+        case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:
+        case USB_DEVICE_ID_RAZER_BLADE_17_2022:
+        case USB_DEVICE_ID_RAZER_BLADE_14_2022:
+        case USB_DEVICE_ID_RAZER_BLADE_14_2023:
+        case USB_DEVICE_ID_RAZER_BLADE_15_2023:
+        case USB_DEVICE_ID_RAZER_BLADE_16_2023:
+        case USB_DEVICE_ID_RAZER_BLADE_18_2023:
+        case USB_DEVICE_ID_RAZER_BLADE_14_2024:
+        case USB_DEVICE_ID_RAZER_BLADE_18_2024:
+        case USB_DEVICE_ID_RAZER_BLADE_16_2025:
             request = razer_chroma_standard_matrix_set_custom_frame(row_id, start_col, stop_col, (unsigned char*)&buf[offset]);
             request.transaction_id.id = 0xFF;
             break;
+
+        default:
+            printk(KERN_WARNING "razerkbd: matrix_custom_frame not supported for this model\n");
+            return -EINVAL;
         }
 
         /*
@@ -3223,9 +4061,8 @@ static ssize_t razer_attr_read_poll_rate(struct device *dev, struct device_attri
         break;
 
     default:
-        request = razer_chroma_misc_get_polling_rate();
-        request.transaction_id.id = 0xFF;
-        break;
+        printk(KERN_WARNING "razerkbd: poll_rate not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -3278,10 +4115,10 @@ static ssize_t razer_attr_write_poll_rate(struct device *dev, struct device_attr
         request = razer_chroma_misc_set_polling_rate2(polling_rate, 0x00);
         request.transaction_id.id = 0x1f;
         break;
+
     default:
-        request = razer_chroma_misc_set_polling_rate(polling_rate);
-        request.transaction_id.id = 0xFF;
-        break;
+        printk(KERN_WARNING "razerkbd: poll_rate not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);

--- a/driver/razerkraken_driver.c
+++ b/driver/razerkraken_driver.c
@@ -549,9 +549,12 @@ static ssize_t razer_attr_read_matrix_effect_breath(struct device *dev, struct d
         break;
 
     case USB_DEVICE_ID_RAZER_KRAKEN:
-    default:
         return get_rgb_from_addr(dev, device->breathing_address[0], 0x04, buf);
         break;
+
+    default:
+        printk(KERN_WARNING "razerkraken: Unknown device\n");
+        return -EINVAL;
     }
 }
 

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -792,9 +792,54 @@ static ssize_t razer_attr_read_firmware_version(struct device *dev, struct devic
         request.transaction_id.id = 0x3f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_NAGA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_NAGA_2012:
+    case USB_DEVICE_ID_RAZER_IMPERATOR:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_TAIPAN:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2013:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
+    case USB_DEVICE_ID_RAZER_OROCHI_2013:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_NAGA_2014:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX:
+    case USB_DEVICE_ID_RAZER_ABYSSUS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ELITE_DVA_EDITION:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_WHITE_EDITION:
+    case USB_DEVICE_ID_RAZER_VIPER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_VIPER_MINI:
+    case USB_DEVICE_ID_RAZER_VIPER_8K:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_2021:
+    case USB_DEVICE_ID_RAZER_COBRA:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: firmware_version not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -933,10 +978,16 @@ static ssize_t razer_attr_write_matrix_effect_custom(struct device *dev, struct 
         request.transaction_id.id = 0x80;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
         request = razer_chroma_standard_matrix_effect_custom_frame(NOSTORE);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: matrix_effect_custom not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1265,9 +1316,53 @@ static ssize_t razer_attr_read_device_serial(struct device *dev, struct device_a
         request.transaction_id.id = 0x08;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_NAGA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
+    case USB_DEVICE_ID_RAZER_NAGA_2012:
+    case USB_DEVICE_ID_RAZER_IMPERATOR:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_TAIPAN:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2013:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
+    case USB_DEVICE_ID_RAZER_OROCHI_2013:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_NAGA_2014:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX:
+    case USB_DEVICE_ID_RAZER_ABYSSUS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ELITE_DVA_EDITION:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_MAMBA_ELITE:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_WHITE_EDITION:
+    case USB_DEVICE_ID_RAZER_VIPER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_VIPER_MINI:
+    case USB_DEVICE_ID_RAZER_VIPER_8K:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_2021:
+    case USB_DEVICE_ID_RAZER_COBRA:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: device_serial not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1343,9 +1438,23 @@ static ssize_t razer_attr_read_charge_level(struct device *dev, struct device_at
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: charge_level not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1424,9 +1533,22 @@ static ssize_t razer_attr_read_charge_status(struct device *dev, struct device_a
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: charge_status not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1457,9 +1579,19 @@ static ssize_t razer_attr_write_charge_effect(struct device *dev, struct device_
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: charge_effect not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1496,9 +1628,19 @@ static ssize_t razer_attr_write_charge_colour(struct device *dev, struct device_
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: charge_colour not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -1629,12 +1771,59 @@ static ssize_t razer_attr_read_poll_rate(struct device *dev, struct device_attri
 
         return sprintf(buf, "%d\n", polling_rate);
 
-    default:
+    case USB_DEVICE_ID_RAZER_OROCHI_2011:
+    case USB_DEVICE_ID_RAZER_NAGA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_NAGA_2012:
+    case USB_DEVICE_ID_RAZER_IMPERATOR:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_TAIPAN:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2013:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
+    case USB_DEVICE_ID_RAZER_OROCHI_2013:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_NAGA_2014:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX:
+    case USB_DEVICE_ID_RAZER_ABYSSUS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ELITE_DVA_EDITION:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_MAMBA_ELITE:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_WHITE_EDITION:
+    case USB_DEVICE_ID_RAZER_VIPER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
+    case USB_DEVICE_ID_RAZER_VIPER_MINI:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_2021:
+    case USB_DEVICE_ID_RAZER_COBRA:
         request = razer_chroma_misc_get_polling_rate();
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: poll_rate not supported for this model\n");
+        return -EINVAL;
     }
 
+    // XXX Clean up this special case for Orochi
     if(device->usb_pid == USB_DEVICE_ID_RAZER_OROCHI_2011) {
         response.arguments[0] = device->orochi2011.poll;
     } else {
@@ -1754,10 +1943,51 @@ static ssize_t razer_attr_write_poll_rate(struct device *dev, struct device_attr
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_NAGA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_NAGA_2012:
+    case USB_DEVICE_ID_RAZER_IMPERATOR:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_TAIPAN:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2013:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
+    case USB_DEVICE_ID_RAZER_OROCHI_2013:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_NAGA_2014:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX:
+    case USB_DEVICE_ID_RAZER_ABYSSUS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ELITE_DVA_EDITION:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_MAMBA_ELITE:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_WHITE_EDITION:
+    case USB_DEVICE_ID_RAZER_VIPER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_VIPER_MINI:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_2021:
+    case USB_DEVICE_ID_RAZER_COBRA:
         request = razer_chroma_misc_set_polling_rate(polling_rate);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: poll_rate not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -2079,9 +2309,45 @@ static ssize_t razer_attr_write_dpi(struct device *dev, struct device_attribute 
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_IMPERATOR:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_TAIPAN:
+    case USB_DEVICE_ID_RAZER_OROCHI_2013:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_NAGA_2014:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ELITE_DVA_EDITION:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_WHITE_EDITION:
+    case USB_DEVICE_ID_RAZER_VIPER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_VIPER_MINI:
+    case USB_DEVICE_ID_RAZER_VIPER_8K:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_2021:
+    case USB_DEVICE_ID_RAZER_COBRA:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: dpi not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -2214,10 +2480,44 @@ static ssize_t razer_attr_read_dpi(struct device *dev, struct device_attribute *
         request.transaction_id.id = 0x3f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_TAIPAN:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_NAGA_2014:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ELITE_DVA_EDITION:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_WHITE_EDITION:
+    case USB_DEVICE_ID_RAZER_VIPER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_VIPER_MINI:
+    case USB_DEVICE_ID_RAZER_VIPER_8K:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_2021:
+    case USB_DEVICE_ID_RAZER_COBRA:
         request = razer_chroma_misc_get_dpi_xy(NOSTORE);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: dpi not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -2524,9 +2824,32 @@ static ssize_t razer_attr_write_dpi_stages(struct device *dev, struct device_att
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRED:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_ATHERIS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_BASILISK_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_VIPER_MINI:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_MINI:
+    case USB_DEVICE_ID_RAZER_VIPER_8K:
+    case USB_DEVICE_ID_RAZER_NAGA_X:
+    case USB_DEVICE_ID_RAZER_BASILISK_V3:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_LITE:
+    case USB_DEVICE_ID_RAZER_COBRA:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: dpi_stages not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -2605,9 +2928,32 @@ static ssize_t razer_attr_read_dpi_stages(struct device *dev, struct device_attr
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRED:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_ATHERIS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_BASILISK_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_VIPER_MINI:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_MINI:
+    case USB_DEVICE_ID_RAZER_VIPER_8K:
+    case USB_DEVICE_ID_RAZER_NAGA_X:
+    case USB_DEVICE_ID_RAZER_BASILISK_V3:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_LITE:
+    case USB_DEVICE_ID_RAZER_COBRA:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: dpi_stages not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -2698,9 +3044,39 @@ static ssize_t razer_attr_read_device_idle_time(struct device *dev, struct devic
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRED:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS:
+    case USB_DEVICE_ID_RAZER_ATHERIS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_WIRED:
+    case USB_DEVICE_ID_RAZER_PRO_CLICK_RECEIVER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_PRO_CLICK_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: device_idle_time not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -2757,9 +3133,39 @@ static ssize_t razer_attr_write_device_idle_time(struct device *dev, struct devi
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRED:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS:
+    case USB_DEVICE_ID_RAZER_ATHERIS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_WIRED:
+    case USB_DEVICE_ID_RAZER_PRO_CLICK_RECEIVER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_PRO_CLICK_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: device_idle_time not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -2802,9 +3208,49 @@ static ssize_t razer_attr_read_charge_low_threshold(struct device *dev, struct d
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRED:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS:
+    case USB_DEVICE_ID_RAZER_ATHERIS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_WIRED:
+    case USB_DEVICE_ID_RAZER_PRO_CLICK_RECEIVER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_PRO_CLICK_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_VIPER_V2_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_COBRA_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_COBRA_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_HYPERPOLLING_WIRELESS_DONGLE:
+    case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_35K_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_35K_WIRELESS:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: charge_low_threshold not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -2849,9 +3295,50 @@ static ssize_t razer_attr_write_charge_low_threshold(struct device *dev, struct 
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRED:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS:
+    case USB_DEVICE_ID_RAZER_ATHERIS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_WIRED:
+    case USB_DEVICE_ID_RAZER_PRO_CLICK_RECEIVER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_PRO_CLICK_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_VIPER_V2_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_COBRA_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_COBRA_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_HYPERPOLLING_WIRELESS_DONGLE:
+    case USB_DEVICE_ID_RAZER_NAGA_V2_HYPERSPEED_RECEIVER:
+    case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_35K_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_35K_WIRELESS:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: charge_low_threshold not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -3080,9 +3567,55 @@ static ssize_t razer_attr_write_device_mode(struct device *dev, struct device_at
         request.transaction_id.id = 0x3f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_NAGA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_NAGA_2012:
+    case USB_DEVICE_ID_RAZER_IMPERATOR:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_TAIPAN:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2013:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
+    case USB_DEVICE_ID_RAZER_OROCHI_2013:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_NAGA_2014:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX:
+    case USB_DEVICE_ID_RAZER_ABYSSUS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ELITE_DVA_EDITION:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_WHITE_EDITION:
+    case USB_DEVICE_ID_RAZER_VIPER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_VIPER_MINI:
+    case USB_DEVICE_ID_RAZER_VIPER_8K:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_2021:
+    case USB_DEVICE_ID_RAZER_COBRA:
+    case USB_DEVICE_ID_RAZER_VIPER_V3_HYPERSPEED:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: device_mode not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -3174,9 +3707,56 @@ static ssize_t razer_attr_read_device_mode(struct device *dev, struct device_att
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_NAGA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_NAGA_2012:
+    case USB_DEVICE_ID_RAZER_IMPERATOR:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
+    case USB_DEVICE_ID_RAZER_TAIPAN:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2013:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
+    case USB_DEVICE_ID_RAZER_OROCHI_2013:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_NAGA_2014:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX:
+    case USB_DEVICE_ID_RAZER_ABYSSUS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ELITE_DVA_EDITION:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_WHITE_EDITION:
+    case USB_DEVICE_ID_RAZER_VIPER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_VIPER_MINI:
+    case USB_DEVICE_ID_RAZER_VIPER_8K:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_2021:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_X_HYPERSPEED:
+    case USB_DEVICE_ID_RAZER_COBRA:
+    case USB_DEVICE_ID_RAZER_NAGA_V2_HYPERSPEED_RECEIVER:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: device_mode not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -3257,10 +3837,27 @@ static ssize_t razer_attr_read_led_brightness(struct device *dev, struct device_
         request.transaction_id.id = 0x3F;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
         request = razer_chroma_standard_get_led_brightness(VARSTORE, led_id);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: led_brightness not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -3339,10 +3936,27 @@ static ssize_t razer_attr_write_led_brightness(struct device *dev, struct device
         request.transaction_id.id = 0x3F;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
+    case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_OUROBOROS:
         request = razer_chroma_standard_set_led_brightness(VARSTORE, led_id, brightness);
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: led_brightness not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -3868,9 +4482,50 @@ static ssize_t razer_attr_write_matrix_effect_breath_common(struct device *dev, 
         request.transaction_id.id = 0x1f;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2013:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
+    case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
+    case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
+    case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRED:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_BASILISK:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_WIRED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_WHITE_EDITION:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_RECEIVER:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_WIRED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2:
+    case USB_DEVICE_ID_RAZER_BASILISK_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ELITE_DVA_EDITION:
+    case USB_DEVICE_ID_RAZER_ABYSSUS_ESSENTIAL:
+    case USB_DEVICE_ID_RAZER_VIPER:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_VIPER_MINI:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V2_MINI:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_2021:
+    case USB_DEVICE_ID_RAZER_COBRA:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
+    case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
+    case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
+    case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
+    case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
         request.transaction_id.id = 0x3f;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: matrix_effect_breath not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);
@@ -4544,9 +5199,14 @@ static ssize_t razer_attr_write_hyperpolling_wireless_dongle_indicator_led_mode(
         request.transaction_id.id = 0x1F;
         break;
 
-    default:
+    case USB_DEVICE_ID_RAZER_VIPER_V3_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_HYPERPOLLING_WIRELESS_DONGLE:
         request.transaction_id.id = 0xFF;
         break;
+
+    default:
+        printk(KERN_WARNING "razermouse: hyperpolling_wireless_dongle_indicator_led_mode not supported for this model\n");
+        return -EINVAL;
     }
 
     razer_send_payload(device, &request, &response);


### PR DESCRIPTION
To prepare getting the transaction IDs a bit more unified, start
by replacing the default case by explicit case statements for the
devices that use them.

For now, it makes it explicit that a code path needs to be chosen for
new devices, and in the future we can use this data to investigate how
to unify this and make this simpler.

This change was done in a script-supported way by slightly modifying
generate_fake_driver.sh to output all devices that create a given sysfs
file, then finding the missing ones from the existing case statements
using essentially grep.

No functional change intended.

See also #2151
