### PR TITLE
Implement sleep/idle state detection and improve support for Razer Naga V2 Hyperspeed in Driver Mode

### DIFF
--- a/daemon/openrazer_daemon/daemon.py
+++ b/daemon/openrazer_daemon/daemon.py
@@ -496,7 +496,8 @@ class RazerDaemon(DBusService):
                                                 persistence=self._persistence, testing=self._test_dir is not None,
                                                 additional_interfaces=sorted(additional_interfaces),
                                                 additional_methods=[],
-                                                unknown_serial_counter=self._unknown_serial_counter)
+                                                unknown_serial_counter=self._unknown_serial_counter,
+                                                reinit_callback=self._reinit_device_callback(device))
 
                     # Wireless devices sometimes don't listen
                     count = 0
@@ -514,6 +515,13 @@ class RazerDaemon(DBusService):
                     self._razer_devices.add(sys_name, device_serial, razer_device)
 
                     device_number += 1
+
+    def _reinit_device_callback(self, device):
+        def inner():
+            self._remove_device(device)
+            self._add_device(device)
+        # Run this in a thread so execution isn't stopped when the device is deleted.
+        return lambda: threading.Thread(target=inner).start()
 
     def _add_device(self, device):
         """
@@ -535,7 +543,8 @@ class RazerDaemon(DBusService):
                 razer_device = device_class(device_path=sys_path, device_number=device_number, config=self._config,
                                             persistence=self._persistence, testing=self._test_dir is not None,
                                             additional_interfaces=None, additional_methods=[],
-                                            unknown_serial_counter=self._unknown_serial_counter)
+                                            unknown_serial_counter=self._unknown_serial_counter,
+                                            reinit_callback=self._reinit_device_callback(device))
 
                 # Its a udev event so currently the device hasn't been chmodded yet
                 time.sleep(0.2)

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/__init__.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/__init__.py
@@ -20,3 +20,4 @@ from openrazer_daemon.dbus_services.dbus_methods.accessory import *
 from openrazer_daemon.dbus_services.dbus_methods.charging_pad_chroma import *
 from openrazer_daemon.dbus_services.dbus_methods.mouse_scroll_wheel import *
 from openrazer_daemon.dbus_services.dbus_methods.argb_controller import *
+from openrazer_daemon.dbus_services.dbus_methods.wireless_mouse import *

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/wireless_mouse.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/wireless_mouse.py
@@ -1,0 +1,18 @@
+from openrazer_daemon.dbus_services import endpoint
+
+
+@endpoint('razer.device.misc', 'getSleepState', out_sig='y')
+def get_sleep_state(self):
+    """
+    Get the device's current sleep state
+
+    :return: The device's current sleep state (0 = awake, 1 = asleep, 2 = unknown)
+    :rtype: int
+    """
+    self.logger.debug("DBus call get_sleep_state")
+
+    driver_path = self.get_driver_path('sleep_state')
+
+    with open(driver_path, 'r') as driver_file:
+        return int(driver_file.read().strip())
+

--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/wireless_mouse.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/wireless_mouse.py
@@ -15,4 +15,3 @@ def get_sleep_state(self):
 
     with open(driver_path, 'r') as driver_file:
         return int(driver_file.read().strip())
-

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -17,6 +17,7 @@ from openrazer_daemon.dbus_services.service import DBusService
 import openrazer_daemon.dbus_services.dbus_methods
 from openrazer_daemon.misc import effect_sync
 from openrazer_daemon.misc.battery_notifier import BatteryManager as _BatteryManager
+from openrazer_daemon.misc.sleep_state_monitor import SleepStateMonitor as _SleepStateMonitor
 
 
 # pylint: disable=too-many-instance-attributes
@@ -70,6 +71,7 @@ class RazerDevice(DBusService):
         if additional_interfaces is not None:
             self.additional_interfaces.extend(additional_interfaces)
         self._battery_manager = None
+        self._sleep_monitor = None
 
         self.config = config
         self.persistence = persistence
@@ -323,6 +325,10 @@ class RazerDevice(DBusService):
         # Initialize battery manager if the device has support
         if 'get_battery' in self.METHODS:
             self._init_battery_manager()
+
+        # Initialize sleep state monitor
+        if 'get_sleep_state' in self.METHODS:
+            self._init_sleep_monitor()
 
         try:
             driver_mode_default = self.DRIVER_MODE
@@ -1096,6 +1102,11 @@ class RazerDevice(DBusService):
         with open(driver_path, 'wb') as driver_file:
             driver_file.write(payload)
 
+    
+    def _init_sleep_monitor(self):
+        self._sleep_monitor = _SleepStateMonitor(self, self._device_number, self.getDeviceName())
+        self._sleep_monitor.start()
+
     def _init_battery_manager(self):
         """
         Initializes the BatteryManager using the provided name
@@ -1206,6 +1217,9 @@ class RazerDevice(DBusService):
 
         if self._battery_manager:
             self._battery_manager.close()
+
+        if self._sleep_monitor:
+            self._sleep_monitor.close()
 
     def close(self):
         """

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -355,11 +355,11 @@ class RazerDevice(DBusService):
         # If the device is asleep when the daemon loads, the serial number is generated and
         # starts with UNKNOWN. Relaad the config now that it will respond with the serial number.
         if self.serial.startswith("UNKNOWN"):
-            self.logger.info("UNKNOWN serial detected upon wake.")
+            self.logger.warning("UNKNOWN serial detected upon wake.")
             # Reset device serial cache
             self._serial = None
             new_serial = self.get_serial()
-            self.logger.info(new_serial)
+            self.logger.debug("new serial %s", new_serial)
             if new_serial != self.serial:
                 self.logger.info("Serial changed to %s, reinit device.", new_serial)
                 self._reinit_callback()

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -52,7 +52,7 @@ class RazerDevice(DBusService):
 
     DEVICE_IMAGE: Optional[str] = None
 
-    def __init__(self, device_path, device_number, config, persistence, testing, additional_interfaces, additional_methods, unknown_serial_counter):
+    def __init__(self, device_path, device_number, config, persistence, testing, additional_interfaces, additional_methods, unknown_serial_counter, reinit_callback):
 
         self.logger = logging.getLogger('razer.device{0}'.format(device_number))
         self.logger.info("Initialising device.%d %s", device_number, self.__class__.__name__)
@@ -66,6 +66,7 @@ class RazerDevice(DBusService):
         # Local storage key name
         self.storage_name = "UnknownDevice"
 
+        self._reinit_callback = reinit_callback
         self._observer_list = []
         self._effect_sync_propagate_up = False
         self._disable_notifications = False
@@ -333,6 +334,61 @@ class RazerDevice(DBusService):
         if 'get_sleep_state' in self.METHODS:
             self._init_sleep_monitor()
 
+        self.get_device_config()
+
+        self.restore_dpi_poll_rate()
+        self.restore_brightness()
+        self._apply_wheel_tilt_config()
+
+        if self.config.getboolean('Startup', "restore_persistence") is True:
+            self.restore_effect()
+
+            # Some devices need setting a second time after encountering Razer Synapse on Windows
+            if self.config.getboolean('Startup', "persistence_dual_boot_quirk") is True:
+                self.logger.debug("Restoring effect persistence again (dual boot quirk)")
+                self.restore_effect()
+
+    def device_wake_callback(self):
+        """
+        Callback called when the device wakes up from sleep/powersave mode.
+        """
+        # If the device is asleep when the daemon loads, the serial number is generated and
+        # starts with UNKNOWN. Relaad the config now that it will respond with the serial number.
+        if self.serial.startswith("UNKNOWN"):
+            self.logger.info("UNKNOWN serial detected upon wake.")
+            # Reset device serial cache
+            self._serial = None
+            new_serial = self.get_serial()
+            self.logger.info(new_serial)
+            if new_serial != self.serial:
+                self.logger.info("Serial changed to %s, reinit device.", new_serial)
+                self._reinit_callback()
+                return
+
+        # Reapply driver settings
+        self.resume_device()
+
+        self._device_wake_callback()
+
+    def _device_wake_callback(self):
+        """
+        Override to implement custom wake behavior
+        """
+        pass
+
+    def device_sleep_callback(self):
+        """
+        Callback called when the device idle timer expires and the device goes into sleep/powersave mode.
+        """
+        self._device_sleep_callback()
+
+    def _device_sleep_callback(self):
+        """
+        Override to implement custom idle sleep behavior
+        """
+        pass
+
+    def get_device_config(self):
         try:
             driver_mode_default = self.DRIVER_MODE
             self.DRIVER_MODE = self.config.getboolean(f"Device:{self.serial}", "driver_mode")
@@ -355,18 +411,6 @@ class RazerDevice(DBusService):
         self.TILT_HWHEEL = _get_optional_config("tilt_hwheel", self.config.getboolean)
         self.TILT_HWHEEL_REPEAT_INTERVAL = _get_optional_config('tilt_hwheel_repeat_interval', self.config.getint)
         self.TILT_HWHEEL_REPEAT_START_DELAY = _get_optional_config('tilt_hwheel_repeat_start_delay', self.config.getint)
-
-        self.restore_dpi_poll_rate()
-        self.restore_brightness()
-        self._apply_wheel_tilt_config()
-
-        if self.config.getboolean('Startup', "restore_persistence") is True:
-            self.restore_effect()
-
-            # Some devices need setting a second time after encountering Razer Synapse on Windows
-            if self.config.getboolean('Startup', "persistence_dual_boot_quirk") is True:
-                self.logger.debug("Restoring effect persistence again (dual boot quirk)")
-                self.restore_effect()
 
     def set_horizontal_wheel_tilt(self, enabled: bool | None):
         """Sets whether horizontal wheel tlit emulating sideways scroll is enabled."""
@@ -1025,7 +1069,7 @@ class RazerDevice(DBusService):
         """
         return os.path.join(self._device_path, driver_filename)
 
