### PR TITLE
Fix Basilisk V3 scroll mode toggle button using workqueue

### DIFF
--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -5886,10 +5886,16 @@ static int razer_raw_event(struct hid_device *hdev, struct hid_report *report, u
             }
 
             for (i = 1; i < size; i++) {
-                if (!search(rdev->rep4 + 1, data[i], size - 1))
-                    input_rep4_code(m_rdev->input, data[i], 1);
-                if (!search(data + 1, rdev->rep4[i], size - 1))
-                    input_rep4_code(m_rdev->input, rdev->rep4[i], 0);
+                if (!search(rdev->rep4 + 1, data[i], size - 1)) {
+                    if (data[i] == REP4_SCROLL)
+                        schedule_work(&m_rdev->scroll_toggle_work);
+                    else
+                        input_rep4_code(m_rdev->input, data[i], 1);
+                }
+                if (!search(data + 1, rdev->rep4[i], size - 1)) {
+                    if (rdev->rep4[i] != REP4_SCROLL)
+                        input_rep4_code(m_rdev->input, rdev->rep4[i], 0);
+                }
             }
             memcpy(rdev->rep4, data, 16);
             return 1;
@@ -6005,6 +6011,17 @@ static int razer_input_configured(struct hid_device *hdev,
     return 0;
 }
 
+static void scroll_toggle_worker(struct work_struct *work)
+{
+    struct razer_mouse_device *dev = container_of(work, struct razer_mouse_device, scroll_toggle_work);
+    struct razer_report request = {0};
+    struct razer_report response = {0};
+    dev->scroll_mode ^= 1;
+    request = razer_chroma_misc_set_scroll_mode(dev->scroll_mode);
+    request.transaction_id.id = 0x1f;
+    razer_send_payload(dev, &request, &response);
+}
+
 /**
  * Mouse init function
  */
@@ -6015,6 +6032,7 @@ static void razer_mouse_init(struct razer_mouse_device *dev, struct usb_interfac
 
     // Initialise mutex
     mutex_init(&dev->lock);
+    INIT_WORK(&dev->scroll_toggle_work, scroll_toggle_worker);
     // Setup values
     dev->usb_dev = usb_dev;
     dev->usb_vid = usb_dev->descriptor.idVendor;

--- a/driver/razermouse_driver.h
+++ b/driver/razermouse_driver.h
@@ -145,6 +145,9 @@ struct razer_mouse_device {
     struct usb_device *usb_dev;
     struct mutex lock;
 
+    struct work_struct scroll_toggle_work;
+    unsigned char scroll_mode;
+
     struct input_dev *input;
     struct hrtimer repeat_timer;
     unsigned int tilt_hwheel;


### PR DESCRIPTION
Fix Basilisk V3 scroll mode toggle button

change introduced in https://github.com/openrazer/openrazer/commit/d7ba046e01b998e5634214ef5166ab33ae650f88
scroll mode toggle button's HID report to BTN_MOUSE+12 as a kernel input event. However, on the Basilisk V3, this button is not meant to emit a key event but on basilisk v3 it is a firmware trigger to change scroll wheel from free spin to tactile mode.

Tested with Razer Basilisk V3 (1532:0099), Ubuntu 24.04, kernel 6.17.0-20-generic.