### PR TITLE
daemon: Apply driver mode to Basilisk V3

### DIFF
--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -1219,6 +1219,7 @@ class RazerBasiliskV3(__RazerDevice):
                'set_custom_effect', 'set_key_row']
 
     DEVICE_IMAGE = "https://assets2.razerzone.com/pages/basilisk-v3-4D578898E8144Le8da21dde32b7a9f5f/basilisk.png"
+    DRIVER_MODE = True
 
     DPI_MAX = 26000
 


### PR DESCRIPTION
Basilisk V3 (1532:0099) requires driver mode for tilt wheel (horizontal scroll)
events to be generated by the firmware. Without it, tilt inputs are not sent.

Same fix as #2456 (Basilisk V3 X HyperSpeed).

Tested on hardware with openrazer v3.11.0.