### PR TITLE
feat: Add hyperscroll (scroll profile) support for Razer Naga V2 Pro

### DIFF
--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/mouse_scroll_wheel.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/mouse_scroll_wheel.py
@@ -100,3 +100,38 @@ def get_scroll_smart_reel(self):
 
     with open(driver_path, 'r') as driver_file:
         return bool(int(driver_file.read().strip()))
+
+
+@endpoint('razer.device.scroll', 'setScrollProfile', in_sig='y')
+def set_scroll_profile(self, profile):
+    """
+    Set the device's scroll profile (hyperscroll)
+
+    :param profile: The profile to set (0 = standard, 1 = distinct, 2 = precise, 3 = adaptive, 4 = smooth, 5 = custom)
+    :type profile: int
+    """
+    self.logger.debug("DBus call set_scroll_profile")
+
+    if profile not in (0, 1, 2, 3, 4, 5):
+        raise ValueError("profile has to be 0-5")
+
+    driver_path = self.get_driver_path('scroll_profile')
+
+    with open(driver_path, 'w') as driver_file:
+        driver_file.write(str(int(profile)))
+
+
+@endpoint('razer.device.scroll', 'getScrollProfile', out_sig='y')
+def get_scroll_profile(self):
+    """
+    Get the device's current scroll profile (hyperscroll)
+
+    :return: The device's current scroll profile (0 = standard, 1 = distinct, 2 = precise, 3 = adaptive, 4 = smooth, 5 = custom)
+    :rtype: int
+    """
+    self.logger.debug("DBus call get_scroll_profile")
+
+    driver_path = self.get_driver_path('scroll_profile')
+
+    with open(driver_path, 'r') as driver_file:
+        return int(driver_file.read().strip())

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -1022,6 +1022,8 @@ class RazerNagaV2ProWired(__RazerDeviceBrightnessSuspend):
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_poll_rate', 'set_poll_rate', 'get_dpi_stages', 'set_dpi_stages',
                # Battery
                'get_battery', 'is_charging', 'get_idle_time', 'set_idle_time', 'get_low_battery_threshold', 'set_low_battery_threshold',
+               # Scroll wheel
+               'get_scroll_mode', 'set_scroll_mode', 'get_scroll_acceleration', 'set_scroll_acceleration', 'get_scroll_smart_reel', 'set_scroll_smart_reel', 'get_scroll_profile', 'set_scroll_profile',
                # Logo
                'get_logo_brightness', 'set_logo_brightness',
                'set_logo_wave', 'set_logo_static', 'set_logo_spectrum', 'set_logo_none', 'set_logo_reactive', 'set_logo_breath_random', 'set_logo_breath_single', 'set_logo_breath_dual',

