### PR TITLE
daemon: Resume devices on exit

### DIFF
--- a/daemon/openrazer_daemon/daemon.py
+++ b/daemon/openrazer_daemon/daemon.py
@@ -642,6 +642,10 @@ class RazerDaemon(DBusService):
         else:
             self.logger.info('Stopping daemon on signal %d', signum)
 
+        # "Resume" all devices, in case they're still "suspended"
+        # (lights off because of screensaver)
+        self.resume_devices()
+
         self._main_loop.quit()
 
         # Stop udev monitor


### PR DESCRIPTION
In case the computer is being shut down, while the screensaver is on (so device lights being off), let's "resume" all devices when exiting to restore the previous brightness.

Fixes #2673