### PR TITLE
Fix Blade 14 (2021) starlight effect ignoring color/speed parameters

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -2950,6 +2950,7 @@ static ssize_t razer_attr_write_matrix_effect_starlight(struct device *dev, stru
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
     case USB_DEVICE_ID_RAZER_BLADE_17_PRO_EARLY_2021:
     case USB_DEVICE_ID_RAZER_BLADE_16_2025:
+    case USB_DEVICE_ID_RAZER_BLADE_14_2021:
         if(count == 7) {
             request = razer_chroma_standard_matrix_effect_starlight_dual(buf[0], (struct razer_rgb*)&buf[1], (struct razer_rgb*)&buf[4]);
             request.transaction_id.id = 0xFF;
@@ -3008,7 +3009,6 @@ static ssize_t razer_attr_write_matrix_effect_starlight(struct device *dev, stru
     case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
     case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
     case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
-    case USB_DEVICE_ID_RAZER_BLADE_14_2021:
     case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
     case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
     case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:


### PR DESCRIPTION
## Summary
- Fix starlight effect on Razer Blade 14 (2021) ignoring color and speed parameters
- Move device to correct case block that reads input buffer instead of hardcoding values

## Problem
The Razer Blade 14 (2021) was grouped with devices that hardcode starlight parameters:
- Always green color (`rgb1 = {.r = 0x00, .g = 0xFF, .b = 0x00}`)
- Always fast speed (`0x01`)

This meant user-provided color and speed values were completely ignored.

## Solution
Move `USB_DEVICE_ID_RAZER_BLADE_14_2021` from the hardcoded case block (line ~3011) to the case block (line ~2950) that properly parses speed and RGB values from the input buffer.

## Testing
Tested on Razer Blade 14 (2021) - starlight now correctly responds to color and speed parameters.

Fixes #2646