### PR TITLE
ci: Add check for Python version compatibility

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -13,6 +13,7 @@ packages:
   - py3-setuptools
   - py3-udev
   - sed
+  - vermin
 sources:
   - https://github.com/openrazer/openrazer
 tasks:
@@ -32,6 +33,8 @@ tasks:
       ./scripts/ci/test-auto-generate.sh
       # Check for hex casing issues
       ./scripts/ci/test-hex-casing.sh
+      # Check for Python version compatibility
+      ./scripts/ci/test-vermin.sh
 
   - compile-driver: |
       cd openrazer

--- a/scripts/ci/test-vermin.sh
+++ b/scripts/ci/test-vermin.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# shellcheck disable=SC2046
+vermin \
+    -t=3.9- \
+    --backport argparse \
+    --backport configparser \
+    --backport typing \
+    --lint \
+    --eval-annotations \
+    $(find . -name '*.py')


### PR DESCRIPTION
Given we already require Python 3.9 in various places in the code, make Vermin check against Python 3.9 then. This ensures we don't accidentally start using new Python features (mainly annotations) while we want to maintain compatibility with mainly old Ubuntu versions.