### PR TITLE
pylib: Clean up return types of various methods

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -7,6 +7,7 @@ packages:
   - py3-daemonize
   - py3-dbus
   - py3-gobject3
+  - py3-mypy
   - py3-numpy
   - py3-pylint
   - py3-setproctitle
@@ -35,6 +36,8 @@ tasks:
       ./scripts/ci/test-hex-casing.sh
       # Check for Python version compatibility
       ./scripts/ci/test-vermin.sh
+      # Check for Python typing issues
+      ./scripts/ci/test-mypy.sh
 
   - compile-driver: |
       cd openrazer

--- a/pylib/openrazer/_fake_driver/__init__.py
+++ b/pylib/openrazer/_fake_driver/__init__.py
@@ -17,14 +17,14 @@ KEY_ACTION = {
 }
 
 
-def touch(fname, times=None):
+def touch(fname: str) -> None:
     with open(fname, 'a'):
-        os.utime(fname, times)
+        os.utime(fname)
 
 
 class FakeDevice(object):
     @staticmethod
-    def parse_endpoint_line(line):
+    def parse_endpoint_line(line: str) -> tuple[int, str, str | None, str]:
         components = line.split(',')
 
         if len(components) == 2:
@@ -38,16 +38,16 @@ class FakeDevice(object):
         orig_perm = chmod
 
         if chmod == 'r':
-            chmod = 0o660
+            chmod_int = 0o660
         elif chmod == 'w':
-            chmod = 0o660
+            chmod_int = 0o660
         else:
-            chmod = 0o660
+            chmod_int = 0o660
 
-        return chmod, name, default, orig_perm
+        return chmod_int, name, default, orig_perm
 
     @staticmethod
-    def create_endpoint(path, chmod, default=None):
+    def create_endpoint(path: str, chmod: int, default: str | None = None) -> None:
         if os.path.exists(path):
             os.chmod(path, 0o660)
             os.remove(path)
@@ -55,17 +55,17 @@ class FakeDevice(object):
         if default is not None:
             # Convert to bytes
             if default.startswith("0x"):
-                default = bytes.fromhex(default[2:])
+                default_bin = bytes.fromhex(default[2:])
             else:
-                default = default.encode('UTF-8')
+                default_bin = default.encode('UTF-8')
 
             with open(path, 'wb') as f:
-                f.write(default)
+                f.write(default_bin)
         else:
             touch(path)
         os.chmod(path, chmod)
 
-    def __init__(self, spec_name, serial=None, tmp_dir=os.environ.get('TMPDIR', '/tmp')):
+    def __init__(self, spec_name: str, serial: str | None = None, tmp_dir: str = os.environ.get('TMPDIR', '/tmp')):
 
         if spec_name not in SPECS:
             raise ValueError("Spec {0} not in SPECS".format(spec_name))
@@ -79,8 +79,8 @@ class FakeDevice(object):
         self._tmp_dir = os.path.join(tmp_dir, self._config.get('device', 'dir_name'))
         os.makedirs(self._tmp_dir, exist_ok=True)
 
-        self.endpoints = {}
-        self.events = {}
+        self.endpoints: dict[str, tuple[int, str | None, str]] = {}
+        self.events: dict[str, tuple[str, int]] = {}
         self.create_endpoints()
         self.create_events()
 
@@ -90,23 +90,23 @@ class FakeDevice(object):
         # Disallow write in directory, so disallow creating new files after setup is done.
         os.chmod(self._tmp_dir, 0o555)
 
-    def _get_endpoint_path(self, endpoint):
+    def _get_endpoint_path(self, endpoint: str) -> str:
         return os.path.join(self._tmp_dir, endpoint)
 
-    def _get_event_path(self, event):
+    def _get_event_path(self, event: str) -> str:
         return os.path.join(self._tmp_dir, 'input', event)
 
-    def create_events(self):
+    def create_events(self) -> None:
         """
         Goes through event files and creates them as needed
         """
-        event_files = self._config.get('device', 'event', fallback=None)
+        event_files: str | None = self._config.get('device', 'event', fallback=None)
         if event_files is None:
-            event_files = []
+            event_files_list = []
         else:
