### PR TITLE
udev: Use udev permission setting as recommended by systemd standards

### DIFF
--- a/install_files/udev/71-razer.rules
+++ b/install_files/udev/71-razer.rules
@@ -1,3 +1,8 @@
+# Set permissions if this is Razer device
+# DO NOT set uaccess for `input` subsystems as it would make it trivial to write keyloggers
+# See https://wiki.archlinux.org/title/Udev#Allowing_regular_users_to_use_devices
+ACTION!="remove", SUBSYSTEMS=="usb|hid", ATTRS{idVendor}=="1532", MODE="0660", TAG+="uaccess"
+
 ACTION!="add", GOTO="razer_end"
 SUBSYSTEMS=="usb|input|hid", ATTRS{idVendor}=="1532", GOTO="razer_vendor"
 GOTO="razer_end"
@@ -26,9 +31,6 @@ ATTRS{idProduct}=="0068|007e|0215|0517|0518|0c00|0c01|0c02|0c04|0c05|0c06|0c08|0
 
 # Get out if no match
 ENV{ID_RAZER_CHROMA}!="1", GOTO="razer_end"
-
-# Set permissions if this is an input node
-SUBSYSTEM=="usb|input|hid", GROUP:="plugdev"
 
 # We're done unless it's the hid node
 SUBSYSTEM!="hid|usb", GOTO="razer_end"

--- a/scripts/ci/test-pids.py
+++ b/scripts/ci/test-pids.py
@@ -15,7 +15,7 @@ passed = True
 with open(f"{repo_root}/README.md") as f:
     README = f.readlines()
 
-with open(f"{repo_root}/install_files/udev/99-razer.rules") as f:
+with open(f"{repo_root}/install_files/udev/71-razer.rules") as f:
     UDEV = f.readlines()
 
 for device in devmgr.devices:


### PR DESCRIPTION
Using the plugdev group is Ubuntu's approch. This gorup does not exist on Fedora and Arch nor do `/dev/` devices are owned by `plugdev`. This makes current rules uneffective under these distributions. systemd's recommanded approach is to use dynamic ACL's. These rules allow correct acces under Fedora.

https://wiki.archlinux.org/title/Udev#Allowing_regular_users_to_use_devices

This should solve #2601.