### PR TITLE
daemon: Allow overriding the key manager from config file

### DIFF
--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -41,6 +41,7 @@ class RazerDevice(DBusService):
     POLL_RATES: Optional[list[int]] = None
     DPI_MAX: Optional[int] = None
     DRIVER_MODE = False
+    USE_KEY_MANAGER = False
 
     WAVE_DIRS = (1, 2)
 
@@ -328,6 +329,13 @@ class RazerDevice(DBusService):
             driver_mode_default = self.DRIVER_MODE
             self.DRIVER_MODE = self.config.getboolean(f"Device:{self.serial}", "driver_mode")
             self.logger.info('Overriding DRIVER_MODE with "%s" from config (default: "%s")', self.DRIVER_MODE, driver_mode_default)
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            pass
+
+        try:
+            key_manager_default = self.USE_KEY_MANAGER
+            self.USE_KEY_MANAGER = self.config.getboolean(f"Device:{self.serial}", "use_key_manager")
+            self.logger.info('Overriding USE_KEY_MANAGER with "%s" from config (default: "%s")', self.USE_KEY_MANAGER, key_manager_default)
         except (configparser.NoSectionError, configparser.NoOptionError):
             pass
 

--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -17,6 +17,7 @@ class _MacroKeyboard(_RazerDeviceBrightnessSuspend):
     Has macro functionality and brightness based suspend
     """
     DRIVER_MODE = True
+    USE_KEY_MANAGER = True
 
     def __init__(self, *args, **kwargs):
         if 'additional_methods' in kwargs:
@@ -26,7 +27,9 @@ class _MacroKeyboard(_RazerDeviceBrightnessSuspend):
         super().__init__(*args, **kwargs)
         # Methods are loaded into DBus by this point
 
-        self.key_manager = _KeyboardKeyManager(self._device_number, self.event_files, self, use_epoll=True, testing=self._testing)
+        self.key_manager = None
+        if self.USE_KEY_MANAGER:
+            self.key_manager = _KeyboardKeyManager(self._device_number, self.event_files, self, use_epoll=True, testing=self._testing)
 
     def _close(self):
         """
@@ -34,7 +37,8 @@ class _MacroKeyboard(_RazerDeviceBrightnessSuspend):
         """
         super()._close()
 
-        self.key_manager.close()
+        if isinstance(self.key_manager, _KeyboardKeyManager):
+            self.key_manager.close()
 
 
 class _RippleKeyboard(_MacroKeyboard):

--- a/daemon/resources/man/razer.conf.5
+++ b/daemon/resources/man/razer.conf.5
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "razer.conf" "5" "2026-04-18"
+.TH "razer.conf" "5" "2026-04-26"
 .PP
 .SH NAME
 .PP
@@ -78,6 +78,17 @@ Additional per-device sections can be defined with the name "Device:XXXX" where 
 \fBdriver_mode\fR \fIbool\fR
 .RS 4
 This flag specifies an override whether the device should be switched into "driver mode" (as opposed to keeping it in "device mode").\& Ideally the OpenRazer stack should support all functionality in software and support the devices being in driver mode, but that'\&s not the case for a wide variety of devices yet, especially mice.\& However some users may want to explicitly force a device into driver mode to enable some functionality like horizontal scrolling.\&
+.PP
+.RE
+\fBuse_key_manager\fR \fIbool\fR
+.RS 4
+This flag specifies an override for the function of the openrazer-daemon key manager.\& It mainly impacts keyboards and gamepads allowing functions such as ripple, macro keys, and function key management.\& You may wish to disable the key manager for a device if you are using a separate input management application for macros, events and special keys, particularly if conflicts are observed.\& Note that some functionality provided by the OpenRazer daemon and applications leveraging it may be degraded for that device if disabled.\& This does not impact the kernel driver.\&
+.PP
+Defaults:
+.br
+True for keyboards & gamepads
+.br
+False for all other devices
 .PP
 .RE
 .SH SEE ALSO

--- a/daemon/resources/man/razer.conf.5.scd
+++ b/daemon/resources/man/razer.conf.5.scd
@@ -55,6 +55,13 @@ Additional per-device sections can be defined with the name "Device:XXXX" where 
 *driver_mode* _bool_
 	This flag specifies an override whether the device should be switched into "driver mode" (as opposed to keeping it in "device mode"). Ideally the OpenRazer stack should support all functionality in software and support the devices being in driver mode, but that's not the case for a wide variety of devices yet, especially mice. However some users may want to explicitly force a device into driver mode to enable some functionality like horizontal scrolling.
 
+*use_key_manager* _bool_
+	This flag specifies an override for the function of the openrazer-daemon key manager. It mainly impacts keyboards and gamepads allowing functions such as ripple, macro keys, and function key management. You may wish to disable the key manager for a device if you are using a separate input management application for macros, events and special keys, particularly if conflicts are observed. Note that some functionality provided by the OpenRazer daemon and applications leveraging it may be degraded for that device if disabled. This does not impact the kernel driver.
+
+	Defaults:++
+	True for keyboards & gamepads++
+	False for all other devices
+
 # SEE ALSO
 
 *openrazer-daemon*(8)


### PR DESCRIPTION
Similar to the DRIVER_MODE switch https://github.com/openrazer/openrazer/commit/faf403d37944d15076cbe15473d92a97da71ac2d, this allows per-device override of the key manager regardless of the default setting.

[Device:XX123456789]
use_key_manager = False

The purpose of this switch is when using external input management applications that may modify device handle properties. Disabling event management on the OpenRazer side prevents potential conflicts from occurring, though at the cost of the associated OpenRazer functionality.

No effect on Razer Huntsman V3 Pro due to separate initialization.