-    def get_serial(self):
+    def get_serial(self, wait_count: int = 5):
         """
         Get serial number for device
 
@@ -1038,7 +1082,7 @@ class RazerDevice(DBusService):
             count = 0
             serial = ''
             while len(serial) == 0:
-                if count >= 5:
+                if count >= wait_count:
                     break
 
                 try:
@@ -1151,7 +1195,7 @@ class RazerDevice(DBusService):
             driver_file.write(payload)
 
     def _init_sleep_monitor(self):
-        self._sleep_monitor = _SleepStateMonitor(self, self._device_number, self.getDeviceName())
+        self._sleep_monitor = _SleepStateMonitor(self, self._device_number, self.getDeviceName())  # pylint: disable=no-member
         self._sleep_monitor.start()
 
     def _init_battery_manager(self):

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -351,7 +351,7 @@ class RazerDevice(DBusService):
                 return config_option
             except (configparser.NoSectionError, configparser.NoOptionError):
                 return None
-        
+
         self.TILT_HWHEEL = _get_optional_config("tilt_hwheel", self.config.getboolean)
         self.TILT_HWHEEL_REPEAT_INTERVAL = _get_optional_config('tilt_hwheel_repeat_interval', self.config.getint)
         self.TILT_HWHEEL_REPEAT_START_DELAY = _get_optional_config('tilt_hwheel_repeat_start_delay', self.config.getint)
@@ -1150,7 +1150,6 @@ class RazerDevice(DBusService):
         with open(driver_path, 'wb') as driver_file:
             driver_file.write(payload)
 
-    
     def _init_sleep_monitor(self):
         self._sleep_monitor = _SleepStateMonitor(self, self._device_number, self.getDeviceName())
         self._sleep_monitor.start()

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -358,9 +358,9 @@ class RazerDevice(DBusService):
             self.logger.warning("UNKNOWN serial detected upon wake.")
             # Reset device serial cache
             self._serial = None
-            new_serial = self.get_serial()
+            new_serial = self.get_serial(increment_unknown_counter=False)
             self.logger.debug("new serial %s", new_serial)
-            if new_serial != self.serial:
+            if not new_serial.startswith("UNKNOWN"):
                 self.logger.info("Serial changed to %s, reinit device.", new_serial)
                 self._reinit_callback()
                 return
@@ -1069,7 +1069,7 @@ class RazerDevice(DBusService):
         """
         return os.path.join(self._device_path, driver_filename)
 
-    def get_serial(self, wait_count: int = 5):
+    def get_serial(self, increment_unknown_counter=True):
         """
         Get serial number for device
 
@@ -1082,7 +1082,7 @@ class RazerDevice(DBusService):
             count = 0
             serial = ''
             while len(serial) == 0:
-                if count >= wait_count:
+                if count >= 5:
                     break
 
                 try:
@@ -1112,7 +1112,8 @@ class RazerDevice(DBusService):
                 self.logger.warning("Original value: %s" % serial)
                 vid, pid = self.get_vid_pid()
                 idx = self._unknown_serial_counter.get((vid, pid), 0)
-                self._unknown_serial_counter[(vid, pid)] = idx + 1
+                if increment_unknown_counter:
+                    self._unknown_serial_counter[(vid, pid)] = idx + 1
                 serial = "UNKNOWN_{0:04X}{1:04X}_{2:04d}".format(vid, pid, idx)
 
             self._serial = serial.replace(' ', '_')

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -42,6 +42,9 @@ class RazerDevice(DBusService):
     POLL_RATES: Optional[list[int]] = None
     DPI_MAX: Optional[int] = None
     DRIVER_MODE = False
+    TILT_HWHEEL = None
+    TILT_HWHEEL_REPEAT_INTERVAL = None
+    TILT_HWHEEL_REPEAT_START_DELAY = None
 
     WAVE_DIRS = (1, 2)
 
@@ -341,8 +344,21 @@ class RazerDevice(DBusService):
             self.logger.info('Setting device to "driver" mode. Daemon will handle special functionality')
             self.set_device_mode(0x03, 0x00)  # Driver mode
 
+        def _get_optional_config(name: str, config_fetcher):
+            try:
+                config_option = config_fetcher(f"Device:{self.serial}", name)
+                self.logger.info('Overriding %s with "%s" from config', name, config_option)
+                return config_option
+            except (configparser.NoSectionError, configparser.NoOptionError):
+                return None
+        
+        self.TILT_HWHEEL = _get_optional_config("tilt_hwheel", self.config.getboolean)
+        self.TILT_HWHEEL_REPEAT_INTERVAL = _get_optional_config('tilt_hwheel_repeat_interval', self.config.getint)
+        self.TILT_HWHEEL_REPEAT_START_DELAY = _get_optional_config('tilt_hwheel_repeat_start_delay', self.config.getint)
+
         self.restore_dpi_poll_rate()
         self.restore_brightness()
+        self._apply_wheel_tilt_config()
 
         if self.config.getboolean('Startup', "restore_persistence") is True:
             self.restore_effect()
@@ -351,6 +367,35 @@ class RazerDevice(DBusService):
             if self.config.getboolean('Startup', "persistence_dual_boot_quirk") is True:
                 self.logger.debug("Restoring effect persistence again (dual boot quirk)")
                 self.restore_effect()
+
+    def set_horizontal_wheel_tilt(self, enabled: bool | None):
+        if enabled is None:
+            return
+        setting_path = os.path.join(self._device_path, 'tilt_hwheel')
+        self.logger.info("Applying %s to tilt_hwheel", enabled)
+        with open(setting_path, 'wb') as tilt_file:
+            tilt_file.write(f"{int(enabled)}\n".encode('ascii'))
+
+    def set_horizontal_wheel_tilt_repeat_interval(self, value: int | None):
+        if value is None:
+            return
+        setting_path = os.path.join(self._device_path, 'tilt_repeat')
+        self.logger.info("Applying %s to tilt_repeat", value)
+        with open(setting_path, 'wb') as tilt_file:
+            tilt_file.write(f"{int(value)}\n".encode('ascii'))
+
+    def set_horizontal_wheel_tilt_repeat_delay(self, value: int | None):
+        if value is None:
+            return
+        setting_path = os.path.join(self._device_path, 'tilt_repeat_delay')
+        self.logger.info("Applying %s to tilt_repeat_delay", value)
+        with open(setting_path, 'wb') as tilt_file:
+            tilt_file.write(f"{int(value)}\n".encode('ascii'))
+
+    def _apply_wheel_tilt_config(self):
+        self.set_horizontal_wheel_tilt(self.TILT_HWHEEL)
+        self.set_horizontal_wheel_tilt_repeat_interval(self.TILT_HWHEEL_REPEAT_INTERVAL)
+        self.set_horizontal_wheel_tilt_repeat_delay(self.TILT_HWHEEL_REPEAT_START_DELAY)
 
     def send_effect_event(self, effect_name, *args):
         """
@@ -1192,6 +1237,7 @@ class RazerDevice(DBusService):
             self.logger.info('Setting device back to "driver" mode.')
             self.set_device_mode(0x03, 0x00)  # Driver mode
 
+        self._apply_wheel_tilt_config()
         self.restore_brightness()
         self._resume_device()
 

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -369,6 +369,7 @@ class RazerDevice(DBusService):
                 self.restore_effect()
 
     def set_horizontal_wheel_tilt(self, enabled: bool | None):
+        """Sets whether horizontal wheel tlit emulating sideways scroll is enabled."""
         if enabled is None:
             return
         setting_path = os.path.join(self._device_path, 'tilt_hwheel')
@@ -377,6 +378,7 @@ class RazerDevice(DBusService):
             tilt_file.write(f"{int(enabled)}\n".encode('ascii'))
 
     def set_horizontal_wheel_tilt_repeat_interval(self, value: int | None):
