### PR TITLE
driver: fix unescaped sprintf string

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -1509,7 +1509,7 @@ static ssize_t razer_attr_read_device_type(struct device *dev, struct device_att
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_75PCT:
-        device_type = "Razer BlackWidow V4 75%\n";
+        device_type = "Razer BlackWidow V4 75%%\n";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRED:


### PR DESCRIPTION
The device_type string for USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_75PCT contains a literal '%' character which is interpreted by sprintf(), causing a kernel warning.

Note: if no formatting is required here, switching to strcpy could be considered in the future.



Kernel trace:
> [ 1442.553487] [  T18406] Please remove unsupported %
                           in format string
[ 1442.553501] [  T18406] WARNING: CPU: 11 PID: 18406 at lib/vsprintf.c:2776 format_decode+0x246/0x2c0
....
[ 1442.553830] [  T18406]  vsnprintf+0xb3/0x5c0
[ 1442.553839] [  T18406]  sprintf+0x59/0x80
[ 1442.553847] [  T18406]  razer_attr_read_device_type+0x58c/0x9b0 [razerkbd e74625a6ab1519ca5068d620cf75665c5e92b436]
