### PR TITLE
driver: Make printing device_type proper

### DIFF
--- a/driver/razeraccessory_driver.c
+++ b/driver/razeraccessory_driver.c
@@ -122,115 +122,115 @@ static ssize_t razer_attr_read_device_type(struct device *dev, struct device_att
 
     switch (device->usb_pid) {
     case USB_DEVICE_ID_RAZER_FIREFLY:
-        device_type = "Razer Firefly\n";
+        device_type = "Razer Firefly";
         break;
 
     case USB_DEVICE_ID_RAZER_FIREFLY_V2:
-        device_type = "Razer Firefly V2\n";
+        device_type = "Razer Firefly V2";
         break;
 
     case USB_DEVICE_ID_RAZER_FIREFLY_V2_PRO:
-        device_type = "Razer Firefly V2 Pro\n";
+        device_type = "Razer Firefly V2 Pro";
         break;
 
     case USB_DEVICE_ID_RAZER_FIREFLY_HYPERFLUX:
-        device_type = "Razer Firefly Hyperflux\n";
+        device_type = "Razer Firefly Hyperflux";
         break;
 
     case USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA:
-        device_type = "Razer Goliathus\n";
+        device_type = "Razer Goliathus";
         break;
 
     case USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA_EXTENDED:
-        device_type = "Razer Goliathus Extended\n";
+        device_type = "Razer Goliathus Extended";
         break;
 
     case USB_DEVICE_ID_RAZER_GOLIATHUS_CHROMA_3XL:
-        device_type = "Razer Goliathus Chroma 3XL\n";
+        device_type = "Razer Goliathus Chroma 3XL";
         break;
 
     case USB_DEVICE_ID_RAZER_STRIDER_CHROMA:
-        device_type = "Razer Strider Chroma\n";
+        device_type = "Razer Strider Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_CORE:
-        device_type = "Razer Core\n";
+        device_type = "Razer Core";
         break;
 
     case USB_DEVICE_ID_RAZER_CORE_X_CHROMA:
-        device_type = "Razer Core X Chroma\n";
+        device_type = "Razer Core X Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_LAPTOP_STAND_CHROMA:
-        device_type = "Razer Laptop Stand Chroma\n";
+        device_type = "Razer Laptop Stand Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_CHROMA_MUG:
-        device_type = "Razer Chroma Mug Holder\n";
+        device_type = "Razer Chroma Mug Holder";
         break;
 
     case USB_DEVICE_ID_RAZER_CHROMA_HDK:
-        device_type = "Razer Chroma HDK\n";
+        device_type = "Razer Chroma HDK";
         break;
 
     case USB_DEVICE_ID_RAZER_CHROMA_BASE:
-        device_type = "Razer Base Station Chroma\n";
+        device_type = "Razer Base Station Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
-        device_type = "Razer Base Station V2 Chroma\n";
+        device_type = "Razer Base Station V2 Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_NOMMO_PRO:
-        device_type = "Razer Nommo Pro\n";
+        device_type = "Razer Nommo Pro";
         break;
 
     case USB_DEVICE_ID_RAZER_NOMMO_CHROMA:
-        device_type = "Razer Nommo Chroma\n";
+        device_type = "Razer Nommo Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_KRAKEN_KITTY_EDITION:
-        device_type = "Razer Kraken Kitty Edition\n";
+        device_type = "Razer Kraken Kitty Edition";
         break;
 
     case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
-        device_type = "Razer Mouse Bungee V3 Chroma\n";
+        device_type = "Razer Mouse Bungee V3 Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_CHARGING_PAD_CHROMA:
-        device_type = "Razer Charging Pad Chroma\n";
+        device_type = "Razer Charging Pad Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_MOUSE_DOCK:
-        device_type = "Razer Mouse Dock\n";
+        device_type = "Razer Mouse Dock";
         break;
 
     case USB_DEVICE_ID_RAZER_THUNDERBOLT_4_DOCK_CHROMA:
-        device_type = "Razer Thunderbolt 4 Dock Chroma\n";
+        device_type = "Razer Thunderbolt 4 Dock Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_RAPTOR_27:
-        device_type = "Razer Raptor 27\n";
+        device_type = "Razer Raptor 27";
         break;
 
     case USB_DEVICE_ID_RAZER_CHROMA_ADDRESSABLE_RGB_CONTROLLER:
-        device_type = "Razer Chroma Addressable RGB Controller\n";
+        device_type = "Razer Chroma Addressable RGB Controller";
         break;
 
     case USB_DEVICE_ID_RAZER_LAPTOP_STAND_CHROMA_V2:
-        device_type = "Razer Laptop Stand Chroma V2\n";
+        device_type = "Razer Laptop Stand Chroma V2";
         break;
 
     case USB_DEVICE_ID_RAZER_TOMAHAWK_ATX:
-        device_type = "Razer Tomahawk ATX\n";
+        device_type = "Razer Tomahawk ATX";
         break;
 
     default:
-        device_type = "Unknown Device\n";
+        device_type = "Unknown Device";
         break;
     }
 
-    return sprintf(buf, device_type);
+    return sprintf(buf, "%s\n", device_type);
 }
 
 /**

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -1100,459 +1100,459 @@ static ssize_t razer_attr_read_device_type(struct device *dev, struct device_att
     switch (device->usb_pid) {
 
     case USB_DEVICE_ID_RAZER_NOSTROMO:
-        device_type = "Razer Nostromo\n";
+        device_type = "Razer Nostromo";
         break;
 
     case USB_DEVICE_ID_RAZER_ORBWEAVER:
-        device_type = "Razer Orbweaver\n";
+        device_type = "Razer Orbweaver";
         break;
 
     case USB_DEVICE_ID_RAZER_ORBWEAVER_CHROMA:
-        device_type = "Razer Orbweaver Chroma\n";
+        device_type = "Razer Orbweaver Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_STEALTH:
-        device_type = "Razer BlackWidow Stealth\n";
+        device_type = "Razer BlackWidow Stealth";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_STEALTH_EDITION:
-        device_type = "Razer BlackWidow Stealth Edition\n";
+        device_type = "Razer BlackWidow Stealth Edition";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2012:
-        device_type = "Razer BlackWidow Ultimate 2012\n";
+        device_type = "Razer BlackWidow Ultimate 2012";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2013:
-        device_type = "Razer BlackWidow Ultimate 2013\n";
+        device_type = "Razer BlackWidow Ultimate 2013";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_ULTIMATE_2016:
-        device_type = "Razer BlackWidow Ultimate 2016\n";
+        device_type = "Razer BlackWidow Ultimate 2016";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_ULTIMATE:
-        device_type = "Razer BlackWidow X Ultimate\n";
+        device_type = "Razer BlackWidow X Ultimate";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_TE_2014:
-        device_type = "Razer BlackWidow Tournament Edition 2014\n";
+        device_type = "Razer BlackWidow Tournament Edition 2014";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH:
-        device_type = "Razer Blade Stealth\n";
+        device_type = "Razer Blade Stealth";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2019:
-        device_type = "Razer Blade Stealth (Late 2019)\n";
+        device_type = "Razer Blade Stealth (Late 2019)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH_EARLY_2020:
-        device_type = "Razer Blade Stealth (Early 2020)\n";
+        device_type = "Razer Blade Stealth (Early 2020)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2020:
-        device_type = "Razer Blade Stealth (Late 2020)\n";
+        device_type = "Razer Blade Stealth (Late 2020)";
         break;
 
     case USB_DEVICE_ID_RAZER_BOOK_2020:
-        device_type = "Razer Book 13 (2020)\n";
+        device_type = "Razer Book 13 (2020)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2016:
-        device_type = "Razer Blade Stealth (Late 2016)\n";
+        device_type = "Razer Blade Stealth (Late 2016)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH_MID_2017:
-        device_type = "Razer Blade Stealth (Mid 2017)\n";
+        device_type = "Razer Blade Stealth (Mid 2017)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_QHD:
-        device_type = "Razer Blade Stealth (QHD)\n";
+        device_type = "Razer Blade Stealth (QHD)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2016:
-        device_type = "Razer Blade Pro (Late 2016)\n";
+        device_type = "Razer Blade Pro (Late 2016)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_2018:
-        device_type = "Razer Blade 15 (2018)\n";
+        device_type = "Razer Blade 15 (2018)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_2018_MERCURY:
-        device_type = "Razer Blade 15 (2018) Mercury\n";
+        device_type = "Razer Blade 15 (2018) Mercury";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_2018_BASE:
-        device_type = "Razer Blade 15 (2018) Base Model\n";
+        device_type = "Razer Blade 15 (2018) Base Model";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_2019_ADV:
-        device_type = "Razer Blade 15 (2019) Advanced\n";
+        device_type = "Razer Blade 15 (2019) Advanced";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_2019_BASE:
-        device_type = "Razer Blade 15 (2019) Base Model\n";
+        device_type = "Razer Blade 15 (2019) Base Model";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_EARLY_2020_BASE:
-        device_type = "Razer Blade 15 Base (Early 2020)\n";
+        device_type = "Razer Blade 15 Base (Early 2020)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_LATE_2020_BASE:
-        device_type = "Razer Blade 15 Base (Late 2020)\n";
+        device_type = "Razer Blade 15 Base (Late 2020)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_MID_2019_MERCURY:
-        device_type = "Razer Blade 15 (Mid 2019) Mercury White\n";
+        device_type = "Razer Blade 15 (Mid 2019) Mercury White";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_STUDIO_EDITION_2019:
-        device_type = "Razer Blade 15 Studio Edition (2019)\n";
+        device_type = "Razer Blade 15 Studio Edition (2019)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_LATE_2016:
-        device_type = "Razer Blade (Late 2016)\n";
+        device_type = "Razer Blade (Late 2016)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_PRO_2017:
-        device_type = "Razer Blade Pro (2017)\n";
+        device_type = "Razer Blade Pro (2017)";
         break;
     case USB_DEVICE_ID_RAZER_BLADE_PRO_2017_FULLHD:
-        device_type = "Razer Blade Pro FullHD (2017)\n";
+        device_type = "Razer Blade Pro FullHD (2017)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_PRO_2019:
-        device_type = "Razer Blade Pro (2019)\n";
+        device_type = "Razer Blade Pro (2019)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_PRO_LATE_2019:
-        device_type = "Razer Blade Pro (Late 2019)\n";
+        device_type = "Razer Blade Pro (Late 2019)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_ADV_LATE_2019:
-        device_type = "Razer Blade Advanced (Late 2019)\n";
+        device_type = "Razer Blade Advanced (Late 2019)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_PRO_EARLY_2020:
-        device_type = "Razer Blade Pro (Early 2020)\n";
+        device_type = "Razer Blade Pro (Early 2020)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH_LATE_2017:
-        device_type = "Razer Blade Stealth (Late 2017)\n";
+        device_type = "Razer Blade Stealth (Late 2017)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_STEALTH_2019:
-        device_type = "Razer Blade Stealth (2019)\n";
+        device_type = "Razer Blade Stealth (2019)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_15_ADV_2020:
-        device_type = "Razer Blade 15 Advanced (2020)\n";
+        device_type = "Razer Blade 15 Advanced (2020)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2021:
-        device_type = "Razer Blade 15 Advanced (Early 2021)\n";
+        device_type = "Razer Blade 15 Advanced (Early 2021)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_15_ADV_MID_2021:
-        device_type = "Razer Blade 15 Advanced (Mid 2021)\n";
+        device_type = "Razer Blade 15 Advanced (Mid 2021)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_15_BASE_EARLY_2021:
-        device_type = "Razer Blade 15 Base (Early 2021)\n";
+        device_type = "Razer Blade 15 Base (Early 2021)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_15_BASE_2022:
-        device_type = "Razer Blade 15 Base (2022)\n";
+        device_type = "Razer Blade 15 Base (2022)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_17_PRO_EARLY_2021:
-        device_type = "Razer Blade 17 Pro (Early 2021)\n";
+        device_type = "Razer Blade 17 Pro (Early 2021)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_17_PRO_MID_2021:
-        device_type = "Razer Blade 17 Pro (Mid 2021)\n";
+        device_type = "Razer Blade 17 Pro (Mid 2021)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_14_2021:
-        device_type = "Razer Blade 14 (2021)\n";
+        device_type = "Razer Blade 14 (2021)";
         break;
 
     case USB_DEVICE_ID_RAZER_TARTARUS:
-        device_type = "Razer Tartarus\n";
+        device_type = "Razer Tartarus";
         break;
 
     case USB_DEVICE_ID_RAZER_TARTARUS_CHROMA:
-        device_type = "Razer Tartarus Chroma\n";
+        device_type = "Razer Tartarus Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_TARTARUS_V2:
-        device_type = "Razer Tartarus V2\n";
+        device_type = "Razer Tartarus V2";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_OVERWATCH:
-        device_type = "Razer BlackWidow Chroma (Overwatch)\n";
+        device_type = "Razer BlackWidow Chroma (Overwatch)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
-        device_type = "Razer BlackWidow Chroma\n";
+        device_type = "Razer BlackWidow Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_ESSENTIAL:
-        device_type = "Razer Deathstalker (Essential)\n";
+        device_type = "Razer Deathstalker (Essential)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_EXPERT:
-        device_type = "Razer Deathstalker Expert\n";
+        device_type = "Razer Deathstalker Expert";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_CHROMA:
-        device_type = "Razer DeathStalker Chroma\n";
+        device_type = "Razer DeathStalker Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_TE:
-        device_type = "Razer BlackWidow Chroma Tournament Edition\n";
+        device_type = "Razer BlackWidow Chroma Tournament Edition";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA:
-        device_type = "Razer BlackWidow X Chroma\n";
+        device_type = "Razer BlackWidow X Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_X_CHROMA_TE:
-        device_type = "Razer BlackWidow X Chroma Tournament Edition\n";
+        device_type = "Razer BlackWidow X Chroma Tournament Edition";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_LITE:
-        device_type = "Razer BlackWidow Lite\n";
+        device_type = "Razer BlackWidow Lite";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_2019:
-        device_type = "Razer BlackWidow 2019\n";
+        device_type = "Razer BlackWidow 2019";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_ESSENTIAL:
-        device_type = "Razer BlackWidow Essential\n";
+        device_type = "Razer BlackWidow Essential";
         break;
 
     case USB_DEVICE_ID_RAZER_ORNATA:
-        device_type = "Razer Ornata\n";
+        device_type = "Razer Ornata";
         break;
 
     case USB_DEVICE_ID_RAZER_ORNATA_CHROMA:
-        device_type = "Razer Ornata Chroma\n";
+        device_type = "Razer Ornata Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_ORNATA_V2:
-        device_type = "Razer Ornata V2\n";
+        device_type = "Razer Ornata V2";
         break;
 
     case USB_DEVICE_ID_RAZER_ORNATA_V3:
     case USB_DEVICE_ID_RAZER_ORNATA_V3_ALT:
-        device_type = "Razer Ornata V3\n";
+        device_type = "Razer Ornata V3";
         break;
 
     case USB_DEVICE_ID_RAZER_ORNATA_V3_X:
     case USB_DEVICE_ID_RAZER_ORNATA_V3_X_ALT:
-        device_type = "Razer Ornata V3 X\n";
+        device_type = "Razer Ornata V3 X";
         break;
 
     case USB_DEVICE_ID_RAZER_ORNATA_V3_TENKEYLESS:
-        device_type = "Razer Ornata V3 Tenkeyless\n";
+        device_type = "Razer Ornata V3 Tenkeyless";
         break;
 
     case USB_DEVICE_ID_RAZER_HUNTSMAN_ELITE:
-        device_type = "Razer Huntsman Elite\n";
+        device_type = "Razer Huntsman Elite";
         break;
 
     case USB_DEVICE_ID_RAZER_HUNTSMAN_TE:
-        device_type = "Razer Huntsman Tournament Edition\n";
+        device_type = "Razer Huntsman Tournament Edition";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_ELITE:
-        device_type = "Razer BlackWidow Elite\n";
+        device_type = "Razer BlackWidow Elite";
         break;
 
     case USB_DEVICE_ID_RAZER_HUNTSMAN:
-        device_type = "Razer Huntsman\n";
+        device_type = "Razer Huntsman";
         break;
 
     case USB_DEVICE_ID_RAZER_CYNOSA_CHROMA:
-        device_type = "Razer Cynosa Chroma\n";
+        device_type = "Razer Cynosa Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_CYNOSA_CHROMA_PRO:
-        device_type = "Razer Cynosa Chroma Pro\n";
+        device_type = "Razer Cynosa Chroma Pro";
         break;
 
     case USB_DEVICE_ID_RAZER_CYNOSA_LITE:
-        device_type = "Razer Cynosa Lite\n";
+        device_type = "Razer Cynosa Lite";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA_V2:
-        device_type = "Razer BlackWidow Chroma V2\n";
+        device_type = "Razer BlackWidow Chroma V2";
         break;
 
     case USB_DEVICE_ID_RAZER_ANANSI:
-        device_type = "Razer Anansi\n";
+        device_type = "Razer Anansi";
         break;
 
     case USB_DEVICE_ID_RAZER_CYNOSA_V2:
-        device_type = "Razer Cynosa V2\n";
+        device_type = "Razer Cynosa V2";
         break;
 
     case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI:
-        device_type = "Razer Huntsman Mini\n";
+        device_type = "Razer Huntsman Mini";
         break;
 
     case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI_JP:
-        device_type = "Razer Huntsman Mini (JP)\n";
+        device_type = "Razer Huntsman Mini (JP)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3:
-        device_type = "Razer BlackWidow V3\n";
+        device_type = "Razer BlackWidow V3";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRED:
-        device_type = "Razer BlackWidow V3 Pro (Wired)\n";
+        device_type = "Razer BlackWidow V3 Pro (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_PRO_WIRELESS:
-        device_type = "Razer BlackWidow V3 Pro (Wireless)\n";
+        device_type = "Razer BlackWidow V3 Pro (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_TK:
-        device_type = "Razer BlackWidow V3 Tenkeyless\n";
+        device_type = "Razer BlackWidow V3 Tenkeyless";
         break;
 
     case USB_DEVICE_ID_RAZER_HUNTSMAN_V2_TENKEYLESS:
-        device_type = "Razer Huntsman V2 Tenkeyless\n";
+        device_type = "Razer Huntsman V2 Tenkeyless";
         break;
 
     case USB_DEVICE_ID_RAZER_HUNTSMAN_V2:
-        device_type = "Razer Huntsman V2\n";
+        device_type = "Razer Huntsman V2";
         break;
 
     case USB_DEVICE_ID_RAZER_HUNTSMAN_V2_ANALOG:
-        device_type = "Razer Huntsman V2 Analog\n";
+        device_type = "Razer Huntsman V2 Analog";
         break;
 
     case USB_DEVICE_ID_RAZER_HUNTSMAN_MINI_ANALOG:
-        device_type = "Razer Huntsman Mini Analog\n";
+        device_type = "Razer Huntsman Mini Analog";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_MINI_HYPERSPEED_WIRED:
-        device_type = "Razer BlackWidow V3 Mini HyperSpeed (Wired)\n";
+        device_type = "Razer BlackWidow V3 Mini HyperSpeed (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V3_MINI_HYPERSPEED_WIRELESS:
-        device_type = "Razer BlackWidow V3 Mini HyperSpeed (Wireless)\n";
+        device_type = "Razer BlackWidow V3 Mini HyperSpeed (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_MINI_HYPERSPEED_WIRED:
-        device_type = "Razer BlackWidow V4 Mini Hyperspeed (Wired)\n";
+        device_type = "Razer BlackWidow V4 Mini Hyperspeed (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_MINI_HYPERSPEED_WIRELESS:
-        device_type = "Razer BlackWidow V4 Mini Hyperspeed (Wireless)\n";
+        device_type = "Razer BlackWidow V4 Mini Hyperspeed (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_17_2022:
-        device_type = "Razer Blade 17 (2022)\n";
+        device_type = "Razer Blade 17 (2022)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_14_2022:
-        device_type = "Razer Blade 14 (2022)\n";
+        device_type = "Razer Blade 14 (2022)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_15_ADV_EARLY_2022:
-        device_type = "Razer Blade 15 Advanced (Early 2022)\n";
+        device_type = "Razer Blade 15 Advanced (Early 2022)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_14_2023:
-        device_type = "Razer Blade 14 (2023)\n";
+        device_type = "Razer Blade 14 (2023)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_14_2024:
-        device_type = "Razer Blade 14 (2024)\n";
+        device_type = "Razer Blade 14 (2024)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_14_2025:
-        device_type = "Razer Blade 14 (2025)\n";
+        device_type = "Razer Blade 14 (2025)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_15_2023:
-        device_type = "Razer Blade 15 (2023)\n";
+        device_type = "Razer Blade 15 (2023)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2:
-        device_type = "Razer DeathStalker V2\n";
+        device_type = "Razer DeathStalker V2";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRED:
-        device_type = "Razer DeathStalker V2 Pro (Wired)\n";
+        device_type = "Razer DeathStalker V2 Pro (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_WIRELESS:
-        device_type = "Razer DeathStalker V2 Pro (Wireless)\n";
+        device_type = "Razer DeathStalker V2 Pro (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4:
-        device_type = "Razer BlackWidow V4\n";
+        device_type = "Razer BlackWidow V4";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_X:
-        device_type = "Razer BlackWidow V4 X\n";
+        device_type = "Razer BlackWidow V4 X";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_PRO:
-        device_type = "Razer BlackWidow V4 Pro\n";
+        device_type = "Razer BlackWidow V4 Pro";
         break;
 
     case USB_DEVICE_ID_RAZER_BLACKWIDOW_V4_75PCT:
-        device_type = "Razer BlackWidow V4 75%\n";
+        device_type = "Razer BlackWidow V4 75%";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRED:
-        device_type = "Razer DeathStalker V2 Pro TKL (Wired)\n";
+        device_type = "Razer DeathStalker V2 Pro TKL (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHSTALKER_V2_PRO_TKL_WIRELESS:
-        device_type = "Razer DeathStalker V2 Pro TKL (Wireless)\n";
+        device_type = "Razer DeathStalker V2 Pro TKL (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_16_2023:
-        device_type = "Razer Blade 16 (2023)\n";
+        device_type = "Razer Blade 16 (2023)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_16_2025:
-        device_type = "Razer Blade 16 (2025)\n";
+        device_type = "Razer Blade 16 (2025)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_18_2023:
-        device_type = "Razer Blade 18 (2023)\n";
+        device_type = "Razer Blade 18 (2023)";
         break;
 
     case USB_DEVICE_ID_RAZER_HUNTSMAN_V3_PRO:
-        device_type = "Razer Huntsman V3 Pro\n";
+        device_type = "Razer Huntsman V3 Pro";
         break;
 
     case USB_DEVICE_ID_RAZER_HUNTSMAN_V3_PRO_TKL:
-        device_type = "Razer Huntsman V3 Pro TKL\n";
+        device_type = "Razer Huntsman V3 Pro TKL";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_18_2024:
-        device_type = "Razer Blade 18 (2024)\n";
+        device_type = "Razer Blade 18 (2024)";
         break;
 
     case USB_DEVICE_ID_RAZER_BLADE_18_2025:
-        device_type = "Razer Blade 18 (2025)\n";
+        device_type = "Razer Blade 18 (2025)";
         break;
 
     default:
-        device_type = "Unknown Device\n";
+        device_type = "Unknown Device";
     }
 
-    return sprintf(buf, device_type);
+    return sprintf(buf, "%s\n", device_type);
 }
 
 /**

--- a/driver/razerkraken_driver.c
+++ b/driver/razerkraken_driver.c
@@ -204,30 +204,30 @@ static ssize_t razer_attr_read_device_type(struct device *dev, struct device_att
     switch (device->usb_pid) {
     case USB_DEVICE_ID_RAZER_KRAKEN_CLASSIC:
     case USB_DEVICE_ID_RAZER_KRAKEN_CLASSIC_ALT:
-        device_type = "Razer Kraken 7.1\n";
+        device_type = "Razer Kraken 7.1";
         break;
 
     case USB_DEVICE_ID_RAZER_KRAKEN:
-        device_type = "Razer Kraken 7.1 Chroma\n"; // Rainie
+        device_type = "Razer Kraken 7.1 Chroma"; // Rainie
         break;
 
     case USB_DEVICE_ID_RAZER_KRAKEN_V2:
-        device_type = "Razer Kraken 7.1 V2\n"; // Kylie
+        device_type = "Razer Kraken 7.1 V2"; // Kylie
         break;
 
     case USB_DEVICE_ID_RAZER_KRAKEN_ULTIMATE:
-        device_type = "Razer Kraken Ultimate\n";
+        device_type = "Razer Kraken Ultimate";
         break;
 
     case USB_DEVICE_ID_RAZER_KRAKEN_KITTY_V2:
-        device_type = "Razer Kraken Kitty V2\n";
+        device_type = "Razer Kraken Kitty V2";
         break;
 
     default:
-        device_type = "Unknown Device\n";
+        device_type = "Unknown Device";
     }
 
-    return sprintf(buf, device_type);
+    return sprintf(buf, "%s\n", device_type);
 }
 
 /**

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -289,448 +289,448 @@ static ssize_t razer_attr_read_device_type(struct device *dev, struct device_att
 
     switch (device->usb_pid) {
     case USB_DEVICE_ID_RAZER_DEATHADDER_3_5G:
-        device_type = "Razer DeathAdder 3.5G\n";
+        device_type = "Razer DeathAdder 3.5G";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_3_5G_BLACK:
-        device_type = "Razer DeathAdder 3.5G Black\n";
+        device_type = "Razer DeathAdder 3.5G Black";
         break;
 
     case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRED:
-        device_type = "Razer Mamba 2012 (Wired)\n";
+        device_type = "Razer Mamba 2012 (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_MAMBA_2012_WIRELESS:
-        device_type = "Razer Mamba 2012 (Wireless)\n";
+        device_type = "Razer Mamba 2012 (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_MAMBA_WIRED:
-        device_type = "Razer Mamba (Wired)\n";
+        device_type = "Razer Mamba (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS:
-        device_type = "Razer Mamba (Wireless)\n";
+        device_type = "Razer Mamba (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_MAMBA_TE_WIRED:
-        device_type = "Razer Mamba Tournament Edition\n";
+        device_type = "Razer Mamba Tournament Edition";
         break;
 
     case USB_DEVICE_ID_RAZER_ABYSSUS:
-        device_type = "Razer Abyssus 2014\n";
+        device_type = "Razer Abyssus 2014";
         break;
 
     case USB_DEVICE_ID_RAZER_ABYSSUS_1800:
-        device_type = "Razer Abyssus 1800\n";
+        device_type = "Razer Abyssus 1800";
         break;
 
     case USB_DEVICE_ID_RAZER_ABYSSUS_2000:
-        device_type = "Razer Abyssus 2000\n";
+        device_type = "Razer Abyssus 2000";
         break;
 
     case USB_DEVICE_ID_RAZER_IMPERATOR:
-        device_type = "Razer Imperator 2012\n";
+        device_type = "Razer Imperator 2012";
         break;
 
     case USB_DEVICE_ID_RAZER_OUROBOROS:
-        device_type = "Razer Ouroboros\n";
+        device_type = "Razer Ouroboros";
         break;
 
     case USB_DEVICE_ID_RAZER_OROCHI_2011:
-        device_type = "Razer Orochi 2011\n";
+        device_type = "Razer Orochi 2011";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_2013:
-        device_type = "Razer DeathAdder 2013\n";
+        device_type = "Razer DeathAdder 2013";
         break;
 
     case USB_DEVICE_ID_RAZER_OROCHI_2013:
-        device_type = "Razer Orochi 2013\n";
+        device_type = "Razer Orochi 2013";
         break;
 
     case USB_DEVICE_ID_RAZER_OROCHI_CHROMA:
-        device_type = "Razer Orochi (Wired)\n";
+        device_type = "Razer Orochi (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_CHROMA:
-        device_type = "Razer DeathAdder Chroma\n";
+        device_type = "Razer DeathAdder Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_HEX_RED:
-        device_type = "Razer Naga Hex (Red)\n";
+        device_type = "Razer Naga Hex (Red)";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_HEX:
-        device_type = "Razer Naga Hex\n";
+        device_type = "Razer Naga Hex";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA:
-        device_type = "Razer Naga\n";
+        device_type = "Razer Naga";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_2012:
-        device_type = "Razer Naga 2012\n";
+        device_type = "Razer Naga 2012";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_EPIC:
-        device_type = "Razer Naga Epic\n";
+        device_type = "Razer Naga Epic";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_2014:
-        device_type = "Razer Naga 2014\n";
+        device_type = "Razer Naga 2014";
         break;
 
     case USB_DEVICE_ID_RAZER_TAIPAN:
-        device_type = "Razer Taipan\n";
+        device_type = "Razer Taipan";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_HEX_V2:
-        device_type = "Razer Naga Hex V2\n";
+        device_type = "Razer Naga Hex V2";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_CHROMA:
-        device_type = "Razer Naga Chroma\n";
+        device_type = "Razer Naga Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_X:
-        device_type = "Razer Naga X\n";
+        device_type = "Razer Naga X";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_ELITE:
-        device_type = "Razer DeathAdder Elite\n";
+        device_type = "Razer DeathAdder Elite";
         break;
 
     case USB_DEVICE_ID_RAZER_ABYSSUS_V2:
-        device_type = "Razer Abyssus V2\n";
+        device_type = "Razer Abyssus V2";
         break;
 
     case USB_DEVICE_ID_RAZER_DIAMONDBACK_CHROMA:
-        device_type = "Razer Diamondback Chroma\n";
+        device_type = "Razer Diamondback Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_3500:
-        device_type = "Razer DeathAdder 3500\n";
+        device_type = "Razer DeathAdder 3500";
         break;
 
     case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRED:
-        device_type = "Razer Lancehead (Wired)\n";
+        device_type = "Razer Lancehead (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS:
-        device_type = "Razer Lancehead (Wireless)\n";
+        device_type = "Razer Lancehead (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_LANCEHEAD_TE_WIRED:
-        device_type = "Razer Lancehead Tournament Edition\n";
+        device_type = "Razer Lancehead Tournament Edition";
         break;
 
     case USB_DEVICE_ID_RAZER_MAMBA_ELITE:
-        device_type = "Razer Mamba Elite\n";
+        device_type = "Razer Mamba Elite";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL:
-        device_type = "Razer DeathAdder Essential\n";
+        device_type = "Razer DeathAdder Essential";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_2021:
-        device_type = "Razer DeathAdder Essential (2021)\n";
+        device_type = "Razer DeathAdder Essential (2021)";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
-        device_type = "Razer Naga Trinity\n";
+        device_type = "Razer Naga Trinity";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_1800:
-        device_type = "Razer DeathAdder 1800\n";
+        device_type = "Razer DeathAdder 1800";
         break;
 
     case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_RECEIVER:
-        device_type = "Razer Lancehead Wireless (Receiver)\n";
+        device_type = "Razer Lancehead Wireless (Receiver)";
         break;
 
     case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_WIRED:
-        device_type = "Razer Lancehead Wireless (Wired)\n";
+        device_type = "Razer Lancehead Wireless (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_RECEIVER:
-        device_type = "Razer Mamba Wireless (Receiver)\n";
+        device_type = "Razer Mamba Wireless (Receiver)";
         break;
 
     case USB_DEVICE_ID_RAZER_MAMBA_WIRELESS_WIRED:
-        device_type = "Razer Mamba Wireless (Wired)\n";
+        device_type = "Razer Mamba Wireless (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_ABYSSUS_ELITE_DVA_EDITION:
-        device_type = "Razer Abyssus Elite (D.Va Edition)\n";
+        device_type = "Razer Abyssus Elite (D.Va Edition)";
         break;
 
     case USB_DEVICE_ID_RAZER_ABYSSUS_ESSENTIAL:
-        device_type = "Razer Abyssus Essential\n";
+        device_type = "Razer Abyssus Essential";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_ESSENTIAL_WHITE_EDITION:
-        device_type = "Razer DeathAdder Essential (White Edition)\n";
+        device_type = "Razer DeathAdder Essential (White Edition)";
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER:
-        device_type = "Razer Viper\n";
+        device_type = "Razer Viper";
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER_MINI:
-        device_type = "Razer Viper Mini\n";
+        device_type = "Razer Viper Mini";
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER_MINI_SE_WIRED:
-        device_type = "Razer Viper Mini Signature Edition (Wired)\n";
+        device_type = "Razer Viper Mini Signature Edition (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER_MINI_SE_WIRELESS:
-        device_type = "Razer Viper Mini Signature Edition (Wireless)\n";
+        device_type = "Razer Viper Mini Signature Edition (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRED:
-        device_type = "Razer Viper Ultimate (Wired)\n";
+        device_type = "Razer Viper Ultimate (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
-        device_type = "Razer Viper Ultimate (Wireless)\n";
+        device_type = "Razer Viper Ultimate (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER_V2_PRO_WIRED:
-        device_type = "Razer Viper V2 Pro (Wired)\n";
+        device_type = "Razer Viper V2 Pro (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER_V2_PRO_WIRELESS:
-        device_type = "Razer Viper V2 Pro (Wireless)\n";
+        device_type = "Razer Viper V2 Pro (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK:
-        device_type = "Razer Basilisk\n";
+        device_type = "Razer Basilisk";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_ESSENTIAL:
-        device_type = "Razer Basilisk Essential\n";
+        device_type = "Razer Basilisk Essential";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_WIRED:
-        device_type = "Razer Basilisk Ultimate (Wired)\n";
+        device_type = "Razer Basilisk Ultimate (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
-        device_type = "Razer Basilisk Ultimate (Receiver)\n";
+        device_type = "Razer Basilisk Ultimate (Receiver)";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_V2:
-        device_type = "Razer Basilisk V2\n";
+        device_type = "Razer Basilisk V2";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_V3:
-        device_type = "Razer Basilisk V3\n";
+        device_type = "Razer Basilisk V3";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2:
-        device_type = "Razer DeathAdder V2\n";
+        device_type = "Razer DeathAdder V2";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRED:
-        device_type = "Razer DeathAdder V2 Pro (Wired)\n";
+        device_type = "Razer DeathAdder V2 Pro (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
-        device_type = "Razer DeathAdder V2 Pro (Wireless)\n";
+        device_type = "Razer DeathAdder V2 Pro (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V3:
-        device_type = "Razer DeathAdder V3\n";
+        device_type = "Razer DeathAdder V3";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V3_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V3_PRO_WIRED_ALT:
-        device_type = "Razer DeathAdder V3 Pro (Wired)\n";
+        device_type = "Razer DeathAdder V3 Pro (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V3_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V3_PRO_WIRELESS_ALT:
-        device_type = "Razer DeathAdder V3 Pro (Wireless)\n";
+        device_type = "Razer DeathAdder V3 Pro (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V3_HYPERSPEED_WIRED:
-        device_type = "Razer DeathAdder V3 HyperSpeed (Wired)\n";
+        device_type = "Razer DeathAdder V3 HyperSpeed (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V3_HYPERSPEED_WIRELESS:
-        device_type = "Razer DeathAdder V3 HyperSpeed (Wireless)\n";
+        device_type = "Razer DeathAdder V3 HyperSpeed (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_HYPERPOLLING_WIRELESS_DONGLE:
-        device_type = "Razer HyperPolling Wireless Dongle\n";
+        device_type = "Razer HyperPolling Wireless Dongle";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_WIRED:
-        device_type = "Razer Basilisk V3 Pro (Wired)\n";
+        device_type = "Razer Basilisk V3 Pro (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_WIRELESS:
-        device_type = "Razer Basilisk V3 Pro (Wireless)\n";
+        device_type = "Razer Basilisk V3 Pro (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_V3_35K:
-        device_type = "Razer Basilisk V3 35K\n";
+        device_type = "Razer Basilisk V3 35K";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_35K_WIRED:
-        device_type = "Razer Basilisk V3 Pro 35K (Wired)\n";
+        device_type = "Razer Basilisk V3 Pro 35K (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_35K_WIRELESS:
-        device_type = "Razer Basilisk V3 Pro 35K (Wireless)\n";
+        device_type = "Razer Basilisk V3 Pro 35K (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_35K_PHANTOM_GREEN_EDITION_WIRED:
-        device_type = "Razer Basilisk V3 Pro 35K Phantom Green Edition (Wired)\n";
+        device_type = "Razer Basilisk V3 Pro 35K Phantom Green Edition (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_V3_PRO_35K_PHANTOM_GREEN_EDITION_WIRELESS:
-        device_type = "Razer Basilisk V3 Pro 35K Phantom Green Edition (Wireless)\n";
+        device_type = "Razer Basilisk V3 Pro 35K Phantom Green Edition (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_MINI:
-        device_type = "Razer DeathAdder V2 Mini\n";
+        device_type = "Razer DeathAdder V2 Mini";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_2000:
-        device_type = "Razer DeathAdder 2000\n";
+        device_type = "Razer DeathAdder 2000";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_X_HYPERSPEED:
-        device_type = "Razer DeathAdder V2 X HyperSpeed\n";
+        device_type = "Razer DeathAdder V2 X HyperSpeed";
         break;
 
     case USB_DEVICE_ID_RAZER_ATHERIS_RECEIVER:
-        device_type = "Razer Atheris (Receiver)\n";
+        device_type = "Razer Atheris (Receiver)";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
-        device_type = "Razer Basilisk X HyperSpeed\n";
+        device_type = "Razer Basilisk X HyperSpeed";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_LEFT_HANDED_2020:
-        device_type = "Razer Naga Left-Handed Edition 2020\n";
+        device_type = "Razer Naga Left-Handed Edition 2020";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED:
-        device_type = "Razer Naga Pro (Wired)\n";
+        device_type = "Razer Naga Pro (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
-        device_type = "Razer Naga Pro (Wireless)\n";
+        device_type = "Razer Naga Pro (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER_8K:
-        device_type = "Razer Viper 8KHz\n";
+        device_type = "Razer Viper 8KHz";
         break;
 
     case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
-        device_type = "Razer Orochi V2 (Receiver)\n";
+        device_type = "Razer Orochi V2 (Receiver)";
         break;
 
     case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
-        device_type = "Razer Orochi V2 (Bluetooth)\n";
+        device_type = "Razer Orochi V2 (Bluetooth)";
         break;
 
     case USB_DEVICE_ID_RAZER_PRO_CLICK_RECEIVER:
-        device_type = "Razer Pro Click (Receiver)\n";
+        device_type = "Razer Pro Click (Receiver)";
         break;
 
     case USB_DEVICE_ID_RAZER_PRO_CLICK_WIRED:
-        device_type = "Razer Pro Click (Wired)\n";
+        device_type = "Razer Pro Click (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
-        device_type = "Razer Naga Epic Chroma\n";
+        device_type = "Razer Naga Epic Chroma";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
-        device_type = "Razer Naga Epic Chroma Dock\n";
+        device_type = "Razer Naga Epic Chroma Dock";
         break;
 
     case USB_DEVICE_ID_RAZER_PRO_CLICK_MINI_RECEIVER:
-        device_type = "Razer Pro Click Mini (Receiver)\n";
+        device_type = "Razer Pro Click Mini (Receiver)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_LITE:
-        device_type = "Razer DeathAdder V2 Lite\n";
+        device_type = "Razer DeathAdder V2 Lite";
         break;
 
     case USB_DEVICE_ID_RAZER_COBRA:
-        device_type = "Razer Cobra\n";
+        device_type = "Razer Cobra";
         break;
 
     case USB_DEVICE_ID_RAZER_COBRA_PRO_WIRELESS:
-        device_type = "Razer Cobra Pro (Wireless)\n";
+        device_type = "Razer Cobra Pro (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_COBRA_PRO_WIRED:
-        device_type = "Razer Cobra Pro (Wired)\n";
+        device_type = "Razer Cobra Pro (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER_V3_HYPERSPEED:
-        device_type = "Razer Viper V3 HyperSpeed\n";
+        device_type = "Razer Viper V3 HyperSpeed";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_V2_HYPERSPEED_RECEIVER:
-        device_type = "Razer Naga V2 HyperSpeed (Receiver)\n";
+        device_type = "Razer Naga V2 HyperSpeed (Receiver)";
         break;
 
     case USB_DEVICE_ID_RAZER_BASILISK_V3_X_HYPERSPEED:
-        device_type = "Razer Basilisk V3 X HyperSpeed\n";
+        device_type = "Razer Basilisk V3 X HyperSpeed";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V4_PRO_WIRED:
-        device_type = "Razer DeathAdder V4 Pro (Wired)\n";
+        device_type = "Razer DeathAdder V4 Pro (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_DEATHADDER_V4_PRO_WIRELESS:
-        device_type = "Razer DeathAdder V4 Pro (Wireless)\n";
+        device_type = "Razer DeathAdder V4 Pro (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER_V3_PRO_WIRED:
-        device_type = "Razer Viper V3 Pro (Wired)\n";
+        device_type = "Razer Viper V3 Pro (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER_V3_PRO_WIRELESS:
-        device_type = "Razer Viper V3 Pro (Wireless)\n";
+        device_type = "Razer Viper V3 Pro (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRED:
-        device_type = "Razer Naga V2 Pro (Wired)\n";
+        device_type = "Razer Naga V2 Pro (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRELESS:
-        device_type = "Razer Naga V2 Pro (Wireless)\n";
+        device_type = "Razer Naga V2 Pro (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRELESS:
-        device_type = "Razer Pro Click V2 Vertical Edition (Wireless)\n";
+        device_type = "Razer Pro Click V2 Vertical Edition (Wireless)";
         break;
 
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRED:
-        device_type = "Razer Pro Click V2 Vertical Edition (Wired)\n";
+        device_type = "Razer Pro Click V2 Vertical Edition (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRED:
-        device_type = "Razer Pro Click V2 (Wired)\n";
+        device_type = "Razer Pro Click V2 (Wired)";
         break;
 
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
-        device_type = "Razer Pro Click V2 (Wireless)\n";
+        device_type = "Razer Pro Click V2 (Wireless)";
         break;
 
     default:
-        device_type = "Unknown Device\n";
+        device_type = "Unknown Device";
     }
 
-    return sprintf(buf, device_type);
+    return sprintf(buf, "%s\n", device_type);
 }
 
 /**

--- a/scripts/generate_fake_driver.sh
+++ b/scripts/generate_fake_driver.sh
@@ -173,7 +173,7 @@ while IFS= read -r device_raw; do
     device_pid=$(echo "$device_raw" | cut -d' ' -f2 | sed 's/0x//')
 
     devicetype_line=$(echo "$devicetype_lines" | sed -n '/case '$device':/,/break;/p' | grep "device_type = ")
-    device_name=$(echo "$devicetype_line" | sed 's/[[:space:]]\+device_type = "\(.\+\)\\n";.*/\1/' | sed 's/%/%%/g')
+    device_name=$(echo "$devicetype_line" | sed 's/[[:space:]]\+device_type = "\(.\+\)";.*/\1/' | sed 's/%/%%/g')
 
     #echo "-----------------------------" >&2
     echo "Generating for $device_name (1532:$device_pid) ..." >&2


### PR DESCRIPTION
We shouldn't pass a string to print directly to sprintf, but should instead use a proper format string.

This also fixes printing "Razer BlackWidow V4 75%" because the last percent was interpreted as a format string. And this way we also don't have to add \n to every single device_type line which will also make things easier for refactoring in the future.

Fixes #2628