-            event_files = event_files.splitlines()
+            event_files_list = event_files.splitlines()
 
-        for index, event_file in enumerate(event_files):
+        for index, event_file in enumerate(event_files_list):
             path = self._get_event_path(event_file)
 
             os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -118,7 +118,7 @@ class FakeDevice(object):
 
             self.events[str(index)] = (event_file, file_object)
 
-    def create_endpoints(self):
+    def create_endpoints(self) -> None:
         for endpoint_line in self._config.get('device', 'files').splitlines():
             chmod, name, default, orig_perm = self.parse_endpoint_line(endpoint_line)
             path = self._get_endpoint_path(name)
@@ -128,7 +128,7 @@ class FakeDevice(object):
             self.endpoints[name] = (chmod, default, orig_perm)
             self.create_endpoint(path, chmod, default)
 
-    def get(self, endpoint, binary=False):
+    def get(self, endpoint: str, binary: bool = False) -> str | bytes:
         """
         Gets a value from a given endpoint
 
@@ -157,9 +157,12 @@ class FakeDevice(object):
         except UnicodeDecodeError as e:
             return str(e)
 
+        if not isinstance(result, bytes) and not isinstance(result, str):
+            raise ValueError(f"Got invalid type in result: {type(result)}")
+
         return result
 
-    def set(self, endpoint, value, binary=False):
+    def set(self, endpoint: str, value: str, binary: bool = False) -> None:
         if endpoint not in self.endpoints:
             raise ValueError("Endpoint {0} does not exist".format(endpoint))
 
@@ -173,23 +176,23 @@ class FakeDevice(object):
         with open(path, write_mode) as open_endpoint:
             open_endpoint.write(value)
 
-    def emit_kb_event(self, file_id, key_code, value):
+    def emit_kb_event(self, file_id: str, key_code: int, value: str) -> int:
 
         if file_id not in self.events:
             raise ValueError("file_id {0} does not exist".format(file_id))
 
         if value in KEY_ACTION:
-            value = KEY_ACTION[value]
+            value_int = KEY_ACTION[value]
         else:
-            value = 0x00
+            value_int = 0x00
 
-        event_binary = struct.pack(EVENT_FORMAT, self._tick, 0, EV_KEY, key_code, value)
+        event_binary = struct.pack(EVENT_FORMAT, self._tick, 0, EV_KEY, key_code, value_int)
         pipe_fd = self.events[file_id][1]
         os.write(pipe_fd, event_binary)
 
         return len(event_binary)
 
-    def close(self):
+    def close(self) -> None:
         if os.path.exists(self._tmp_dir):
             # Allow deletion
             for endpoint in self.endpoints:

--- a/pylib/openrazer/client/device.py
+++ b/pylib/openrazer/client/device.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-import dbus
+import dbus  # type: ignore
 from openrazer.client.devices import RazerDevice, BaseDeviceFactory
 from openrazer.client.devices.mousemat import RazerMousemat
 from openrazer.client.devices.keyboard import RazerKeyboard

--- a/pylib/openrazer/client/device_manager.py
+++ b/pylib/openrazer/client/device_manager.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import json
-import dbus as _dbus
+import dbus as _dbus  # type: ignore
 from openrazer.client.device import RazerDeviceFactory as _RazerDeviceFactory
 from openrazer.client.devices import RazerDevice as _RazerDevice
 
@@ -92,7 +92,8 @@ class DeviceManager(object):
     def supported_devices(self) -> dict[str, tuple[int, int]]:
         json_data = self._dbus_daemon.supportedDevices()
 
-        return json.loads(json_data)
+        data: dict[str, tuple[int, int]] = json.loads(json_data)
+        return data
 
     @property
     def devices(self) -> list[_RazerDevice]:

--- a/pylib/openrazer/client/devices/__init__.py
+++ b/pylib/openrazer/client/devices/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 from collections.abc import Iterable
-import dbus as _dbus
+import dbus as _dbus  # type: ignore
 from openrazer.client.fx import RazerFX as _RazerFX
 from xml.etree import ElementTree as _ET
 from openrazer.client.macro import RazerMacro as _RazerMacro
@@ -218,7 +218,8 @@ class RazerDevice(object):
 
         # Nasty hack to convert dbus.Int32 into native
         if self.has('lighting_led_matrix'):
-            self._matrix_dimensions = tuple([int(dim) for dim in self._dbus_interfaces['device'].getMatrixDimensions()])
+            matrix_dims = self._dbus_interfaces['device'].getMatrixDimensions()
+            self._matrix_dimensions = (int(matrix_dims[0]), int(matrix_dims[1]))
         else:
             self._matrix_dimensions = None
 

--- a/pylib/openrazer/client/fx.py
+++ b/pylib/openrazer/client/fx.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+from collections.abc import Callable
+from typing import Any
 import numpy as _np
 import numpy.typing as _npt
-import dbus as _dbus
+import dbus as _dbus  # type: ignore
 # from openrazer.client.constants import WAVE_LEFT, WAVE_RIGHT, REACTIVE_500MS, REACTIVE_1000MS, REACTIVE_1500MS, REACTIVE_2000MS
 from openrazer.client import constants as c
-from types import FunctionType
 
 # TODO logging.debug if value out of range v1.1
 
@@ -641,9 +642,12 @@ class SingleLed(BaseRazerFX):
     def _shas(self, item: str) -> bool:
         return self.has('{0}_{1}'.format(self._led_name, item))
 
-    def _getattr(self, name: str) -> FunctionType:
-        attr = name.replace('#', self._led_name.title().replace("_", ""))
-        return getattr(self._lighting_dbus, attr, None)
+    def _getattr(self, name: str) -> Callable[..., Any]:
+        attr_name = name.replace('#', self._led_name.title().replace("_", ""))
+        attr = getattr(self._lighting_dbus, attr_name, None)
+        if not callable(attr):
+            raise RuntimeError(f"Expected to get callable, got {type(attr)}")
+        return attr  # type: ignore
 
     @property
     def active(self) -> bool:

--- a/pylib/openrazer/client/fx.py
+++ b/pylib/openrazer/client/fx.py
@@ -111,6 +111,8 @@ class RazerAdvancedFX(BaseRazerFX):
                     raise ValueError("Row or column out of bounds. Max dimensions are: {0},{1}".format(*self._matrix_dims))
             else:
                 raise ValueError("RGB must be an RGB tuple")
+        else:
+            raise NotImplementedError()
 
     def restore(self) -> None:
         """
