### PR TITLE
Fix missing game mode driver logic for Huntsman V3 Pro TKL

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -890,6 +890,7 @@ static ssize_t razer_attr_write_game_led_state(struct device *dev, struct device
     case USB_DEVICE_ID_RAZER_HUNTSMAN_V3_PRO:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_TENKEYLESS_HYPERSPEED_WIRED:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_TENKEYLESS_HYPERSPEED_WIRELESS:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V3_PRO_TKL:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_TK:
         request = razer_chroma_standard_set_led_state(VARSTORE, GAME_LED, enabled);
         request.transaction_id.id = 0xFF;
@@ -983,6 +984,7 @@ static ssize_t razer_attr_read_game_led_state(struct device *dev, struct device_
     case USB_DEVICE_ID_RAZER_HUNTSMAN_V3_PRO:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_TENKEYLESS_HYPERSPEED_WIRED:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_TENKEYLESS_HYPERSPEED_WIRELESS:
+    case USB_DEVICE_ID_RAZER_HUNTSMAN_V3_PRO_TKL:
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_TK:
         request = razer_chroma_standard_get_led_state(VARSTORE, GAME_LED);
         request.transaction_id.id = 0xFF;


### PR DESCRIPTION
It seems this keyboard is supposed to have a game mode, but isn't implemented in the driver.

Confirmed to fix the problem by two users: https://github.com/openrazer/openrazer/issues/2612#issuecomment-3536946949 and https://github.com/polychromatic/polychromatic/issues/567#issuecomment-3568020908.

Fixes #2612.
Fixes polychromatic/polychromatic#579.
Fixes polychromatic/polychromatic#567.

I wondered how our auto tests didn't catch it, but it technically passes: There **was** a sysfs file, it just didn't work on physical hardware. The fake driver had no error reading/writing `game_mode_led`.