+        """Sets the interval between sideways scrolling while the wheel tilt is held."""
         if value is None:
             return
         setting_path = os.path.join(self._device_path, 'tilt_repeat')
@@ -385,6 +387,7 @@ class RazerDevice(DBusService):
             tilt_file.write(f"{int(value)}\n".encode('ascii'))
 
     def set_horizontal_wheel_tilt_repeat_delay(self, value: int | None):
+        """Sets the delay before starting sideways scrolling repeat."""
         if value is None:
             return
         setting_path = os.path.join(self._device_path, 'tilt_repeat_delay')

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -1926,7 +1926,6 @@ class RazerNagaV2HyperSpeedReceiver(__RazerDevice):
     DEVICE_IMAGE = "https://hybrismediaprod.blob.core.windows.net/sys-master-phoenix-images-container%2Fh4c%2Fh44%2F9451887460382%2Fnaga-v2-hyperspeed-500x500.png"
 
     DPI_MAX = 30000
-    DRIVER_MODE = True
 
 
 class RazerViperV3HyperSpeed(__RazerDevice):

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -1921,7 +1921,7 @@ class RazerNagaV2HyperSpeedReceiver(__RazerDevice):
     HAS_MATRIX = False
     METHODS = ['get_device_type_mouse', 'max_dpi', 'get_dpi_xy', 'set_dpi_xy', 'get_dpi_stages', 'set_dpi_stages',
                'get_poll_rate', 'set_poll_rate',
-               'get_battery', 'is_charging', 'get_idle_time', 'set_idle_time', 'get_low_battery_threshold', 'set_low_battery_threshold']
+               'get_battery', 'is_charging', 'get_sleep_state', 'get_idle_time', 'set_idle_time', 'get_low_battery_threshold', 'set_low_battery_threshold']
 
     DEVICE_IMAGE = "https://hybrismediaprod.blob.core.windows.net/sys-master-phoenix-images-container%2Fh4c%2Fh44%2F9451887460382%2Fnaga-v2-hyperspeed-500x500.png"
 

--- a/daemon/openrazer_daemon/hardware/mouse.py
+++ b/daemon/openrazer_daemon/hardware/mouse.py
@@ -1926,6 +1926,7 @@ class RazerNagaV2HyperSpeedReceiver(__RazerDevice):
     DEVICE_IMAGE = "https://hybrismediaprod.blob.core.windows.net/sys-master-phoenix-images-container%2Fh4c%2Fh44%2F9451887460382%2Fnaga-v2-hyperspeed-500x500.png"
 
     DPI_MAX = 30000
+    DRIVER_MODE = True
 
 
 class RazerViperV3HyperSpeed(__RazerDevice):

--- a/daemon/openrazer_daemon/misc/sleep_state_monitor.py
+++ b/daemon/openrazer_daemon/misc/sleep_state_monitor.py
@@ -14,8 +14,6 @@ class SleepState(Enum):
     UNKNOWN = 2
 
 
-
-
 class SleepStateMonitor(threading.Thread):
     """
     Thread to watch sleep state
@@ -51,12 +49,12 @@ class SleepStateMonitor(threading.Thread):
         :type value: bool
         """
         self._shutdown = value
-    
+
     def close(self):
         if not self._shutdown:
             self._logger.debug("Closing sleep state monitor")
-            self.shutdown=True
-            self.join(timeout = 2)
+            self.shutdown = True
+            self.join(timeout=2)
             if self.is_alive():
                 self._logger.error("Failed to stop sleep state monitoring for %s.", self._device_name)
 

--- a/daemon/openrazer_daemon/misc/sleep_state_monitor.py
+++ b/daemon/openrazer_daemon/misc/sleep_state_monitor.py
@@ -71,7 +71,7 @@ class SleepStateMonitor(threading.Thread):
             if self.state != new_state:
                 self.state = new_state
                 self._logger.info(
-                    "Sleep state for %s updated to %s", self._device_name, self.state
+                    "Sleep state for %s updated to %s", self._device_name, self.state.name
                 )
                 if new_state == SleepState.AWAKE:
                     self.parent.resume_device()

--- a/daemon/openrazer_daemon/misc/sleep_state_monitor.py
+++ b/daemon/openrazer_daemon/misc/sleep_state_monitor.py
@@ -21,17 +21,19 @@ class SleepStateMonitor(threading.Thread):
 
     def __init__(self, parent: "RazerDevice", device_id: str, device_name: str):
         super().__init__()
+        self.parent: "RazerDevice" = parent
         self._logger = logging.getLogger(
             "razer.device{0}.sleepmonitor".format(device_id)
         )
 
         self.interval = 0.1
-        self.state = SleepState.UNKNOWN
+        try:
+            self.state = SleepState(self.parent.getSleepState())
+        except Exception:
+            self.state = SleepState.UNKNOWN
 
         self._shutdown = False
         self._device_name = device_name
-
-        self.parent: "RazerDevice" = parent
 
     @property
     def shutdown(self):
