### PR TITLE
feat: enable horizontal scrolling support for PCV2

### DIFF
--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -5778,6 +5778,8 @@ static int razer_raw_event(struct hid_device *hdev, struct hid_report *report, u
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_35K_PHANTOM_GREEN_EDITION_WIRELESS:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_WIRED:
+    case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRED:
+    case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
         /* Detect wheel tilt edges */
         if(intf->cur_altsetting->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_MOUSE) {
             int i;
@@ -5913,6 +5915,8 @@ static int razer_input_configured(struct hid_device *hdev,
         case USB_DEVICE_ID_RAZER_MAMBA_ELITE:
         case USB_DEVICE_ID_RAZER_NAGA_2014:
         case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
+        case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRED:
+        case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
             input_set_capability(hidinput->input, EV_REL, REL_HWHEEL);
             input_set_capability(hidinput->input, EV_REL, REL_HWHEEL_HI_RES);
             input_set_capability(hidinput->input, EV_KEY, BTN_FORWARD);
@@ -7019,6 +7023,20 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
 
         case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRELESS:
         case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRED:
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi_stages);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_level);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_status);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_low_threshold);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_device_idle_time);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_spectrum);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_wave);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_static);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_none);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_brightness);
+            break;
+
         case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRED:
         case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
@@ -7033,6 +7051,9 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_static);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_none);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_brightness);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_tilt_hwheel);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_tilt_repeat_delay);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_tilt_repeat);
             break;
         }
 
@@ -8094,6 +8115,20 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
 
         case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRELESS:
         case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRED:
+            device_remove_file(&hdev->dev, &dev_attr_poll_rate);
+            device_remove_file(&hdev->dev, &dev_attr_dpi);
+            device_remove_file(&hdev->dev, &dev_attr_dpi_stages);
+            device_remove_file(&hdev->dev, &dev_attr_charge_level);
+            device_remove_file(&hdev->dev, &dev_attr_charge_status);
+            device_remove_file(&hdev->dev, &dev_attr_charge_low_threshold);
+            device_remove_file(&hdev->dev, &dev_attr_device_idle_time);
+            device_remove_file(&hdev->dev, &dev_attr_matrix_effect_spectrum);
+            device_remove_file(&hdev->dev, &dev_attr_matrix_effect_wave);
+            device_remove_file(&hdev->dev, &dev_attr_matrix_effect_static);
+            device_remove_file(&hdev->dev, &dev_attr_matrix_effect_none);
+            device_remove_file(&hdev->dev, &dev_attr_matrix_brightness);
+            break;
+
         case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRED:
         case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
             device_remove_file(&hdev->dev, &dev_attr_poll_rate);
@@ -8108,6 +8143,9 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_static);
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_none);
             device_remove_file(&hdev->dev, &dev_attr_matrix_brightness);
+            device_remove_file(&hdev->dev, &dev_attr_tilt_hwheel);
+            device_remove_file(&hdev->dev, &dev_attr_tilt_repeat_delay);
+            device_remove_file(&hdev->dev, &dev_attr_tilt_repeat);
             break;
         }
 

--- a/pylib/openrazer/_fake_driver/razerproclickv2wired.cfg
+++ b/pylib/openrazer/_fake_driver/razerproclickv2wired.cfg
@@ -19,4 +19,7 @@ files = r,charge_level,255
         w,matrix_effect_static
         w,matrix_effect_wave
         rw,poll_rate,500
+        rw,tilt_hwheel,0
+        rw,tilt_repeat,0
+        rw,tilt_repeat_delay,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerproclickv2wireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerproclickv2wireless.cfg
@@ -19,4 +19,7 @@ files = r,charge_level,255
         w,matrix_effect_static
         w,matrix_effect_wave
         rw,poll_rate,500
+        rw,tilt_hwheel,0
+        rw,tilt_repeat,0
+        rw,tilt_repeat_delay,0
         r,version,1.0.0


### PR DESCRIPTION
## Changes

- add PCV2 wired and wireless to detect scroll wheel tilt and convert
into horizontal scroll event
- add tilt scroll to fake driver
- fixes #2608

## Test logs

Now the events correctly logs `REL_HWHEEL` and `REL_HWHEEL_HI_RES` when scroll wheel is tilted.

```sh
➜  driver git:(avinal/pcv2) ✗ sudo evtest /dev/input/by-id/usb-1532_Razer_Pro_Click_V2_000000000000-event-mouse

Input driver version is 1.0.1
Input device ID: bus 0x3 vendor 0x1532 product 0xd0 version 0x111
Input device name: "Razer Pro Click V2"
Supported events:
  Event type 0 (EV_SYN)
  Event type 1 (EV_KEY)
    Event code 272 (BTN_LEFT)
    Event code 273 (BTN_RIGHT)
    Event code 274 (BTN_MIDDLE)
    Event code 275 (BTN_SIDE)
    Event code 276 (BTN_EXTRA)
    Event code 277 (BTN_FORWARD)
    Event code 278 (BTN_BACK)
  Event type 2 (EV_REL)
    Event code 0 (REL_X)
    Event code 1 (REL_Y)
    Event code 6 (REL_HWHEEL)
    Event code 8 (REL_WHEEL)
    Event code 11 (REL_WHEEL_HI_RES)
    Event code 12 (REL_HWHEEL_HI_RES)
  Event type 4 (EV_MSC)
    Event code 4 (MSC_SCAN)
Properties:
Testing ... (interrupt to exit)
Event: time 1768995946.063406, -------------- SYN_REPORT ------------
Event: time 1768995947.467405, type 2 (EV_REL), code 8 (REL_WHEEL), value -1
Event: time 1768995947.467405, type 2 (EV_REL), code 11 (REL_WHEEL_HI_RES), value -120
Event: time 1768995947.467405, -------------- SYN_REPORT ------------
Event: time 1768995948.831413, type 2 (EV_REL), code 8 (REL_WHEEL), value 1
Event: time 1768995948.831413, type 2 (EV_REL), code 11 (REL_WHEEL_HI_RES), value 120
Event: time 1768995948.831413, -------------- SYN_REPORT ------------
Event: time 1768995950.684434, type 2 (EV_REL), code 6 (REL_HWHEEL), value 1
Event: time 1768995950.684434, type 2 (EV_REL), code 12 (REL_HWHEEL_HI_RES), value 120
Event: time 1768995950.684434, -------------- SYN_REPORT ------------
Event: time 1768995951.965432, type 2 (EV_REL), code 6 (REL_HWHEEL), value -1
Event: time 1768995951.965432, type 2 (EV_REL), code 12 (REL_HWHEEL_HI_RES), value -120
```

Signed-off-by: Avinal Kumar <avinal.xlvii@gmail.com>
