### PR TITLE
Fix missing 8000 Hz poll rate for DeathAdder V4 Pro

### DIFF
--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -1810,8 +1810,6 @@ static ssize_t razer_attr_read_poll_rate(struct device *dev, struct device_attri
     case USB_DEVICE_ID_RAZER_NAGA_V2_HYPERSPEED_RECEIVER:
     case USB_DEVICE_ID_RAZER_VIPER_V3_HYPERSPEED:
     case USB_DEVICE_ID_RAZER_BASILISK_V3_X_HYPERSPEED:
-    case USB_DEVICE_ID_RAZER_DEATHADDER_V4_PRO_WIRED:
-    case USB_DEVICE_ID_RAZER_DEATHADDER_V4_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_VIPER_V3_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRELESS:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRED:
@@ -1826,6 +1824,8 @@ static ssize_t razer_attr_read_poll_rate(struct device *dev, struct device_attri
     case USB_DEVICE_ID_RAZER_VIPER_MINI_SE_WIRELESS:
     case USB_DEVICE_ID_RAZER_HYPERPOLLING_WIRELESS_DONGLE:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V3:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V4_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_DEATHADDER_V4_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_VIPER_V3_PRO_WIRELESS:
         request = razer_chroma_misc_get_polling_rate2();
         request.transaction_id.id = 0x1f;


### PR DESCRIPTION
The device is capable of 8000 Hz wireless and wired, but 8000 Hz could only be set in wired mode. It is capped at 1000 Hz in wireless mode.

This keeps the same transaction ID, but uses the other function so it reads up to 8000 instead. This seems in line with the user's deleted comment:

> Odd? it seems running cat /sys/bus/hid/drivers/razer*/*1532*/poll_rate results in a static 500 even when running echo -n "8000" | sudo tee /sys/bus/hid/drivers/razer*/*1532*/poll_rate

> echo -n "1000" | sudo tee /sys/bus/hid/drivers/razer*/*1532*/poll_rate sets it to 1000 while setting 8000 seems to overload it

Tested by @DekoDX.

Fixes #2714