@@ -181,41 +183,30 @@ class RazerFX(BaseRazerFX):
         """
         return int(self._lighting_dbus.getWaveDir())
 
-    def none(self) -> bool:
+    def none(self) -> None:
         """
         No effect
-
-        :return: True if success, False otherwise
-        :rtype: bool
         """
         if self.has('none'):
             self._lighting_dbus.setNone()
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def spectrum(self) -> bool:
+    def spectrum(self) -> None:
         """
         Spectrum effect
-
-        :return: True if success, False otherwise
-        :rtype: bool
         """
         if self.has('spectrum'):
             self._lighting_dbus.setSpectrum()
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def wave(self, direction: int) -> bool:
+    def wave(self, direction: int) -> None:
         """
         Wave effect
 
         :param direction: Wave direction either WAVE_RIGHT (0x01) or WAVE_LEFT (0x02)
         :type direction: int
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If direction is invalid
         """
@@ -224,19 +215,15 @@ class RazerFX(BaseRazerFX):
 
         if self.has('wave'):
             self._lighting_dbus.setWave(direction)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def wheel(self, direction: int) -> bool:
+    def wheel(self, direction: int) -> None:
         """
         Wheel effect
 
         :param direction: Wheel direction either WHEEL_RIGHT or WHEEL_LEFT
         :type direction: int
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If direction is invalid
         """
@@ -245,11 +232,10 @@ class RazerFX(BaseRazerFX):
 
         if self.has('wheel'):
             self._lighting_dbus.setWheel(direction)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def static(self, red: int, green: int, blue: int) -> bool:
+    def static(self, red: int, green: int, blue: int) -> None:
         """
         Static effect
 
