### PR TITLE
razerkbd: Fix ignored lighting commands on Huntsman V3 Pro 8KHz

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -656,6 +656,21 @@ static int razer_set_device_mode(struct razer_kbd_device *device, unsigned char 
 }
 
 /**
+ * Set the active onboard profile
+ */
+static int razer_set_active_profile(struct razer_kbd_device *device, unsigned char profile)
+{
+    struct razer_report request = {0};
+    struct razer_report response = {0};
+
+    request = get_razer_report(0x05, 0x02, 0x01);
+    request.arguments[0] = profile;
+    request.transaction_id.id = 0x1F;
+
+    return razer_send_payload(device, &request, &response);
+}
+
+/**
  * Read device file "charge_level"
  *
  * Returns an integer which needs to be scaled from 0-255 -> 0-100
@@ -5800,6 +5815,16 @@ static int razer_kbd_probe(struct hid_device *hdev, const struct hid_device_id *
         // Tartarus Pro resets when it receives this command
         if (usb_dev->descriptor.idProduct != USB_DEVICE_ID_RAZER_TARTARUS_PRO) {
             err = razer_set_device_mode(dev, 0x00, 0x00);
+            if (err)
+                return err;
+        }
+
+        // The Huntsman V3 Pro 8KHz silently ignores effect and brightness
+        // commands while the read-only profile is active. Selecting profile 1,
+        // as Synapse does on startup, makes the device apply these commands
+        // again.
+        if (usb_dev->descriptor.idProduct == USB_DEVICE_ID_RAZER_HUNTSMAN_V3_PRO_8KHZ) {
+            err = razer_set_active_profile(dev, 0x01);
             if (err)
                 return err;
         }


### PR DESCRIPTION
### Problem

The Huntsman V3 Pro 8KHz (`1532:02CF`) has six onboard profile slots. OpenRazer always writes `matrix_effect_*` and `matrix_brightness` changes to profile 1 (which succeed with a success status), but if one of the other profiles are active, the changes will not show.

### Fix

A new `razer_activate_lighting_profile()` helper activates profile 1 on this keyboard (command class `0x05`, command `0x04`) before the lighting attribute handlers store an effect, so lighting changes always take a visible effect. Other profiles remain reachable via the Fn shortcuts and keep their stored lighting (although there is no support to modify lighting for any profile except profile 1).

### Testing

Verified on hardware: cycled all six slots (set 0x05/0x04, readback 0x05/0x84); confirmed each writable slot stores and displays its own lighting; confirmed the factory profile rejects lighting writes with FAIL; reproduced the factory-fresh wedge and confirmed activating profile 1 makes previously-stored lighting visible.

### Note for maintainers

The Huntsman V3 Pro (`02A6`), TKL (`02A7`), and Mini (`02B0`) might share this firmware behavior, but I only own the 8KHz, so I scoped the quirk to the tested PID only. Extending it is a one-line case addition if owners of the siblings can test.