@@ -64,14 +66,19 @@ class SleepStateMonitor(threading.Thread):
         """
 
         while not self._shutdown:
-            new_state = SleepState(self.parent.getSleepState())
-            if self.state != new_state:
-                self.state = new_state
-                self._logger.info(
-                    "Sleep state for %s updated to %s", self._device_name, self.state.name
-                )
-                if new_state == SleepState.AWAKE:
-                    self.parent.resume_device()
+            try:
+                new_state = SleepState(self.parent.getSleepState())
+                if self.state != new_state:
+                    self.state = new_state
+                    self._logger.info(
+                        "Sleep state for %s updated to %s", self._device_name, self.state.name
+                    )
+                    if new_state == SleepState.AWAKE:
+                        self.parent.device_wake_callback()
+                    elif new_state == SleepState.ASLEEP:
+                        self.parent.device_sleep_callback()
+            except Exception as exc:
+                self._logger.warning("Exception in sleep polling. %s", str(exc))
             time.sleep(self.interval)
 
         self._logger.debug("Shutting down Sleep State Monitor")

--- a/daemon/openrazer_daemon/misc/sleep_state_monitor.py
+++ b/daemon/openrazer_daemon/misc/sleep_state_monitor.py
@@ -1,0 +1,80 @@
+import logging
+import threading
+import time
+import typing
+from enum import Enum
+
+if typing.TYPE_CHECKING:
+    from openrazer_daemon.hardware.device_base import RazerDevice
+
+
+class SleepState(Enum):
+    AWAKE = 0
+    ASLEEP = 1
+    UNKNOWN = 2
+
+
+
+
+class SleepStateMonitor(threading.Thread):
+    """
+    Thread to watch sleep state
+    """
+
+    def __init__(self, parent: "RazerDevice", device_id: str, device_name: str):
+        super().__init__()
+        self._logger = logging.getLogger(
+            "razer.device{0}.sleepmonitor".format(device_id)
+        )
+
+        self.interval = 0.1
+        self.state = SleepState.UNKNOWN
+
+        self._shutdown = False
+        self._device_name = device_name
+
+        # Could save reference to parent but only need battery level function
+        self.parent: "RazerDevice" = parent
+
+    @property
+    def shutdown(self):
+        """
+        Get the shutdown flag
+        """
+        return self._shutdown
+
+    @shutdown.setter
+    def shutdown(self, value):
+        """
+        Set the shutdown flag
+
+        :param value: Shutdown
+        :type value: bool
+        """
+        self._shutdown = value
+    
+    def close(self):
+        if not self._shutdown:
+            self._logger.debug("Closing sleep state monitor")
+            self.shutdown=True
+            self.join(timeout = 2)
+            if self.is_alive():
+                self._logger.error("Failed to stop sleep state monitoring for %s.", self._device_name)
+
+    def run(self):
+        """
+        Main thread function
+        """
+
+        while not self._shutdown:
+            new_state = SleepState(self.parent.getSleepState())
+            if self.state != new_state:
+                self.state = new_state
+                self._logger.info(
+                    "Sleep state for %s updated to %s", self._device_name, self.state
+                )
+                if new_state == SleepState.AWAKE:
+                    self.parent.resume_device()
+            time.sleep(self.interval)
+
+        self._logger.debug("Shutting down Sleep State Monitor")

--- a/daemon/openrazer_daemon/misc/sleep_state_monitor.py
+++ b/daemon/openrazer_daemon/misc/sleep_state_monitor.py
@@ -33,7 +33,6 @@ class SleepStateMonitor(threading.Thread):
         self._shutdown = False
         self._device_name = device_name
 
-        # Could save reference to parent but only need battery level function
         self.parent: "RazerDevice" = parent
 
     @property

--- a/daemon/resources/man/razer.conf.5
+++ b/daemon/resources/man/razer.conf.5
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "razer.conf" "5" "2026-04-18"
+.TH "razer.conf" "5" "1980-01-01"
 .PP
 .SH NAME
 .PP
@@ -78,6 +78,21 @@ Additional per-device sections can be defined with the name "Device:XXXX" where 
 \fBdriver_mode\fR \fIbool\fR
 .RS 4
 This flag specifies an override whether the device should be switched into "driver mode" (as opposed to keeping it in "device mode").\& Ideally the OpenRazer stack should support all functionality in software and support the devices being in driver mode, but that'\&s not the case for a wide variety of devices yet, especially mice.\& However some users may want to explicitly force a device into driver mode to enable some functionality like horizontal scrolling.\&
+.PP
+.RE
+\fBtilt_hwheel\fR \fIbool\fR
+.RS 4
+Enable or disable horizontal wheel tilt emulation via HWHEEL events for the device.\&
+.PP
+.RE
+\fBtilt_hwheel_repeat_interval\fR \fIint\fR
+.RS 4
+Interval in milliseconds between repeated horizontal tilt events while tilt is held.\&
+.PP
+.RE
+\fBtilt_hwheel_repeat_start_delay\fR \fIint\fR
+.RS 4
+Delay in milliseconds before repeated horizontal tilt events start after initial tilt event.\&
 .PP
 .RE
 .SH SEE ALSO

--- a/daemon/resources/man/razer.conf.5
+++ b/daemon/resources/man/razer.conf.5
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "razer.conf" "5" "1980-01-01"
+.TH "razer.conf" "5" "2026-07-01"
 .PP
 .SH NAME
 .PP

--- a/daemon/resources/man/razer.conf.5.scd
+++ b/daemon/resources/man/razer.conf.5.scd
@@ -55,6 +55,15 @@ Additional per-device sections can be defined with the name "Device:XXXX" where 
 *driver_mode* _bool_
 	This flag specifies an override whether the device should be switched into "driver mode" (as opposed to keeping it in "device mode"). Ideally the OpenRazer stack should support all functionality in software and support the devices being in driver mode, but that's not the case for a wide variety of devices yet, especially mice. However some users may want to explicitly force a device into driver mode to enable some functionality like horizontal scrolling.
 
+*tilt_hwheel* _bool_
+	Enable or disable horizontal wheel tilt emulation via HWHEEL events for the device.
+
+*tilt_hwheel_repeat_interval* _int_
+	Interval in milliseconds between repeated horizontal tilt events while tilt is held.
+
+*tilt_hwheel_repeat_start_delay* _int_
+	Delay in milliseconds before repeated horizontal tilt events start after initial tilt event.
+
 # SEE ALSO
 
 *openrazer-daemon*(8)

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -6033,10 +6033,10 @@ static void update_sleep_state(struct hid_device *hdev, u8 state)
     struct usb_device *usbdev = interface_to_usbdev(first_intf);
 
     if (!usbdev || !usbdev->actconfig)
-      return;
+        return;
     for (i = 0; i < usbdev->actconfig->desc.bNumInterfaces; i++) {
         struct usb_interface *intf = usb_ifnum_to_if(usbdev, i);
-        if (!intf) 
+        if (!intf)
             continue;
         dev = device_find_child(&intf->dev, (void *)mouse_hid_bus_type, dev_is_on_bus);
         if (!dev)
@@ -6164,7 +6164,7 @@ static int razer_raw_event(struct hid_device *hdev, struct hid_report *report, u
             hid_dbg(hdev, "sleep_state -> awake\n");
         }
     } else if (rdev->sleep_state != RAZER_MOUSE_SLEEP_STATE_AWAKE && size > 0) {
-        // Any regular report indicates active link/device. 
+        // Any regular report indicates active link/device.
         // Mainly to update state when the driver loads, but also covers other edge cases.
         update_sleep_state(hdev, RAZER_MOUSE_SLEEP_STATE_AWAKE);
     }
@@ -6405,7 +6405,7 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
         break;
     }
 
-    // Expose sleep state on all interfaces 
+    // Expose sleep state on all interfaces
     CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_sleep_state);
 
     if(dev->usb_interface_protocol == USB_INTERFACE_PROTOCOL_MOUSE

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -297,11 +297,11 @@ static ssize_t razer_attr_read_version(struct device *dev, struct device_attribu
 }
 
 /**
- * Read device file "device_sleep_state"
+ * Read device file "sleep_state"
  *
  * Returns 0 (awake), 1 (asleep), or 2 (unknown)
  */
-static ssize_t razer_attr_read_device_sleep_state(struct device *dev, struct device_attribute *attr, char *buf)
+static ssize_t razer_attr_read_sleep_state(struct device *dev, struct device_attribute *attr, char *buf)
 {
     struct razer_mouse_device *device = dev_get_drvdata(dev);
 
@@ -5787,7 +5787,7 @@ static DEVICE_ATTR(dpi_stages,                0660, razer_attr_read_dpi_stages, 
 static DEVICE_ATTR(device_type,               0440, razer_attr_read_device_type,           NULL);
 static DEVICE_ATTR(device_mode,               0660, razer_attr_read_device_mode,           razer_attr_write_device_mode);
 static DEVICE_ATTR(device_serial,             0440, razer_attr_read_device_serial,         NULL);
-static DEVICE_ATTR(device_sleep_state,        0440, razer_attr_read_device_sleep_state,    NULL);
+static DEVICE_ATTR(sleep_state,               0440, razer_attr_read_sleep_state,           NULL);
 static DEVICE_ATTR(device_idle_time,          0660, razer_attr_read_device_idle_time,      razer_attr_write_device_idle_time);
 
 static DEVICE_ATTR(scroll_mode,               0660, razer_attr_read_scroll_mode,           razer_attr_write_scroll_mode);
@@ -6406,7 +6406,7 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
     }
 
     /* Expose sleep state on all interfaces for this mouse. */
-    CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_device_sleep_state);
+    CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_sleep_state);
 
     if(dev->usb_interface_protocol == USB_INTERFACE_PROTOCOL_MOUSE
        && (expected_subclass == 0xFF || dev->usb_interface_subclass == expected_subclass)) {
@@ -7523,7 +7523,7 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
 
     dev = hid_get_drvdata(hdev);
 
-    device_remove_file(&hdev->dev, &dev_attr_device_sleep_state);
+    device_remove_file(&hdev->dev, &dev_attr_sleep_state);
 
     if(intf->cur_altsetting->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_MOUSE) {
         device_remove_file(&hdev->dev, &dev_attr_version);

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -6249,6 +6249,7 @@ static int razer_input_configured(struct hid_device *hdev,
         case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
         case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA:
         case USB_DEVICE_ID_RAZER_NAGA_EPIC_CHROMA_DOCK:
+        case USB_DEVICE_ID_RAZER_NAGA_V2_HYPERSPEED_RECEIVER:
             input_set_capability(hidinput->input, EV_REL, REL_HWHEEL);
             input_set_capability(hidinput->input, EV_REL, REL_HWHEEL_HI_RES);
             input_set_capability(hidinput->input, EV_KEY, BTN_FORWARD);
@@ -7323,6 +7324,9 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_status);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_charge_low_threshold);
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_device_idle_time);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_tilt_hwheel);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_tilt_repeat_delay);
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_tilt_repeat);
             break;
 
         case USB_DEVICE_ID_RAZER_BASILISK_V3_X_HYPERSPEED:

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -6065,6 +6065,33 @@ static int search(u8 *array, u8 value, unsigned n)
     return 0;
 }
 
+static void process_mouse_button_edges(struct razer_mouse_device *rdev, u8 *data)
+{
+    int i;
+
+    for (i = 0; i < ARRAY_SIZE(button_mappings); i++) {
+        const struct button_mapping *mapping = &button_mappings[i];
+        u8 mask = 1 << mapping->bit;
+
+        if (mapping->hwheel_value && rdev->tilt_hwheel) {
+            __s32 rel_value = mapping->hwheel_value;
+
+            if (rising_bit(rdev->button_byte, data[0], mask))
+                tilt_hwheel_start(rdev, rel_value);
+            if (falling_bit(rdev->button_byte, data[0], mask))
+                tilt_hwheel_stop(rdev);
+        } else if (edge_bit(rdev->button_byte, data[0], mask)) {
+            unsigned int code = mapping->code;
+
+            input_button_msc_scan(rdev->input, code);
+            input_report_key(rdev->input, code, !!(data[0] & mask));
+            input_sync(rdev->input);
+        }
+    }
+
+    rdev->button_byte = data[0];
+}
+
 /**
  * Raw event function
  */
@@ -6094,24 +6121,7 @@ static int razer_raw_event(struct hid_device *hdev, struct hid_report *report, u
     case USB_DEVICE_ID_RAZER_PRO_CLICK_V2_WIRELESS:
         /* Detect wheel tilt edges */
         if(intf->cur_altsetting->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_MOUSE) {
-            int i;
-            for (i = 0; i < ARRAY_SIZE(button_mappings); i++) {
-                const struct button_mapping *mapping = &button_mappings[i];
-                u8 mask = 1 << mapping->bit;
-                if (mapping->hwheel_value && rdev->tilt_hwheel) {
-                    __s32 rel_value = mapping->hwheel_value;
-                    if (rising_bit(rdev->button_byte, data[0], mask))
-                        tilt_hwheel_start(rdev, rel_value);
-                    if (falling_bit(rdev->button_byte, data[0], mask))
-                        tilt_hwheel_stop(rdev);
-                } else if (edge_bit(rdev->button_byte, data[0], mask)) {
-                    unsigned int code = mapping->code;
-                    input_button_msc_scan(rdev->input, code);
-                    input_report_key(rdev->input, code, !!(data[0] & mask));
-                    input_sync(rdev->input);
-                }
-            }
-            rdev->button_byte = data[0];
+            process_mouse_button_edges(rdev, data);
         }
 
         /* Detect buttons reported on the keyboard interface */
@@ -6134,6 +6144,12 @@ static int razer_raw_event(struct hid_device *hdev, struct hid_report *report, u
             return 1;
         }
         break;
+    case USB_DEVICE_ID_RAZER_NAGA_V2_HYPERSPEED_RECEIVER:
+        // When in device mode, this device needs the same mouse button tilt as above but also the dpi up/down from default.
+        /* Detect wheel tilt edges */
+        if(intf->cur_altsetting->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_MOUSE)
+            process_mouse_button_edges(rdev, data);
+        fallthrough;
     default:
         // The event were looking for is 16 bytes long and starts with 0x04
         if(intf->cur_altsetting->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_KEYBOARD && size == 16 && data[0] == 0x04) {

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -6405,7 +6405,7 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
         break;
     }
 
-    /* Expose sleep state on all interfaces for this mouse. */
+    // Expose sleep state on all interfaces 
     CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_sleep_state);
 
     if(dev->usb_interface_protocol == USB_INTERFACE_PROTOCOL_MOUSE

--- a/driver/razermouse_driver.c
+++ b/driver/razermouse_driver.c
@@ -27,6 +27,10 @@ MODULE_DESCRIPTION(DRIVER_DESC);
 MODULE_VERSION(DRIVER_VERSION);
 MODULE_LICENSE(DRIVER_LICENSE);
 
+#define RAZER_MOUSE_SLEEP_STATE_AWAKE 0
+#define RAZER_MOUSE_SLEEP_STATE_ASLEEP 1
+#define RAZER_MOUSE_SLEEP_STATE_UNKNOWN 2
+
 /**
  * Send report to the mouse
  */
@@ -290,6 +294,18 @@ static int orochi_2011_set_led_state(struct razer_mouse_device *device, unsigned
 static ssize_t razer_attr_read_version(struct device *dev, struct device_attribute *attr, char *buf)
 {
     return sysfs_emit(buf, "%s\n", DRIVER_VERSION);
+}
+
+/**
+ * Read device file "device_sleep_state"
+ *
+ * Returns 0 (awake), 1 (asleep), or 2 (unknown)
+ */
+static ssize_t razer_attr_read_device_sleep_state(struct device *dev, struct device_attribute *attr, char *buf)
+{
+    struct razer_mouse_device *device = dev_get_drvdata(dev);
+
+    return sysfs_emit(buf, "%u\n", device->sleep_state);
 }
 
 /**
@@ -5771,6 +5787,7 @@ static DEVICE_ATTR(dpi_stages,                0660, razer_attr_read_dpi_stages, 
 static DEVICE_ATTR(device_type,               0440, razer_attr_read_device_type,           NULL);
 static DEVICE_ATTR(device_mode,               0660, razer_attr_read_device_mode,           razer_attr_write_device_mode);
 static DEVICE_ATTR(device_serial,             0440, razer_attr_read_device_serial,         NULL);
+static DEVICE_ATTR(device_sleep_state,        0440, razer_attr_read_device_sleep_state,    NULL);
 static DEVICE_ATTR(device_idle_time,          0660, razer_attr_read_device_idle_time,      razer_attr_write_device_idle_time);
 
 static DEVICE_ATTR(scroll_mode,               0660, razer_attr_read_scroll_mode,           razer_attr_write_scroll_mode);
@@ -6004,6 +6021,37 @@ static struct usb_interface *find_intf_with_proto(struct usb_device *usbdev, u8 
 }
 
 /**
+ * Update the sleep state for all interfaces.
+ */
+static void update_sleep_state(struct hid_device *hdev, u8 state)
+{
+    int i;
+    struct device *dev;
+    struct razer_mouse_device *rdev;
+    const struct bus_type *mouse_hid_bus_type = hdev->dev.bus;
+    struct usb_interface *first_intf = to_usb_interface(hdev->dev.parent);
+    struct usb_device *usbdev = interface_to_usbdev(first_intf);
+
+    if (!usbdev || !usbdev->actconfig)
+      return;
+    for (i = 0; i < usbdev->actconfig->desc.bNumInterfaces; i++) {
+        struct usb_interface *intf = usb_ifnum_to_if(usbdev, i);
+        if (!intf) 
+            continue;
+        dev = device_find_child(&intf->dev, (void *)mouse_hid_bus_type, dev_is_on_bus);
+        if (!dev)
+            continue;
+
+        rdev = dev_get_drvdata(dev);
+        put_device(dev);
+        if (!rdev)
+            continue;
+        if (rdev->sleep_state != state)
+            rdev->sleep_state = state;
+    }
+}
+
+/**
  * Walk up the device tree from an interface to the device it is a
  * part of, then back down through the interface with protocol == MOUSE
  * to the razer_mouse_device associated with it
@@ -6100,6 +6148,27 @@ static int razer_raw_event(struct hid_device *hdev, struct hid_report *report, u
     struct usb_interface *intf = to_usb_interface(hdev->dev.parent);
     struct razer_mouse_device *rdev = hid_get_drvdata(hdev);
 
+
+    // Sleep state starts with 05090X01
+    //                              2 = sleep
+    //                              3 = awake
+    if (size == 16 && data[0] == 0x05 && data[1] == 0x09 && data[3] == 0x01) {
+        if (data[2] == 0x02) {
+            // Sleep state is reported on a different interface than the mouse itself.
+            // So apply it to all devices so we can avoid traversing the device tree
+            // every raw event, but still set the sleep state below on all activity.
+            update_sleep_state(hdev, RAZER_MOUSE_SLEEP_STATE_ASLEEP);
+            hid_dbg(hdev, "sleep_state -> asleep\n");
+        } else if (data[2] == 0x03) {
+            update_sleep_state(hdev, RAZER_MOUSE_SLEEP_STATE_AWAKE);
+            hid_dbg(hdev, "sleep_state -> awake\n");
+        }
+    } else if (rdev->sleep_state != RAZER_MOUSE_SLEEP_STATE_AWAKE && size > 0) {
+        // Any regular report indicates active link/device. 
+        // Mainly to update state when the driver loads, but also covers other edge cases.
+        update_sleep_state(hdev, RAZER_MOUSE_SLEEP_STATE_AWAKE);
+    }
+
     switch (hdev->product) {
     case USB_DEVICE_ID_RAZER_MAMBA_ELITE:
     case USB_DEVICE_ID_RAZER_NAGA_2014:
@@ -6145,7 +6214,7 @@ static int razer_raw_event(struct hid_device *hdev, struct hid_report *report, u
         }
         break;
     case USB_DEVICE_ID_RAZER_NAGA_V2_HYPERSPEED_RECEIVER:
-        // When in device mode, this device needs the same mouse button tilt as above but also the dpi up/down from default.
+        // When in driver mode, this device needs the same mouse button tilt as above but also the dpi up/down from default.
         /* Detect wheel tilt edges */
         if(intf->cur_altsetting->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_MOUSE)
             process_mouse_button_edges(rdev, data);
@@ -6279,6 +6348,7 @@ static void razer_mouse_init(struct razer_mouse_device *dev, struct hid_device *
     dev->usb_pid = usb_dev->descriptor.idProduct;
     dev->usb_interface_protocol = intf->cur_altsetting->desc.bInterfaceProtocol;
     dev->usb_interface_subclass = intf->cur_altsetting->desc.bInterfaceSubClass;
+    dev->sleep_state = RAZER_MOUSE_SLEEP_STATE_UNKNOWN;
 
     // Get a "random" integer
     get_random_bytes(&rand_serial, sizeof(unsigned int));
@@ -6334,6 +6404,9 @@ static int razer_mouse_probe(struct hid_device *hdev, const struct hid_device_id
         expected_subclass = 0x01;
         break;
     }
+
+    /* Expose sleep state on all interfaces for this mouse. */
+    CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_device_sleep_state);
 
     if(dev->usb_interface_protocol == USB_INTERFACE_PROTOCOL_MOUSE
        && (expected_subclass == 0xFF || dev->usb_interface_subclass == expected_subclass)) {
@@ -7449,6 +7522,8 @@ static void razer_mouse_disconnect(struct hid_device *hdev)
     struct usb_device *usb_dev = interface_to_usbdev(intf);
 
     dev = hid_get_drvdata(hdev);
+
+    device_remove_file(&hdev->dev, &dev_attr_device_sleep_state);
 
     if(intf->cur_altsetting->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_MOUSE) {
         device_remove_file(&hdev->dev, &dev_attr_version);

--- a/driver/razermouse_driver.h
+++ b/driver/razermouse_driver.h
@@ -153,7 +153,7 @@ struct razer_mouse_device {
     unsigned short usb_vid;
     unsigned short usb_pid;
 
-    /* 0=awake, 1=asleep, 2=unknown */
+    // 0=awake, 1=asleep, 2=unknown
     u8 sleep_state;
 
     char serial[23]; // Now storing a random serial to be used with old devices that don't support it

--- a/driver/razermouse_driver.h
+++ b/driver/razermouse_driver.h
@@ -153,6 +153,9 @@ struct razer_mouse_device {
     unsigned short usb_vid;
     unsigned short usb_pid;
 
+    /* 0=awake, 1=asleep, 2=unknown */
+    u8 sleep_state;
+
     char serial[23]; // Now storing a random serial to be used with old devices that don't support it
 
     struct {

--- a/pylib/openrazer/_fake_driver/razerabyssus1800.cfg
+++ b/pylib/openrazer/_fake_driver/razerabyssus1800.cfg
@@ -11,4 +11,5 @@ files = rw,device_mode,0x0000
         w,logo_matrix_effect_none
         w,logo_matrix_effect_on
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerabyssus2000.cfg
+++ b/pylib/openrazer/_fake_driver/razerabyssus2000.cfg
@@ -11,4 +11,5 @@ files = rw,device_mode,0x0000
         w,logo_matrix_effect_none
         w,logo_matrix_effect_on
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerabyssus2014.cfg
+++ b/pylib/openrazer/_fake_driver/razerabyssus2014.cfg
@@ -10,4 +10,5 @@ files = rw,device_mode,0x0000
         w,logo_matrix_effect_none
         w,logo_matrix_effect_on
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerabyssuselited.vaedition.cfg
+++ b/pylib/openrazer/_fake_driver/razerabyssuselited.vaedition.cfg
@@ -15,4 +15,5 @@ files = rw,device_mode,0x0000
         w,logo_matrix_effect_spectrum
         w,logo_matrix_effect_static
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerabyssusessential.cfg
+++ b/pylib/openrazer/_fake_driver/razerabyssusessential.cfg
@@ -15,4 +15,5 @@ files = rw,device_mode,0x0000
         w,logo_matrix_effect_spectrum
         w,logo_matrix_effect_static
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerabyssusv2.cfg
+++ b/pylib/openrazer/_fake_driver/razerabyssusv2.cfg
@@ -21,4 +21,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razeratherisreceiver.cfg
+++ b/pylib/openrazer/_fake_driver/razeratherisreceiver.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerbasilisk.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasilisk.cfg
@@ -23,4 +23,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_reactive
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerbasiliskessential.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskessential.cfg
@@ -18,4 +18,5 @@ files = rw,device_mode,0x0000
         w,matrix_custom_frame
         w,matrix_effect_custom
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerbasiliskmobilereceiver.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskmobilereceiver.cfg
@@ -17,4 +17,5 @@ files = r,charge_level,255
         w,matrix_effect_none
         w,matrix_effect_static
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerbasiliskmobilewired.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskmobilewired.cfg
@@ -17,4 +17,5 @@ files = r,charge_level,255
         w,matrix_effect_none
         w,matrix_effect_static
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerbasiliskultimatereceiver.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskultimatereceiver.cfg
@@ -43,6 +43,7 @@ files = w,charge_colour
         w,scroll_matrix_effect_reactive
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerbasiliskultimatewired.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskultimatewired.cfg
@@ -41,6 +41,7 @@ files = r,charge_level,255
         w,scroll_matrix_effect_reactive
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerbasiliskv2.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskv2.cfg
@@ -23,6 +23,7 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_reactive
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerbasiliskv3.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskv3.cfg
@@ -27,6 +27,7 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_wave
         rw,scroll_mode,0
         rw,scroll_smart_reel,0
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerbasiliskv335k.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskv335k.cfg
@@ -30,6 +30,7 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_wave
         rw,scroll_mode,0
         rw,scroll_smart_reel,0
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerbasiliskv3pro35kphantomgreeneditionwired.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskv3pro35kphantomgreeneditionwired.cfg
@@ -29,6 +29,7 @@ files = r,charge_level,255
         w,scroll_matrix_effect_wave
         rw,scroll_mode,0
         rw,scroll_smart_reel,0
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerbasiliskv3pro35kphantomgreeneditionwireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskv3pro35kphantomgreeneditionwireless.cfg
@@ -29,6 +29,7 @@ files = r,charge_level,255
         w,scroll_matrix_effect_wave
         rw,scroll_mode,0
         rw,scroll_smart_reel,0
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerbasiliskv3pro35kwired.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskv3pro35kwired.cfg
@@ -34,6 +34,7 @@ files = r,charge_level,255
         w,scroll_matrix_effect_wave
         rw,scroll_mode,0
         rw,scroll_smart_reel,0
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerbasiliskv3pro35kwireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskv3pro35kwireless.cfg
@@ -34,6 +34,7 @@ files = r,charge_level,255
         w,scroll_matrix_effect_wave
         rw,scroll_mode,0
         rw,scroll_smart_reel,0
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerbasiliskv3prowired.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskv3prowired.cfg
@@ -34,6 +34,7 @@ files = r,charge_level,255
         w,scroll_matrix_effect_wave
         rw,scroll_mode,0
         rw,scroll_smart_reel,0
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerbasiliskv3prowireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskv3prowireless.cfg
@@ -34,6 +34,7 @@ files = r,charge_level,255
         w,scroll_matrix_effect_wave
         rw,scroll_mode,0
         rw,scroll_smart_reel,0
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerbasiliskv3xhyperspeed.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskv3xhyperspeed.cfg
@@ -21,4 +21,5 @@ files = r,charge_level,255
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerbasiliskxhyperspeed.cfg
+++ b/pylib/openrazer/_fake_driver/razerbasiliskxhyperspeed.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razercobra.cfg
+++ b/pylib/openrazer/_fake_driver/razercobra.cfg
@@ -16,4 +16,5 @@ files = rw,device_mode,0x0000
         w,logo_matrix_effect_spectrum
         w,logo_matrix_effect_static
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razercobraprowired.cfg
+++ b/pylib/openrazer/_fake_driver/razercobraprowired.cfg
@@ -29,4 +29,5 @@ files = r,charge_level,255
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razercobraprowireless.cfg
+++ b/pylib/openrazer/_fake_driver/razercobraprowireless.cfg
@@ -29,4 +29,5 @@ files = r,charge_level,255
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadder1800.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadder1800.cfg
@@ -11,4 +11,5 @@ files = rw,device_mode,0x0000
         w,logo_matrix_effect_none
         w,logo_matrix_effect_on
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadder2000.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadder2000.cfg
@@ -17,4 +17,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_breath
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadder2013.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadder2013.cfg
@@ -17,4 +17,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_breath
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadder3.5g.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadder3.5g.cfg
@@ -13,4 +13,5 @@ files = rw,device_mode,0x0000
         rw,poll_rate,500
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadder3.5gblack.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadder3.5gblack.cfg
@@ -9,4 +9,5 @@ files = rw,device_mode,0x0000
         rw,dpi,800:800
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadder3500.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadder3500.cfg
@@ -19,4 +19,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_breath
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderchroma.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderchroma.cfg
@@ -21,4 +21,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderelite.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderelite.cfg
@@ -23,4 +23,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_reactive
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderessential.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderessential.cfg
@@ -17,4 +17,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_breath
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderessential2021.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderessential2021.cfg
@@ -13,4 +13,5 @@ files = rw,device_mode,0x0000
         w,logo_matrix_effect_none
         w,logo_matrix_effect_static
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderessentialwhiteedition.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderessentialwhiteedition.cfg
@@ -17,4 +17,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_breath
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv2.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv2.cfg
@@ -23,4 +23,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_reactive
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv2lite.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv2lite.cfg
@@ -18,4 +18,5 @@ files = rw,device_mode,0x0000
         w,matrix_custom_frame
         w,matrix_effect_custom
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv2mini.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv2mini.cfg
@@ -18,4 +18,5 @@ files = rw,device_mode,0x0000
         w,matrix_custom_frame
         w,matrix_effect_custom
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv2prowired.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv2prowired.cfg
@@ -22,4 +22,5 @@ files = r,charge_level,255
         w,matrix_custom_frame
         w,matrix_effect_custom
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv2prowireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv2prowireless.cfg
@@ -24,4 +24,5 @@ files = w,charge_colour
         w,matrix_custom_frame
         w,matrix_effect_custom
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv2xhyperspeed.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv2xhyperspeed.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv3.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv3.cfg
@@ -10,4 +10,5 @@ files = rw,device_mode,0x0000
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv3hyperspeedwired.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv3hyperspeedwired.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv3hyperspeedwireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv3hyperspeedwireless.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv3prowired.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv3prowired.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv3prowired_2.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv3prowired_2.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv3prowireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv3prowireless.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv3prowireless_2.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv3prowireless_2.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv4prowired.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv4prowired.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdeathadderv4prowireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerdeathadderv4prowireless.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerdiamondbackchroma.cfg
+++ b/pylib/openrazer/_fake_driver/razerdiamondbackchroma.cfg
@@ -17,4 +17,5 @@ files = rw,backlight_led_brightness,0
         r,firmware_version,v1.0
         w,matrix_custom_frame
         w,matrix_effect_custom
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerhyperpollingwirelessdongle.cfg
+++ b/pylib/openrazer/_fake_driver/razerhyperpollingwirelessdongle.cfg
@@ -17,4 +17,5 @@ files = r,charge_level,255
         w,hyperpolling_wireless_dongle_pair
         w,hyperpolling_wireless_dongle_unpair
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerimperator2012.cfg
+++ b/pylib/openrazer/_fake_driver/razerimperator2012.cfg
@@ -13,4 +13,5 @@ files = rw,device_mode,0x0000
         rw,poll_rate,500
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerlanceheadtournamentedition.cfg
+++ b/pylib/openrazer/_fake_driver/razerlanceheadtournamentedition.cfg
@@ -40,4 +40,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerlanceheadwired.cfg
+++ b/pylib/openrazer/_fake_driver/razerlanceheadwired.cfg
@@ -44,4 +44,5 @@ files = r,charge_level,255
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerlanceheadwireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerlanceheadwireless.cfg
@@ -46,4 +46,5 @@ files = w,charge_colour
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerlanceheadwirelessreceiver.cfg
+++ b/pylib/openrazer/_fake_driver/razerlanceheadwirelessreceiver.cfg
@@ -46,4 +46,5 @@ files = w,charge_colour
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerlanceheadwirelesswired.cfg
+++ b/pylib/openrazer/_fake_driver/razerlanceheadwirelesswired.cfg
@@ -44,4 +44,5 @@ files = r,charge_level,255
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razermamba2012wired.cfg
+++ b/pylib/openrazer/_fake_driver/razermamba2012wired.cfg
@@ -17,4 +17,5 @@ files = r,charge_level,255
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razermamba2012wireless.cfg
+++ b/pylib/openrazer/_fake_driver/razermamba2012wireless.cfg
@@ -17,4 +17,5 @@ files = r,charge_level,255
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razermambaelite.cfg
+++ b/pylib/openrazer/_fake_driver/razermambaelite.cfg
@@ -39,6 +39,7 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razermambatournamentedition.cfg
+++ b/pylib/openrazer/_fake_driver/razermambatournamentedition.cfg
@@ -17,4 +17,5 @@ files = rw,backlight_led_brightness,0
         r,firmware_version,v1.0
         w,matrix_custom_frame
         w,matrix_effect_custom
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razermambawired.cfg
+++ b/pylib/openrazer/_fake_driver/razermambawired.cfg
@@ -22,4 +22,5 @@ files = w,backlight_matrix_effect_breath
         w,matrix_custom_frame
         w,matrix_effect_custom
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razermambawireless.cfg
+++ b/pylib/openrazer/_fake_driver/razermambawireless.cfg
@@ -24,4 +24,5 @@ files = w,backlight_matrix_effect_breath
         w,matrix_custom_frame
         w,matrix_effect_custom
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razermambawirelessreceiver.cfg
+++ b/pylib/openrazer/_fake_driver/razermambawirelessreceiver.cfg
@@ -29,4 +29,5 @@ files = w,charge_colour
         w,scroll_matrix_effect_reactive
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razermambawirelesswired.cfg
+++ b/pylib/openrazer/_fake_driver/razermambawirelesswired.cfg
@@ -27,4 +27,5 @@ files = r,charge_level,255
         w,scroll_matrix_effect_reactive
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernaga.cfg
+++ b/pylib/openrazer/_fake_driver/razernaga.cfg
@@ -15,4 +15,5 @@ files = w,backlight_matrix_effect_none
         rw,poll_rate,500
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernaga2012.cfg
+++ b/pylib/openrazer/_fake_driver/razernaga2012.cfg
@@ -15,4 +15,5 @@ files = w,backlight_matrix_effect_none
         rw,poll_rate,500
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernaga2014.cfg
+++ b/pylib/openrazer/_fake_driver/razernaga2014.cfg
@@ -15,6 +15,7 @@ files = w,backlight_matrix_effect_none
         rw,poll_rate,500
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razernagachroma.cfg
+++ b/pylib/openrazer/_fake_driver/razernagachroma.cfg
@@ -29,6 +29,7 @@ files = rw,backlight_led_brightness,0
         w,scroll_matrix_effect_reactive
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razernagaepic.cfg
+++ b/pylib/openrazer/_fake_driver/razernagaepic.cfg
@@ -17,4 +17,5 @@ files = r,charge_level,255
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernagaepicchroma.cfg
+++ b/pylib/openrazer/_fake_driver/razernagaepicchroma.cfg
@@ -23,6 +23,7 @@ files = rw,backlight_led_brightness,0
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razernagaepicchromadock.cfg
+++ b/pylib/openrazer/_fake_driver/razernagaepicchromadock.cfg
@@ -23,6 +23,7 @@ files = rw,backlight_led_brightness,0
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razernagahex.cfg
+++ b/pylib/openrazer/_fake_driver/razernagahex.cfg
@@ -13,4 +13,5 @@ files = rw,device_mode,0x0000
         rw,poll_rate,500
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernagahexred.cfg
+++ b/pylib/openrazer/_fake_driver/razernagahexred.cfg
@@ -13,4 +13,5 @@ files = rw,device_mode,0x0000
         rw,poll_rate,500
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernagahexv2.cfg
+++ b/pylib/openrazer/_fake_driver/razernagahexv2.cfg
@@ -29,4 +29,5 @@ files = rw,backlight_led_brightness,0
         w,scroll_matrix_effect_reactive
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernagaleft-handededition2020.cfg
+++ b/pylib/openrazer/_fake_driver/razernagaleft-handededition2020.cfg
@@ -32,4 +32,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernagaprowired.cfg
+++ b/pylib/openrazer/_fake_driver/razernagaprowired.cfg
@@ -36,4 +36,5 @@ files = r,charge_level,255
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernagaprowireless.cfg
+++ b/pylib/openrazer/_fake_driver/razernagaprowireless.cfg
@@ -38,4 +38,5 @@ files = w,charge_colour
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernagatrinity.cfg
+++ b/pylib/openrazer/_fake_driver/razernagatrinity.cfg
@@ -11,4 +11,5 @@ files = rw,device_mode,0x0000
         rw,matrix_brightness,0
         w,matrix_effect_static
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernagav2hyperspeedreceiver.cfg
+++ b/pylib/openrazer/_fake_driver/razernagav2hyperspeedreceiver.cfg
@@ -14,4 +14,8 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
+        rw,tilt_hwheel,0
+        rw,tilt_repeat,0
+        rw,tilt_repeat_delay,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernagav2prowired.cfg
+++ b/pylib/openrazer/_fake_driver/razernagav2prowired.cfg
@@ -29,4 +29,5 @@ files = r,charge_level,255
         w,matrix_effect_spectrum
         w,matrix_effect_static
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernagav2prowireless.cfg
+++ b/pylib/openrazer/_fake_driver/razernagav2prowireless.cfg
@@ -31,4 +31,5 @@ files = w,charge_colour
         w,matrix_effect_spectrum
         w,matrix_effect_static
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razernagax.cfg
+++ b/pylib/openrazer/_fake_driver/razernagax.cfg
@@ -26,4 +26,5 @@ files = rw,device_mode,0x0000
         w,scroll_matrix_effect_spectrum
         w,scroll_matrix_effect_static
         w,scroll_matrix_effect_wave
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerorochi2011.cfg
+++ b/pylib/openrazer/_fake_driver/razerorochi2011.cfg
@@ -13,4 +13,5 @@ files = rw,device_mode,0x0000
         rw,poll_rate,500
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerorochi2013.cfg
+++ b/pylib/openrazer/_fake_driver/razerorochi2013.cfg
@@ -11,4 +11,5 @@ files = rw,device_mode,0x0000
         rw,poll_rate,500
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerorochiv2bluetooth.cfg
+++ b/pylib/openrazer/_fake_driver/razerorochiv2bluetooth.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerorochiv2receiver.cfg
+++ b/pylib/openrazer/_fake_driver/razerorochiv2receiver.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerorochiwired.cfg
+++ b/pylib/openrazer/_fake_driver/razerorochiwired.cfg
@@ -19,4 +19,5 @@ files = w,backlight_matrix_effect_breath
         rw,scroll_led_brightness,0
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerouroboros.cfg
+++ b/pylib/openrazer/_fake_driver/razerouroboros.cfg
@@ -16,4 +16,5 @@ files = r,charge_level,255
         rw,scroll_led_brightness,0
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerproclickminireceiver.cfg
+++ b/pylib/openrazer/_fake_driver/razerproclickminireceiver.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerproclickreceiver.cfg
+++ b/pylib/openrazer/_fake_driver/razerproclickreceiver.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerproclickv2verticaleditionwired.cfg
+++ b/pylib/openrazer/_fake_driver/razerproclickv2verticaleditionwired.cfg
@@ -19,4 +19,5 @@ files = r,charge_level,255
         w,matrix_effect_static
         w,matrix_effect_wave
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerproclickv2verticaleditionwireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerproclickv2verticaleditionwireless.cfg
@@ -19,4 +19,5 @@ files = r,charge_level,255
         w,matrix_effect_static
         w,matrix_effect_wave
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerproclickv2wired.cfg
+++ b/pylib/openrazer/_fake_driver/razerproclickv2wired.cfg
@@ -19,6 +19,7 @@ files = r,charge_level,255
         w,matrix_effect_static
         w,matrix_effect_wave
         rw,poll_rate,500
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerproclickv2wireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerproclickv2wireless.cfg
@@ -19,6 +19,7 @@ files = r,charge_level,255
         w,matrix_effect_static
         w,matrix_effect_wave
         rw,poll_rate,500
+        r,sleep_state,0
         rw,tilt_hwheel,0
         rw,tilt_repeat,0
         rw,tilt_repeat_delay,0

--- a/pylib/openrazer/_fake_driver/razerproclickwired.cfg
+++ b/pylib/openrazer/_fake_driver/razerproclickwired.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razertaipan.cfg
+++ b/pylib/openrazer/_fake_driver/razertaipan.cfg
@@ -13,4 +13,5 @@ files = rw,device_mode,0x0000
         rw,poll_rate,500
         w,scroll_matrix_effect_none
         w,scroll_matrix_effect_on
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerviper.cfg
+++ b/pylib/openrazer/_fake_driver/razerviper.cfg
@@ -18,4 +18,5 @@ files = rw,device_mode,0x0000
         w,matrix_custom_frame
         w,matrix_effect_custom
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerviper8khz.cfg
+++ b/pylib/openrazer/_fake_driver/razerviper8khz.cfg
@@ -16,4 +16,5 @@ files = rw,device_mode,0x0000
         w,logo_matrix_effect_spectrum
         w,logo_matrix_effect_static
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razervipermini.cfg
+++ b/pylib/openrazer/_fake_driver/razervipermini.cfg
@@ -18,4 +18,5 @@ files = rw,device_mode,0x0000
         w,matrix_custom_frame
         w,matrix_effect_custom
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerviperminisignatureeditionwired.cfg
+++ b/pylib/openrazer/_fake_driver/razerviperminisignatureeditionwired.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerviperminisignatureeditionwireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerviperminisignatureeditionwireless.cfg
@@ -15,4 +15,5 @@ files = r,charge_level,255
         r,firmware_version,v1.0
         w,hyperpolling_wireless_dongle_indicator_led_mode
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerviperultimatewired.cfg
+++ b/pylib/openrazer/_fake_driver/razerviperultimatewired.cfg
@@ -22,4 +22,5 @@ files = r,charge_level,255
         w,matrix_custom_frame
         w,matrix_effect_custom
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerviperultimatewireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerviperultimatewireless.cfg
@@ -24,4 +24,5 @@ files = w,charge_colour
         w,matrix_custom_frame
         w,matrix_effect_custom
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerviperv2prowired.cfg
+++ b/pylib/openrazer/_fake_driver/razerviperv2prowired.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerviperv2prowireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerviperv2prowireless.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerviperv3hyperspeed.cfg
+++ b/pylib/openrazer/_fake_driver/razerviperv3hyperspeed.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerviperv3prowired.cfg
+++ b/pylib/openrazer/_fake_driver/razerviperv3prowired.cfg
@@ -14,4 +14,5 @@ files = r,charge_level,255
         rw,dpi_stages,0x010320032005dc05dc
         r,firmware_version,v1.0
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/_fake_driver/razerviperv3prowireless.cfg
+++ b/pylib/openrazer/_fake_driver/razerviperv3prowireless.cfg
@@ -15,4 +15,5 @@ files = r,charge_level,255
         r,firmware_version,v1.0
         w,hyperpolling_wireless_dongle_indicator_led_mode
         rw,poll_rate,500
+        r,sleep_state,0
         r,version,1.0.0

--- a/pylib/openrazer/client/devices/__init__.py
+++ b/pylib/openrazer/client/devices/__init__.py
@@ -49,6 +49,7 @@ class RazerDevice(object):
             'brightness': self._has_feature('razer.device.lighting.brightness'),
 
             'battery': self._has_feature('razer.device.power', 'getBattery'),
+            'sleep_state': self._has_feature('razer.device.misc', 'getSleepState'),
             'idle_time': self._has_feature('razer.device.power', ('getIdleTime', 'setIdleTime')),
             'low_battery_threshold': self._has_feature('razer.device.power', ('getLowBatteryThreshold', 'setLowBatteryThreshold')),
             # Deprecated, use idle_time & low_battery_threshold
@@ -486,6 +487,20 @@ class RazerDevice(object):
         """
         if self.has('battery'):
             self._dbus_interfaces['power'].setIdleTime(idle_time)