@@ -261,9 +247,6 @@ class RazerFX(BaseRazerFX):
 
         :param blue: Blue component. Must be 0->255
         :type blue: int
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If parameters are invalid
         """
@@ -280,11 +263,10 @@ class RazerFX(BaseRazerFX):
             blue = clamp_ubyte(blue)
 
             self._lighting_dbus.setStatic(red, green, blue)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def reactive(self, red: int, green: int, blue: int, time: int) -> bool:
+    def reactive(self, red: int, green: int, blue: int, time: int) -> None:
         """
         Reactive effect
 
@@ -299,9 +281,6 @@ class RazerFX(BaseRazerFX):
 
         :param blue: Blue component. Must be 0->255
         :type blue: int
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If parameters are invalid
         """
@@ -320,11 +299,10 @@ class RazerFX(BaseRazerFX):
             blue = clamp_ubyte(blue)
 
             self._lighting_dbus.setReactive(red, green, blue, time)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def breath_single(self, red: int, green: int, blue: int) -> bool:
+    def breath_single(self, red: int, green: int, blue: int) -> None:
         """
         Breath effect - single colour
 
@@ -336,9 +314,6 @@ class RazerFX(BaseRazerFX):
 
         :param blue: Blue component. Must be 0->255
         :type blue: int
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If parameters are invalid
         """
@@ -355,12 +330,11 @@ class RazerFX(BaseRazerFX):
             blue = clamp_ubyte(blue)
 
             self._lighting_dbus.setBreathSingle(red, green, blue)
-
-            return True
-        return False
+        else:
+            raise NotImplementedError()
 
     # TODO Change to tuple of rgb
-    def breath_dual(self, red: int, green: int, blue: int, red2: int, green2: int, blue2: int) -> bool:
+    def breath_dual(self, red: int, green: int, blue: int, red2: int, green2: int, blue2: int) -> None:
         """
         Breath effect - single colour
 
@@ -381,9 +355,6 @@ class RazerFX(BaseRazerFX):
 
         :param blue2: Second blue component. Must be 0->255
         :type blue2: int
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If parameters are invalid
         """
@@ -409,11 +380,10 @@ class RazerFX(BaseRazerFX):
             blue2 = clamp_ubyte(blue2)
 
             self._lighting_dbus.setBreathDual(red, green, blue, red2, green2, blue2)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def breath_triple(self, red: int, green: int, blue: int, red2: int, green2: int, blue2: int, red3: int, green3: int, blue3: int) -> bool:
+    def breath_triple(self, red: int, green: int, blue: int, red2: int, green2: int, blue2: int, red3: int, green3: int, blue3: int) -> None:
         """
         Breath effect - single colour
 
@@ -443,9 +413,6 @@ class RazerFX(BaseRazerFX):
 
         :param blue3: Second blue component. Must be 0->255
         :type blue3: int
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If parameters are invalid
         """
@@ -480,11 +447,10 @@ class RazerFX(BaseRazerFX):
             blue3 = clamp_ubyte(blue3)
 
             self._lighting_dbus.setBreathTriple(red, green, blue, red2, green2, blue2, red3, green3, blue3)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def breath_random(self) -> bool:
+    def breath_random(self) -> None:
         """
         Breath effect - random colours
 
@@ -496,11 +462,10 @@ class RazerFX(BaseRazerFX):
 
         if self.has('breath_random'):
             self._lighting_dbus.setBreathRandom()
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def ripple(self, red: int, green: int, blue: int, refreshrate: float = c.RIPPLE_REFRESH_RATE) -> bool:
+    def ripple(self, red: int, green: int, blue: int, refreshrate: float = c.RIPPLE_REFRESH_RATE) -> None:
         """
         Set the Ripple Effect.
 
@@ -516,9 +481,6 @@ class RazerFX(BaseRazerFX):
 
         :param refreshrate: Effect refresh rate
         :type refreshrate: float
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If arguments are invalid
         """
@@ -537,20 +499,16 @@ class RazerFX(BaseRazerFX):
             blue = clamp_ubyte(blue)
 
             self._custom_lighting_dbus.setRipple(red, green, blue, refreshrate)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def ripple_random(self, refreshrate: float = c.RIPPLE_REFRESH_RATE) -> bool:
+    def ripple_random(self, refreshrate: float = c.RIPPLE_REFRESH_RATE) -> None:
         """
         Set the Ripple Effect with random colours
 
         The refresh rate should be set to about 0.05 for a decent effect
         :param refreshrate: Effect refresh rate
         :type refreshrate: float
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If arguments are invalid
         """
@@ -559,11 +517,10 @@ class RazerFX(BaseRazerFX):
 
         if self.has('ripple_random'):
             self._custom_lighting_dbus.setRippleRandomColour(refreshrate)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def starlight_single(self, red: int, green: int, blue: int, time: int) -> bool:
+    def starlight_single(self, red: int, green: int, blue: int, time: int) -> None:
         """
         Starlight effect
 
@@ -578,9 +535,6 @@ class RazerFX(BaseRazerFX):
 
         :param time: Starlight speed
         :type time: int
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If parameters are invalid
         """
@@ -599,11 +553,10 @@ class RazerFX(BaseRazerFX):
             blue = clamp_ubyte(blue)
 
             self._lighting_dbus.setStarlightSingle(red, green, blue, time)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def starlight_dual(self, red: int, green: int, blue: int, red2: int, green2: int, blue2: int, time: int) -> bool:
+    def starlight_dual(self, red: int, green: int, blue: int, red2: int, green2: int, blue2: int, time: int) -> None:
         """
         Starlight effect
 
@@ -657,19 +610,15 @@ class RazerFX(BaseRazerFX):
             blue2 = clamp_ubyte(blue2)
 
             self._lighting_dbus.setStarlightDual(red, green, blue, red2, green2, blue2, time)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def starlight_random(self, time: int) -> bool:
+    def starlight_random(self, time: int) -> None:
         """
         Starlight effect
 
         :param time: Starlight speed
         :type time: int
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If parameters are invalid
         """
@@ -678,9 +627,8 @@ class RazerFX(BaseRazerFX):
 
         if self.has('starlight_random'):
             self._lighting_dbus.setStarlightRandom(time)
-
-            return True
-        return False
+        else:
+            raise NotImplementedError()
 
 
 class SingleLed(BaseRazerFX):
@@ -702,8 +650,7 @@ class SingleLed(BaseRazerFX):
         func = self._getattr('get#Active')
         if func is not None:
             return bool(func())
-        else:
-            return False
+        raise NotImplementedError()
 
     @active.setter
     def active(self, value: bool) -> None:
@@ -713,6 +660,8 @@ class SingleLed(BaseRazerFX):
                 func(True)
             else:
                 func(False)
+        else:
+            raise NotImplementedError()
 
     @property
     def effect(self) -> str:
@@ -772,8 +721,10 @@ class SingleLed(BaseRazerFX):
                 brightness = 0.0
 
             self._getattr('set#Brightness')(brightness)
+        else:
+            raise NotImplementedError()
 
-    def blinking(self, red: int, green: int, blue: int) -> bool:
+    def blinking(self, red: int, green: int, blue: int) -> None:
         if not isinstance(red, int):
             raise ValueError("Red is not an integer")
         if not isinstance(green, int):
@@ -787,11 +738,10 @@ class SingleLed(BaseRazerFX):
             blue = clamp_ubyte(blue)
 
             self._getattr('set#Blinking')(red, green, blue)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def pulsate(self, red: int, green: int, blue: int) -> bool:
+    def pulsate(self, red: int, green: int, blue: int) -> None:
         if not isinstance(red, int):
             raise ValueError("Red is not an integer")
         if not isinstance(green, int):
@@ -805,11 +755,10 @@ class SingleLed(BaseRazerFX):
             blue = clamp_ubyte(blue)
 
             self._getattr('set#Pulsate')(red, green, blue)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def static(self, red: int, green: int, blue: int) -> bool:
+    def static(self, red: int, green: int, blue: int) -> None:
         if not isinstance(red, int):
             raise ValueError("Red is not an integer")
         if not isinstance(green, int):
@@ -823,42 +772,37 @@ class SingleLed(BaseRazerFX):
             blue = clamp_ubyte(blue)
 
             self._getattr('set#Static')(red, green, blue)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def wave(self, direction: int) -> bool:
+    def wave(self, direction: int) -> None:
         if direction not in (c.WAVE_LEFT, c.WAVE_RIGHT):
             raise ValueError("Direction must be WAVE_RIGHT (0x01) or WAVE_LEFT (0x02)")
 
         if self._shas('wave'):
             self._getattr('set#Wave')(direction)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def none(self) -> bool:
+    def none(self) -> None:
         if self._shas('none'):
             self._getattr('set#None')()
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def on(self) -> bool:
+    def on(self) -> None:
         if self._shas('on'):
             self._getattr('set#On')()
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def spectrum(self) -> bool:
+    def spectrum(self) -> None:
         if self._shas('spectrum'):
             self._getattr('set#Spectrum')()
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def reactive(self, red: int, green: int, blue: int, time: int) -> bool:
+    def reactive(self, red: int, green: int, blue: int, time: int) -> None:
         """
         Reactive effect
 