--- a/driver/razerchromacommon.c
+++ b/driver/razerchromacommon.c
@@ -1530,6 +1530,47 @@ struct razer_report razer_chroma_misc_get_scroll_smart_reel(void)
 }
 
 /**
+ * Set scroll wheel profile (hyperscroll) on the device
+ *
+ * Profiles:
+ * 0 = Standard
+ * 1 = Distinct
+ * 2 = Precise
+ * 3 = Adaptive
+ * 4 = Smooth
+ * 5 = Custom
+ *
+ * Status Trans Packet Proto DataSize Class CMD Args
+ * 00     1f    0000   00    02       02    18  0100    | SET SCROLL PROFILE (VARSTR, STANDARD)
+ * 00     1f    0000   00    02       02    18  0101    | SET SCROLL PROFILE (VARSTR, DISTINCT)
+ * 00     1f    0000   00    02       02    18  0102    | SET SCROLL PROFILE (VARSTR, PRECISE)
+ * 00     1f    0000   00    02       02    18  0103    | SET SCROLL PROFILE (VARSTR, ADAPTIVE)
+ * 00     1f    0000   00    02       02    18  0104    | SET SCROLL PROFILE (VARSTR, SMOOTH)
+ * 00     1f    0000   00    02       02    18  0105    | SET SCROLL PROFILE (VARSTR, CUSTOM)
+ */
+struct razer_report razer_chroma_misc_set_scroll_profile(unsigned char profile)
+{
+    struct razer_report report = get_razer_report(0x02, 0x18, 0x02);
+
+    report.arguments[0] = VARSTORE;
+    report.arguments[1] = profile;
+
+    return report;
+}
+
+/**
+ * Get scroll wheel profile (hyperscroll) from the device
+ */
+struct razer_report razer_chroma_misc_get_scroll_profile(void)
+{
+    struct razer_report report = get_razer_report(0x02, 0x98, 0x02);
+
+    report.arguments[0] = VARSTORE;
+
+    return report;
+}
+
+/**
  * Set LED mode for HyperPolling Wireless Dongle
  * 1 = Connection Status
  * 2 = Battery Status

--- a/driver/razerchromacommon.h
+++ b/driver/razerchromacommon.h
@@ -149,6 +149,9 @@ struct razer_report razer_chroma_misc_get_scroll_acceleration(void);
 struct razer_report razer_chroma_misc_set_scroll_smart_reel(bool smart_reel);
 struct razer_report razer_chroma_misc_get_scroll_smart_reel(void);
 
+struct razer_report razer_chroma_misc_set_scroll_profile(unsigned char profile);
+struct razer_report razer_chroma_misc_get_scroll_profile(void);
+
 struct razer_report razer_chroma_misc_set_hyperpolling_wireless_dongle_indicator_led_mode(unsigned char mode);
 struct razer_report razer_chroma_misc_set_hyperpolling_wireless_dongle_pair_step1(unsigned short pid);
 struct razer_report razer_chroma_misc_set_hyperpolling_wireless_dongle_pair_step2(unsigned short pid);

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -2778,6 +2778,48 @@ static ssize_t razer_attr_read_scroll_smart_reel(struct device *dev, struct devi
     return sprintf(buf, "%d\n", response.arguments[1]);
 }
 
+/**
+ * Write device file "scroll_profile"
+ *
+ * Sets the scroll profile (hyperscroll) of the mouse.
+ */
+static ssize_t razer_attr_write_scroll_profile(struct device *dev, struct device_attribute *attr, const char *buf, size_t count)
+{
+    struct razer_mouse_device *device = dev_get_drvdata(dev);
+    struct razer_report request = {0};
+    struct razer_report response = {0};
+    unsigned int profile;
+
+    if (kstrtouint(buf, 0, &profile) < 0 || profile > 5)
+        return -EINVAL;
+
+    request = razer_chroma_misc_set_scroll_profile(profile);
+    request.transaction_id.id = 0x1f;
+
+    razer_send_payload(device, &request, &response);
+
+    return count;
+}
+
+/**
+ * Read device file "scroll_profile"
+ *
+ * Gets the scroll profile (hyperscroll) from the mouse.
+ */
+static ssize_t razer_attr_read_scroll_profile(struct device *dev, struct device_attribute *attr, char *buf)
+{
+    struct razer_mouse_device *device = dev_get_drvdata(dev);
+    struct razer_report request = {0};
+    struct razer_report response = {0};
+
+    request = razer_chroma_misc_get_scroll_profile();
+    request.transaction_id.id = 0x1f;
+
+    razer_send_payload(device, &request, &response);
+
+    return sprintf(buf, "%d\n", response.arguments[1]);
+}
+
 static ssize_t razer_attr_write_tilt_hwheel(struct device *dev, struct device_attribute *attr, const char *buf, size_t count)
 {
     struct razer_mouse_device *device = dev_get_drvdata(dev);
@@ -5472,6 +5514,7 @@ static DEVICE_ATTR(device_idle_time,          0660, razer_attr_read_device_idle_
 static DEVICE_ATTR(scroll_mode,               0660, razer_attr_read_scroll_mode,           razer_attr_write_scroll_mode);
 static DEVICE_ATTR(scroll_acceleration,       0660, razer_attr_read_scroll_acceleration,   razer_attr_write_scroll_acceleration);
 static DEVICE_ATTR(scroll_smart_reel,         0660, razer_attr_read_scroll_smart_reel,     razer_attr_write_scroll_smart_reel);
+static DEVICE_ATTR(scroll_profile,            0660, razer_attr_read_scroll_profile,        razer_attr_write_scroll_profile);
 
 static DEVICE_ATTR(tilt_hwheel,               0660, razer_attr_read_tilt_hwheel,           razer_attr_write_tilt_hwheel);
 static DEVICE_ATTR(tilt_repeat,               0660, razer_attr_read_tilt_repeat,           razer_attr_write_tilt_repeat);
@@ -6707,6 +6750,11 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_status);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_low_threshold);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_device_idle_time);
+
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_mode);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_acceleration);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_smart_reel);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_scroll_profile);
 
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_brightness);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_matrix_effect_wave);

