### PR TITLE
scripts: Use multiple threads for autopep8

### DIFF
--- a/scripts/format_source.sh
+++ b/scripts/format_source.sh
@@ -6,4 +6,4 @@ set -ex
 find driver/ -name "*.c" -o -name "*.h" | xargs astyle --style=linux -n
 
 # Python (autopep8)
-autopep8 --recursive --in-place --max-line-length 500 --ignore E402 .
+autopep8 --jobs 0 --recursive --in-place --max-line-length 500 --ignore E402 .


### PR DESCRIPTION
As per 'autopep8 --help':

  -j, --jobs n          number of parallel jobs; match CPU count if value is less than 1