@@ -873,9 +817,6 @@ class SingleLed(BaseRazerFX):
 
         :param blue: Blue component. Must be 0->255
         :type blue: int
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If parameters are invalid
         """
@@ -894,11 +835,10 @@ class SingleLed(BaseRazerFX):
             blue = clamp_ubyte(blue)
 
             self._getattr('set#Reactive')(red, green, blue, time)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def breath_single(self, red: int, green: int, blue: int) -> bool:
+    def breath_single(self, red: int, green: int, blue: int) -> None:
         """
         Breath effect - single colour
 
@@ -910,9 +850,6 @@ class SingleLed(BaseRazerFX):
 
         :param blue: Blue component. Must be 0->255
         :type blue: int
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If parameters are invalid
         """
@@ -929,12 +866,11 @@ class SingleLed(BaseRazerFX):
             blue = clamp_ubyte(blue)
 
             self._getattr('set#BreathSingle')(red, green, blue)
-
-            return True
-        return False
+        else:
+            raise NotImplementedError()
 
     # TODO Change to tuple of rgb
-    def breath_dual(self, red: int, green: int, blue: int, red2: int, green2: int, blue2: int) -> bool:
+    def breath_dual(self, red: int, green: int, blue: int, red2: int, green2: int, blue2: int) -> None:
         """
         Breath effect - single colour
 
@@ -955,9 +891,6 @@ class SingleLed(BaseRazerFX):
 
         :param blue2: Second blue component. Must be 0->255
         :type blue2: int
-
-        :return: True if success, False otherwise
-        :rtype: bool
 
         :raises ValueError: If parameters are invalid
         """
@@ -983,11 +916,10 @@ class SingleLed(BaseRazerFX):
             blue2 = clamp_ubyte(blue2)
 
             self._getattr('set#BreathDual')(red, green, blue, red2, green2, blue2)
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def breath_random(self) -> bool:
+    def breath_random(self) -> None:
         """
         Breath effect - random colours
 
@@ -999,11 +931,10 @@ class SingleLed(BaseRazerFX):
 
         if self._shas('breath_random'):
             self._getattr('set#BreathRandom')()
+        else:
+            raise NotImplementedError()
 
