### PR TITLE
driver: Fix RGB effects for Naga V2 Pro

### DIFF
--- a/driver/razerchromacommon.c
+++ b/driver/razerchromacommon.c
@@ -1464,6 +1464,91 @@ struct razer_report razer_naga_trinity_effect_static(struct razer_rgb *rgb)
 }
 
 /**
+ * Set the Naga Trinity to "Breathing Single" effect
+ */
+struct razer_report razer_naga_trinity_effect_breathing_single(struct razer_rgb *rgb)
+{
+    struct razer_report report = get_razer_report(0x0f, 0x02, 0x09);
+
+    report.arguments[0] = 0x00;
+    report.arguments[1] = 0x00;
+    report.arguments[2] = 0x02;
+    report.arguments[3] = 0x01;
+    report.arguments[4] = 0x00;
+    report.arguments[5] = 0x01;
+    report.arguments[6] = rgb->r;
+    report.arguments[7] = rgb->g;
+    report.arguments[8] = rgb->b;
+
+    return report;
+}
+
+/**
+ * Set the Naga Trinity to "Breathing Dual" effect
+ */
+struct razer_report razer_naga_trinity_effect_breathing_dual(struct razer_rgb *rgb1, struct razer_rgb *rgb2)
+{
+    struct razer_report report = get_razer_report(0x0f, 0x02, 0x0c);
+
+    report.arguments[0] = 0x00;
+    report.arguments[1] = 0x00;
+    report.arguments[2] = 0x02;
+    report.arguments[3] = 0x02;
+    report.arguments[4] = 0x00;
+    report.arguments[5] = 0x02;
+    report.arguments[6] = rgb1->r;
+    report.arguments[7] = rgb1->g;
+    report.arguments[8] = rgb1->b;
+    report.arguments[9] = rgb2->r;
+    report.arguments[10] = rgb2->g;
+    report.arguments[11] = rgb2->b;
+
+    return report;
+}
+
+/**
+ * Set the Naga Trinity to "Breathing Random" effect
+ */
+struct razer_report razer_naga_trinity_effect_breathing_random(void)
+{
+    struct razer_report report = get_razer_report(0x0f, 0x02, 0x06);
+
+    report.arguments[0] = 0x00;
+    report.arguments[1] = 0x00;
+    report.arguments[2] = 0x02;
+
+    return report;
+}
+
+/**
+ * Set the Naga Trinity to "Spectrum Cycle" effect
+ */
+struct razer_report razer_naga_trinity_effect_spectrum(void)
+{
+    struct razer_report report = get_razer_report(0x0f, 0x02, 0x06);
+
+    report.arguments[0] = 0x00;
+    report.arguments[1] = 0x00;
+    report.arguments[2] = 0x03;
+
+    return report;
+}
+
+/**
+ * Set the Naga Trinity to "None" effect
+ */
+struct razer_report razer_naga_trinity_effect_none(void)
+{
+    struct razer_report report = get_razer_report(0x0f, 0x02, 0x06);
+
+    report.arguments[0] = 0x00;
+    report.arguments[1] = 0x00;
+    report.arguments[2] = 0x00;
+
+    return report;
+}
+
+/**
  * Set scroll wheel mode on the device
  *
  * Status Trans Packet Proto DataSize Class CMD Args

--- a/driver/razerchromacommon.h
+++ b/driver/razerchromacommon.h
@@ -140,6 +140,11 @@ struct razer_report razer_chroma_misc_set_orochi2011_poll_dpi(unsigned short pol
 
 struct razer_report razer_basilisk_mobile_effect_static(struct razer_rgb* rgb);
 struct razer_report razer_naga_trinity_effect_static(struct razer_rgb* rgb);
+struct razer_report razer_naga_trinity_effect_breathing_single(struct razer_rgb* rgb);
+struct razer_report razer_naga_trinity_effect_breathing_dual(struct razer_rgb* rgb1, struct razer_rgb* rgb2);
+struct razer_report razer_naga_trinity_effect_breathing_random(void);
+struct razer_report razer_naga_trinity_effect_spectrum(void);
+struct razer_report razer_naga_trinity_effect_none(void);
 
 struct razer_report razer_chroma_misc_set_scroll_mode(unsigned int scroll_mode);
 struct razer_report razer_chroma_misc_get_scroll_mode(void);

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -946,12 +946,12 @@ static ssize_t razer_attr_write_matrix_effect_none(struct device *dev, struct de
         request.transaction_id.id = 0x1f;
         break;
 
-    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS: // TODO: this is probably wrong?
-    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED: // TODO: this is probably wrong?
+    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRELESS:
-        request = razer_chroma_standard_matrix_effect_none();
-        request.transaction_id.id = 0xFF;
+        request = razer_naga_trinity_effect_none();
+        request.transaction_id.id = 0x1f;
         break;
 
     default:
@@ -1190,7 +1190,7 @@ static ssize_t razer_attr_write_matrix_effect_spectrum(struct device *dev, struc
     case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRELESS:
-        request = razer_chroma_mouse_extended_matrix_effect_spectrum(VARSTORE, BACKLIGHT_LED);
+        request = razer_naga_trinity_effect_spectrum();
         request.transaction_id.id = 0x1f;
         break;
 
@@ -1285,18 +1285,18 @@ static ssize_t razer_attr_write_matrix_effect_breath(struct device *dev, struct 
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
         switch(count) {
-        case 3: // Single colour mode
-            request = razer_chroma_mouse_extended_matrix_effect_breathing_single(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0]);
+        case 3:
+            request = razer_naga_trinity_effect_breathing_single((struct razer_rgb*)&buf[0]);
             request.transaction_id.id = 0x1f;
             break;
 
-        case 6: // Dual colour mode
-            request = razer_chroma_mouse_extended_matrix_effect_breathing_dual(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0], (struct razer_rgb*)&buf[3]);
+        case 6:
+            request = razer_naga_trinity_effect_breathing_dual((struct razer_rgb*)&buf[0], (struct razer_rgb*)&buf[3]);
             request.transaction_id.id = 0x1f;
             break;
 
-        default: // "Random" colour mode
-            request = razer_chroma_mouse_extended_matrix_effect_breathing_random(VARSTORE, BACKLIGHT_LED);
+        default:
+            request = razer_naga_trinity_effect_breathing_random();
             request.transaction_id.id = 0x1f;
             break;
         }

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -971,12 +971,12 @@ static ssize_t razer_attr_write_matrix_effect_none(struct device *dev, struct de
         request.transaction_id.id = 0x1f;
         break;
 
-    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS: // TODO: this is probably wrong?
-    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED: // TODO: this is probably wrong?
+    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
+    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRELESS:
-        request = razer_chroma_standard_matrix_effect_none();
-        request.transaction_id.id = 0xFF;
+        request = razer_naga_trinity_effect_none();
+        request.transaction_id.id = 0x1f;
         break;
 
     default:
@@ -1235,7 +1235,7 @@ static ssize_t razer_attr_write_matrix_effect_spectrum(struct device *dev, struc
     case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRELESS:
-        request = razer_chroma_mouse_extended_matrix_effect_spectrum(VARSTORE, BACKLIGHT_LED);
+        request = razer_naga_trinity_effect_spectrum();
         request.transaction_id.id = 0x1f;
         break;
 
@@ -1336,18 +1336,18 @@ static ssize_t razer_attr_write_matrix_effect_breath(struct device *dev, struct 
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
         switch(count) {
-        case 3: // Single colour mode
-            request = razer_chroma_mouse_extended_matrix_effect_breathing_single(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0]);
+        case 3:
+            request = razer_naga_trinity_effect_breathing_single((struct razer_rgb*)&buf[0]);
             request.transaction_id.id = 0x1f;
             break;
 
-        case 6: // Dual colour mode
-            request = razer_chroma_mouse_extended_matrix_effect_breathing_dual(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0], (struct razer_rgb*)&buf[3]);
+        case 6:
+            request = razer_naga_trinity_effect_breathing_dual((struct razer_rgb*)&buf[0], (struct razer_rgb*)&buf[3]);
             request.transaction_id.id = 0x1f;
             break;
 
-        default: // "Random" colour mode
-            request = razer_chroma_mouse_extended_matrix_effect_breathing_random(VARSTORE, BACKLIGHT_LED);
+        default:
+            request = razer_naga_trinity_effect_breathing_random();
             request.transaction_id.id = 0x1f;
             break;
         }

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -971,8 +971,12 @@ static ssize_t razer_attr_write_matrix_effect_none(struct device *dev, struct de
         request.transaction_id.id = 0x1f;
         break;
 
-    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
-    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS: // TODO: this is probably wrong?
+    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED: // TODO: this is probably wrong?
+        request = razer_chroma_standard_matrix_effect_none();
+        request.transaction_id.id = 0xFF;
+        break;
+
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRELESS:
         request = razer_naga_trinity_effect_none();
@@ -1231,11 +1235,15 @@ static ssize_t razer_attr_write_matrix_effect_spectrum(struct device *dev, struc
     int err;
 
     switch (device->usb_pid) {
-    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED:
-    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRELESS:
         request = razer_naga_trinity_effect_spectrum();
+        request.transaction_id.id = 0x1f;
+        break;
+
+    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
+        request = razer_chroma_mouse_extended_matrix_effect_spectrum(VARSTORE, BACKLIGHT_LED);
         request.transaction_id.id = 0x1f;
         break;
 
@@ -1327,27 +1335,45 @@ static ssize_t razer_attr_write_matrix_effect_breath(struct device *dev, struct 
     int err;
 
     switch (device->usb_pid) {
-    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED:
-    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_NAGA_V2_PRO_WIRELESS:
+        switch(count) {
+        case 3: // Single colour mode
+            request = razer_naga_trinity_effect_breathing_single((struct razer_rgb*)&buf[0]);
+            request.transaction_id.id = 0x1f;
+            break;
+
+        case 6: // Dual colour mode
+            request = razer_naga_trinity_effect_breathing_dual((struct razer_rgb*)&buf[0], (struct razer_rgb*)&buf[3]);
+            request.transaction_id.id = 0x1f;
+            break;
+
+        default: // "Random" colour mode
+            request = razer_naga_trinity_effect_breathing_random();
+            request.transaction_id.id = 0x1f;
+            break;
+        }
+        break;
+
+    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED:
+    case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRELESS:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
         switch(count) {
-        case 3:
-            request = razer_naga_trinity_effect_breathing_single((struct razer_rgb*)&buf[0]);
+        case 3: // Single colour mode
+            request = razer_chroma_mouse_extended_matrix_effect_breathing_single(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0]);
             request.transaction_id.id = 0x1f;
             break;
 
-        case 6:
-            request = razer_naga_trinity_effect_breathing_dual((struct razer_rgb*)&buf[0], (struct razer_rgb*)&buf[3]);
+        case 6: // Dual colour mode
+            request = razer_chroma_mouse_extended_matrix_effect_breathing_dual(VARSTORE, BACKLIGHT_LED, (struct razer_rgb*)&buf[0], (struct razer_rgb*)&buf[3]);
             request.transaction_id.id = 0x1f;
             break;
 
-        default:
-            request = razer_naga_trinity_effect_breathing_random();
+        default: // "Random" colour mode
+            request = razer_chroma_mouse_extended_matrix_effect_breathing_random(VARSTORE, BACKLIGHT_LED);
             request.transaction_id.id = 0x1f;
             break;
         }


### PR DESCRIPTION
My Naga V2 Pro thumbgrid was not working properly with openrazer. Any RGB effects were not being applied. However, the device worked properly using OpenRGB. Comparing the protocols used by openrazer and OpenRGB, I can see that they are different: 0x0F/0x02 instead of 0x03. I changed openrazer to use naga_trinity instead of chroma_standard_matrix, and this fixed the issue for me.

This change was tested on Naga V2 Pro (single/dual/random breathing, spectrum, none). I have not tested this on Naga Pro and Pro Click V2, since I do not have those devices. I assume they use the same protocol, but I cannot confirm that.

I see there were a couple of "TODO: this is probably wrong?" comments in the sections that I changed. Was this issue already suspected?