--- a/pylib/openrazer/client/devices/__init__.py
+++ b/pylib/openrazer/client/devices/__init__.py
@@ -74,6 +74,7 @@ class RazerDevice(object):
             'scroll_mode': self._has_feature('razer.device.scroll', ('getScrollMode', 'setScrollMode')),
             'scroll_acceleration': self._has_feature('razer.device.scroll', ('getScrollAcceleration', 'setScrollAcceleration')),
             'scroll_smart_reel': self._has_feature('razer.device.scroll', ('getScrollSmartReel', 'setScrollSmartReel')),
+            'scroll_profile': self._has_feature('razer.device.scroll', ('getScrollProfile', 'setScrollProfile')),
 
             # Default device is a chroma so lighting capabilities
             'lighting': self._has_feature('razer.device.lighting.chroma'),
@@ -248,7 +249,7 @@ class RazerDevice(object):
             self._dbus_interfaces['macro_mode_led'] = _dbus.Interface(self._dbus, "razer.device.led.macromode")
         if self.has('lighting_profile_led_red') or self.has('lighting_profile_led_green') or self.has('lighting_profile_led_blue'):
             self._dbus_interfaces['profile_led'] = _dbus.Interface(self._dbus, "razer.device.lighting.profile_led")
-        if self.has('scroll_mode') or self.has('scroll_acceleration') or self.has('scroll_smart_reel'):
+        if self.has('scroll_mode') or self.has('scroll_acceleration') or self.has('scroll_smart_reel') or self.has('scroll_profile'):
             self._dbus_interfaces['scroll'] = _dbus.Interface(self._dbus, "razer.device.scroll")
 
     def _get_available_features(self) -> dict[str, list[str]]:

--- a/pylib/openrazer/client/devices/mice.py
+++ b/pylib/openrazer/client/devices/mice.py
@@ -263,3 +263,33 @@ class RazerMouse(__RazerDevice):
             self._dbus_interfaces['scroll'].setScrollSmartReel(enabled)
         else:
             raise NotImplementedError()
+
+    @property
+    def scroll_profile(self) -> int:
+        """
+        Get the device's scroll profile (hyperscroll)
+
+        :return: The device's current scroll profile (0 = standard, 1 = distinct, 2 = precise, 3 = adaptive, 4 = smooth, 5 = custom)
+        :rtype: int
+
+        :raises NotImplementedError: If function is not supported
+        """
+        if self.has('scroll_profile'):
+            return int(self._dbus_interfaces['scroll'].getScrollProfile())
+        else:
+            raise NotImplementedError()
+
+    @scroll_profile.setter
+    def scroll_profile(self, profile: int) -> None:
+        """
+        Set the device's scroll profile (hyperscroll)
+
+        :param profile: The profile to set (0 = standard, 1 = distinct, 2 = precise, 3 = adaptive, 4 = smooth, 5 = custom)
+        :type profile: int
+
+        :raises NotImplementedError: If function is not supported
+        """
+        if self.has('scroll_profile'):
+            self._dbus_interfaces['scroll'].setScrollProfile(profile)
+        else:
+            raise NotImplementedError()


### PR DESCRIPTION
- Added scroll profile protocol functions (cmd 0x18/0x98)
- Implemented 6 scroll profiles: standard, distinct, precise, adaptive, smooth, custom
- Added DBus methods for scroll profile control
- Extended Naga V2 Pro device classes with scroll methods
- Added Python client library support with scroll_profile property
- Registered sysfs device files for both wired and wireless variants