### PR TITLE
razermouse: fix idle time and low battery threshold for Orochi V2

### DIFF
--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -3358,6 +3358,8 @@ static ssize_t razer_attr_read_device_idle_time(struct device *dev, struct devic
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
         request.transaction_id.id = 0x1f;
         break;
 
@@ -3386,8 +3388,6 @@ static ssize_t razer_attr_read_device_idle_time(struct device *dev, struct devic
     case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_WIRED:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
-    case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
-    case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
         request.transaction_id.id = 0xFF;
         break;
 
@@ -3462,6 +3462,8 @@ static ssize_t razer_attr_write_device_idle_time(struct device *dev, struct devi
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
         request.transaction_id.id = 0x1f;
         break;
 
@@ -3490,8 +3492,6 @@ static ssize_t razer_attr_write_device_idle_time(struct device *dev, struct devi
     case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_WIRED:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
-    case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
-    case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
         request.transaction_id.id = 0xFF;
         break;
 
@@ -3546,6 +3546,8 @@ static ssize_t razer_attr_read_charge_low_threshold(struct device *dev, struct d
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
         request.transaction_id.id = 0x1f;
         break;
 
@@ -3574,8 +3576,6 @@ static ssize_t razer_attr_read_charge_low_threshold(struct device *dev, struct d
     case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_WIRED:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
-    case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
-    case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_X_HYPERSPEED:
     case USB_DEVICE_ID_RAZER_VIPER_V2_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_VIPER_V2_PRO_WIRELESS:
@@ -3648,6 +3648,8 @@ static ssize_t razer_attr_write_charge_low_threshold(struct device *dev, struct 
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_VERTICAL_EDITION_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRED:
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
+    case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
         request.transaction_id.id = 0x1f;
         break;
 
@@ -3676,8 +3678,6 @@ static ssize_t razer_attr_write_charge_low_threshold(struct device *dev, struct 
     case USB_DEVICE_ID_RAZER_BASILISK_X_HYPERSPEED:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_WIRED:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
-    case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
-    case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_X_HYPERSPEED:
     case USB_DEVICE_ID_RAZER_VIPER_V2_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_VIPER_V2_PRO_WIRELESS:


### PR DESCRIPTION
## razermouse: move Orochi V2 to correct transaction_id group in power management functions

### Problem

Setting sleep mode (idle time) and low battery threshold on the Razer Orochi V2 (both RECEIVER and BLUETOOTH) results in command timeouts:

    razermouse: Command timed out. status: 04 transaction_id.id: ff remaining_packets: 00 protocol_type: 00 data_size: 02, command_class: 07, command_id.id: 83
    razermouse: Command timed out. status: 04 transaction_id.id: ff remaining_packets: 00 protocol_type: 00 data_size: 01, command_class: 07, command_id.id: 81
    razermouse: Command timed out. status: 04 transaction_id.id: ff remaining_packets: 00 protocol_type: 00 data_size: 02, command_class: 07, command_id.id: 03

### Root cause

`USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER` and `USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH` were already present in all four power management functions:
- `razer_attr_read_device_idle_time`
- `razer_attr_write_device_idle_time`
- `razer_attr_read_charge_low_threshold`
- `razer_attr_write_charge_low_threshold`

However, they were placed in the `transaction_id = 0xFF` group instead of the `transaction_id = 0x1f` group.

The Orochi V2 communicates through a wireless receiver that requires `transaction_id = 0x1f` to correctly forward commands to the mouse. With `0xFF` the receiver does not forward the command wirelessly and the driver times out waiting for a response that never arrives.

`0x1f` is already used correctly for the Orochi V2 in all other functions across the driver (serial, battery level, firmware version, etc). This fix brings the power management functions in line with the rest.

### Fix

Move `USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER` and `USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH` from the `0xFF` transaction ID group to the `0x1f` group in all four affected functions.

### Testing

Tested on Razer Orochi V2 via USB dongle under Ubuntu 26.04 with a locally built module:

- `device_idle_time` read/write round-trips correctly (e.g. 7 min -> 420)
- `charge_low_threshold` read/write round-trips correctly (e.g. 24% -> raw value 61)
- No `Command timed out` errors in dmesg after applying the fix
- Values persist correctly across Polychromatic and system restarts

Note: the Orochi V2 firmware enforces a maximum `charge_low_threshold` of `0x3F` (63 raw / ~25%). Values above this are silently clamped by the device firmware. This is expected hardware behaviour unrelated to this fix.

Tested with USB dongle (OROCHI_V2_RECEIVER). Bluetooth PID (OROCHI_V2_BLUETOOTH) follows the same protocol pattern but was not tested due to VM constraints. Confirmation from a Bluetooth-mode user welcome.