-            return True
-        return False
-
-    def breath_mono(self) -> bool:
+    def breath_mono(self) -> None:
         """
         Breath effect - mono colour
 
@@ -1015,9 +946,8 @@ class SingleLed(BaseRazerFX):
 
         if self._shas('breath_mono'):
             self._getattr('set#BreathMono')()
-
-            return True
-        return False
+        else:
+            raise NotImplementedError()
 
 
 class MiscLighting(BaseRazerFX):

--- a/pylib/openrazer/client/macro.py
+++ b/pylib/openrazer/client/macro.py
@@ -3,9 +3,9 @@
 import json as _json
 from collections.abc import Iterable
 
-import dbus as _dbus
+import dbus as _dbus  # type: ignore
 
-import openrazer_daemon.misc.macro as _daemon_macro
+import openrazer_daemon.misc.macro as _daemon_macro  # type: ignore
 from openrazer_daemon import keyboard
 
 

--- a/scripts/ci/test-mypy.sh
+++ b/scripts/ci/test-mypy.sh
@@ -7,4 +7,4 @@
 # $ mypy --strict daemon/
 # $ mypy --strict pylib/
 
-mypy --strict pylib/openrazer/client/
+mypy --strict pylib/openrazer/

--- a/scripts/ci/test-mypy.sh
+++ b/scripts/ci/test-mypy.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Currently openrazer does not have a lot of typing annotations and
+# correctness, so limit checking to known-good paths to avoid regressions.
+#
+# Long-term we want to enable it fully for both daemon and pylib:
+# $ mypy --strict daemon/
+# $ mypy --strict pylib/
+
+mypy --strict pylib/openrazer/client/

--- a/scripts/ci/test-mypy.sh
+++ b/scripts/ci/test-mypy.sh
@@ -7,4 +7,4 @@
 # $ mypy --strict daemon/
 # $ mypy --strict pylib/
 
-mypy --strict pylib/openrazer/
+mypy --strict pylib/openrazer/ scripts/create_fake_device.py

--- a/scripts/ci/test-vermin.sh
+++ b/scripts/ci/test-vermin.sh
@@ -3,9 +3,6 @@
 # shellcheck disable=SC2046
 vermin \
     -t=3.10- \
-    --backport argparse \
-    --backport configparser \
-    --backport typing \
     --lint \
     --eval-annotations \
     $(find . -name '*.py')

--- a/scripts/ci/test-vermin.sh
+++ b/scripts/ci/test-vermin.sh
@@ -2,7 +2,7 @@
 
 # shellcheck disable=SC2046
 vermin \
-    -t=3.9- \
+    -t=3.10- \
     --backport argparse \
     --backport configparser \
     --backport typing \

--- a/scripts/create_fake_device.py
+++ b/scripts/create_fake_device.py
@@ -16,15 +16,15 @@ import openrazer._fake_driver as fake_driver
 
 class FakeDevicePrompt(cmd.Cmd):
 
-    def __init__(self, device_map, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, device_map: dict[str, fake_driver.FakeDevice]):
+        super().__init__()
 
         self._device_map = device_map
-        self._current_device = None
+        self._current_device: str | None = None
 
-        self._ep = {}
-        self._read = []
-        self._write = []
+        self._ep: dict[str, str] = {}
+        self._read: list[str] = []
+        self._write: list[str] = []
 
         # If only 1 device, auto use that
         if len(self._device_map) == 1:
@@ -32,7 +32,7 @@ class FakeDevicePrompt(cmd.Cmd):
         else:
             self._change_device(None)
 
-    def _change_device(self, device_name=None):
+    def _change_device(self, device_name: str | None = None) -> None:
         if device_name is not None:
             self._current_device = device_name
             self.prompt = self._current_device + "> "
@@ -46,7 +46,7 @@ class FakeDevicePrompt(cmd.Cmd):
             self._current_device = None
             self.prompt = "> "
 
-    def do_dev(self, arg):
+    def do_dev(self, arg: str | None) -> None:
         """
         Change current device
         """
@@ -58,7 +58,7 @@ class FakeDevicePrompt(cmd.Cmd):
         else:
             print('Invalid device name: {0}'.format(arg))
 
-    def complete_dev(self, text, line, begidx, endidx):
+    def complete_dev(self, text: str, line: str, begidx: int, endidx: int) -> list[str]:
         if not text:
             completions = list(self._device_map.keys())
         else:
@@ -66,7 +66,7 @@ class FakeDevicePrompt(cmd.Cmd):
 
         return completions
 
-    def do_list(self, arg):
+    def do_list(self, arg: str) -> None:
         """List available device files"""
         if self._current_device is not None:
             print('Device files')
@@ -88,11 +88,11 @@ class FakeDevicePrompt(cmd.Cmd):
             for device in list(self._device_map.keys()):
                 print('  {0}'.format(device))
 
-    def do_ls(self, arg):
+    def do_ls(self, arg: str) -> None:
         """List available device files"""
         self.do_list(arg)
 
-    def do_read(self, arg, binary=False):
+    def do_read(self, arg: str, binary: bool = False) -> None:
         """Read ASCII from given device file"""
         if self._current_device is not None:
             if arg in self._ep:
@@ -104,11 +104,11 @@ class FakeDevicePrompt(cmd.Cmd):
             else:
                 print("Device endpoint not found")
 
-    def do_binary_read(self, arg):
+    def do_binary_read(self, arg: str) -> None:
         """Read binary from given device file"""
         self.do_read(arg, binary=True)
 
-    def complete_read(self, text, line, begidx, endidx):
+    def complete_read(self, text: str, line: str, begidx: int, endidx: int) -> list[str]:
         if not text:
             completions = self._read
         else:
@@ -118,7 +118,7 @@ class FakeDevicePrompt(cmd.Cmd):
 
     complete_binary_read = complete_read
 
-    def do_write(self, arg):
+    def do_write(self, arg: str) -> None:
         """Write ASCII to device file. DEVICE_FILE DATA"""
         if self._current_device is not None:
             try:
@@ -128,14 +128,14 @@ class FakeDevicePrompt(cmd.Cmd):
                     if len(data) > 0:
                         self._device_map[self._current_device].set(device_file, data)
 
-                        print("{0}: {1}".format(device_file, self._device_map[self._current_device].get(device_file)))
+                        print("{0}: {1!s}".format(device_file, self._device_map[self._current_device].get(device_file)))
                 else:
                     print("Device endpoint not found")
 
             except ValueError:
                 print("Must specify a device endpoint then a space then data to write")
 
-    def complete_write(self, text, line, begidx, endidx):
+    def complete_write(self, text: str, line: str, begidx: int, endidx: int) -> list[str]:
         if not text:
             completions = self._write
         else:
@@ -143,7 +143,7 @@ class FakeDevicePrompt(cmd.Cmd):
 
         return completions
 
-    def do_event(self, arg):
+    def do_event(self, arg: str) -> None:
         """Emit an event, format: EVENT_ID KEY_ID STATE
 
         Where state in 'up' 'down' and 'repeat'
