### PR TITLE
daemon: Allow overriding DRIVER_MODE from config file

### DIFF
--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -324,6 +324,13 @@ class RazerDevice(DBusService):
         if 'get_battery' in self.METHODS:
             self._init_battery_manager()
 
+        try:
+            driver_mode_default = self.DRIVER_MODE
+            self.DRIVER_MODE = self.config.getboolean(f"Device:{self.serial}", "driver_mode")
+            self.logger.info('Overriding DRIVER_MODE with "%s" from config (default: "%s")', self.DRIVER_MODE, driver_mode_default)
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            pass
+
         if self.DRIVER_MODE:
             self.logger.info('Setting device to "driver" mode. Daemon will handle special functionality')
             self.set_device_mode(0x03, 0x00)  # Driver mode

--- a/daemon/resources/man/razer.conf.5
+++ b/daemon/resources/man/razer.conf.5
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "razer.conf" "5" "2026-03-10"
+.TH "razer.conf" "5" "2026-04-18"
 .PP
 .SH NAME
 .PP
@@ -69,6 +69,15 @@ This flag specifies whether effects saved in persistence.\&conf should be applie
 \fBpersistence_dual_boot_quirk\fR \fIbool\fR
 .RS 4
 This flag specifies whether the persisted effect is applied twice to address a quirk with newer devices that were last changed by Razer Synapse on Windows.\& Only applicable with restore_persistence = True.\&
+.PP
+.RE
+.SS DEVICE
+.PP
+Additional per-device sections can be defined with the name "Device:XXXX" where XXXX is the serial number of your device.\&
+.PP
+\fBdriver_mode\fR \fIbool\fR
+.RS 4
+This flag specifies an override whether the device should be switched into "driver mode" (as opposed to keeping it in "device mode").\& Ideally the OpenRazer stack should support all functionality in software and support the devices being in driver mode, but that'\&s not the case for a wide variety of devices yet, especially mice.\& However some users may want to explicitly force a device into driver mode to enable some functionality like horizontal scrolling.\&
 .PP
 .RE
 .SH SEE ALSO

--- a/daemon/resources/man/razer.conf.5.scd
+++ b/daemon/resources/man/razer.conf.5.scd
@@ -48,6 +48,13 @@ The *[Startup]* section in the configuration file contains values to be used dur
 *persistence_dual_boot_quirk* _bool_
 	This flag specifies whether the persisted effect is applied twice to address a quirk with newer devices that were last changed by Razer Synapse on Windows. Only applicable with restore_persistence = True.
 
+## DEVICE
+
+Additional per-device sections can be defined with the name "Device:XXXX" where XXXX is the serial number of your device.
+
+*driver_mode* _bool_
+	This flag specifies an override whether the device should be switched into "driver mode" (as opposed to keeping it in "device mode"). Ideally the OpenRazer stack should support all functionality in software and support the devices being in driver mode, but that's not the case for a wide variety of devices yet, especially mice. However some users may want to explicitly force a device into driver mode to enable some functionality like horizontal scrolling.
+
 # SEE ALSO
 
 *openrazer-daemon*(8)


### PR DESCRIPTION
Allows adding a section like the following to
~/.config/openrazer/razer.conf to force a device to use or not use driver mode, regardless what the default in the daemon is.
```
[Device:XX123456789]
driver_mode = False
```
Ideally the OpenRazer stack should support all functionality in software and support the devices being in driver mode, but that's not the case for a wide variety of devices yet, especially mice. However some users may want to explicitly force a device into driver mode to enable some functionality like horizontal scrolling.