+        else:
+            raise NotImplementedError()
+
+    def get_sleep_state(self) -> int:
+        """
+        Gets the sleep state of the device
+
+        :return: Sleep state
+                 0: Awake
+                 1: Asleep
+                 2: Unknown
+        """
+        if self.has('sleep_state'):
+            return int(self._dbus_interfaces['wireless'].getSleepState())
         else:
             raise NotImplementedError()
 

--- a/scripts/generate_fake_driver.sh
+++ b/scripts/generate_fake_driver.sh
@@ -110,6 +110,7 @@ declare -A files_metadata=(
     ["scroll_mode"]="rw;0"
     ["scroll_acceleration"]="rw;0"
     ["scroll_smart_reel"]="rw;0"
+    ["sleep_state"]="r;0"
     ["tilt_hwheel"]="rw;0"
     ["tilt_repeat"]="rw;0"
     ["tilt_repeat_delay"]="rw;0"


### PR DESCRIPTION
## Related issues
- #1143 : I don't have any other devices to test this with, so I've only implemented it for the mouse that I have. Will need testing and adding the feature to other devices.
- #2122 : Fixed for my device.
## Changes

- Implement sleep/idle state detection via the packets sent from the device on sleep and wakeup
  - My device (Hyperspeed v2 naga) sends one packet upon going to sleep, then on wake sends the wake packet, DPI packet, and the packet for the input all at once.
- Add support for disabling hwheel within the daemon via config similar to device_mode
- Add bindings for Razer Naga v2 hyperspeed wheel tilt when hwheel is disabled
- Add device reinitialization when UNKNOWN serial number is detected and the serial number has changed.

## TODO

- [x] There is an issue where the serial number isn't always detected, I think it happens if the mouse is in powersave mode when the daemon loads, but I need to research that more, may be related to #2122

## Testing
- Tested via a VM and running it on my PC. Has been running on my machine no issue for nearly 2 months now:
  - Kernel: Linux 6.18.44
  - OS: Nixos Unstable

## Example logs
```2026-07-03 17:05:34 | razer.device0.sleepmonitor     | INFO     | Sleep state for Razer Naga V2 HyperSpeed (Receiver) updated to AWAKE
2026-07-03 17:05:34 | razer.device0                  | INFO     | UNKNOWN serial detected upon wake.
2026-07-03 17:05:34 | razer.device0                  | INFO     | Serial changed to <REDACTED>, reinit device.
2026-07-03 17:05:34 | razer                          | WARNING  | Removing 0003:1532:00B4.0038
2026-07-03 17:05:34 | razer                          | INFO     | Found valid device.0: 0003:1532:00B4.0038
2026-07-03 17:05:34 | razer.device0                  | INFO     | Initialising device.0 RazerNagaV2HyperSpeedReceiver
2026-07-03 17:05:34 | razer.device0                  | INFO     | Overriding DRIVER_MODE with "True" from config (default: "False")
2026-07-03 17:05:34 | razer.device0                  | INFO     | Setting device to "driver" mode. Daemon will handle special functionality
2026-07-03 17:05:34 | razer.device0                  | INFO     | Overriding tilt_hwheel with "False" from config
2026-07-03 17:05:34 | razer.device0                  | INFO     | Applying False to tilt_hwheel

```