@@ -164,7 +164,7 @@ class FakeDevicePrompt(cmd.Cmd):
                 except ValueError as err:
                     print("Caught exception: {0}".format(err))
 
-    def do_exit(self, arg):
+    def do_exit(self, arg: str) -> bool:
         """Exit"""
         if self._current_device is not None:
             self._change_device(None)
@@ -172,12 +172,12 @@ class FakeDevicePrompt(cmd.Cmd):
         else:
             return True
 
-    def do_EOF(self, arg):
+    def do_EOF(self, arg: str) -> None:
         """Press Ctrl+D to exit"""
         self.do_exit(arg)
 
 
-def create_envionment(device_name, destination):
+def create_envionment(device_name: str, destination: str) -> fake_driver.FakeDevice | None:
     os.makedirs(destination, exist_ok=True)
 
     try:
@@ -185,9 +185,10 @@ def create_envionment(device_name, destination):
         return fake_device
     except ValueError:
         print('Device {0}.cfg not found'.format(device_name))
+        return None
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument('device', metavar='DEVICE', nargs='*', help='Device config name')
     parser.add_argument('--dest', metavar='DESTDIR', required=False, default=None, help='Directory to create driver files in. If omitted then a tmp directory is used')
@@ -198,7 +199,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def run():
+def run() -> None:
     args = parse_args()
 
     if args.dest is None:
@@ -214,12 +215,12 @@ def run():
     else:
         devices = args.device
 
-    device_map = {}
-    for device in devices:
+    device_map: dict[str, fake_driver.FakeDevice] = {}
+    for device_name in devices:
         # Device name: FakeDriver
-        fake_device = create_envionment(device, destination)
+        fake_device = create_envionment(device_name, destination)
         if fake_device is not None:
-            device_map[device] = fake_device
+            device_map[device_name] = fake_device
 
     if len(device_map) == 0:
         print("ERROR: No valid devices passed to script, you either need to pass devices as arguments or use '--all'")


### PR DESCRIPTION
This is obviously a breaking change. But programs using the pylib should anyways rely on checking before whether they can use a method before using it. This also aligns the behavior with all other functions in the pylib, which throw an exception when you use it wrong, instead of silently swallowing the errors - sometimes indicating with a bool return.