### PR TITLE
pylib: Add capability for razer.device.lighting.channel

### DIFF
--- a/pylib/openrazer/client/devices/__init__.py
+++ b/pylib/openrazer/client/devices/__init__.py
@@ -108,6 +108,9 @@ class RazerDevice(object):
             'lighting_led_matrix': self._dbus_interfaces['device'].hasMatrix() == True,
             'lighting_led_single': self._has_feature('razer.device.lighting.chroma', 'setKey'),
 
+            # Razer Chroma Addressable RGB Controller
+            'lighting_channels': self._has_feature('razer.device.lighting.channel', 'getNumChannels'),
+
             # Mouse lighting attrs
             'lighting_logo': self._has_feature('razer.device.lighting.logo'),
             'lighting_logo_active': self._has_feature('razer.device.lighting.logo', 'setLogoActive'),

--- a/scripts/ci/test-daemon.py
+++ b/scripts/ci/test-daemon.py
@@ -137,6 +137,11 @@ def test_sysfs_consistency(d):
 
         check_any_sysfs([f"lighting_{prefix}_breath_single", f"lighting_{prefix}_breath_mono"], [f"{prefix}_matrix_effect_breath"])
 
+    for channel in range(1, 7):
+        check_sysfs("lighting_channels", f"channel{channel}_led_brightness")
+        check_sysfs("lighting_channels", f"channel{channel}_size")
+    check_sysfs("lighting_channels", "reset_channels")
+
 
 def test_ripple_capable(d):
     # Check that the device has a matrix for a software ripple effect


### PR DESCRIPTION
The Razer Chroma Addressable RGB Controller has the ability to configure channels, but the capabilities were not exposed in the Python library.

Related: https://github.com/polychromatic/polychromatic/issues/520

**Edit:** Realising a month after creating this PR, we don't have `pylib` bindings:

* https://github.com/openrazer/openrazer/issues/2641
