### PR TITLE
razerkbd: don't fail probe when set_device_mode times out

### DIFF
--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -5798,10 +5798,14 @@ static int razer_kbd_probe(struct hid_device *hdev, const struct hid_device_id *
         // Set device to regular mode, not driver mode
         // When the daemon discovers the device it will instruct it to enter driver mode
         // Tartarus Pro resets when it receives this command
+        // Wireless devices that are asleep at enumeration time cannot answer this,
+        // so a failure here must not abort probe: returning early would leave the
+        // device files created above attached to a device with no driver data,
+        // and any read of them would dereference NULL.
         if (usb_dev->descriptor.idProduct != USB_DEVICE_ID_RAZER_TARTARUS_PRO) {
             err = razer_set_device_mode(dev, 0x00, 0x00);
             if (err)
-                return err;
+                hid_warn(hdev, "failed to set device mode: %d\n", err);
         }
     } else if(intf->cur_altsetting->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_KEYBOARD) {
         CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_key_super);


### PR DESCRIPTION
## Problem

`razer_kbd_probe()` creates all of its sysfs attributes before calling
`razer_set_device_mode()`, but `dev_set_drvdata(&hdev->dev, dev)` only runs
*after* the interface-protocol `if`/`else` block. Returning early on a
`set_device_mode()` error therefore leaves the already-created device files
attached to a device whose driver data is still `NULL`, so any read of e.g.
`device_type` dereferences NULL and oopses the kernel.

The attributes are mode `0440`, group `plugdev`, so an unprivileged desktop
session reading them is enough to trigger it — and `openrazer-daemon` does
exactly that on startup.

## Why wireless keyboards make this reachable

A HyperSpeed dongle enumerates whether or not the keyboard itself is awake.
If the keyboard is asleep or powered off when the dongle is plugged in — the
normal case at boot, or when switching from wired to wireless — the command
times out with `-ETIMEDOUT` and probe aborts.

## Reproduction

BlackWidow V4 Low Profile HyperSpeed, `1532:02c9`, kernel 6.8.0-136-generic.
Keyboard powered off, dongle inserted:

```
razerkbd 0003:1532:02C9.000B: Command timed out. status: 04 transaction_id.id: 9f \
  remaining_packets: 00 protocol_type: 00 data_size: 02, command_class: 00, command_id.id: 04
razerkbd 0003:1532:02C9.000B: failed to set device mode: -110
razerkbd 0003:1532:02C9.000B: input,hidraw2: USB HID v1.11 Mouse [...]
```

`-110` is `-ETIMEDOUT`. `.000B` is the control interface — the one that owns
`device_type`, `firmware_version` and every lighting attribute. Without this
patch probe returns there and that interface is left unbound with its files
over NULL drvdata.

## Fix

Setting regular mode is advisory; the daemon puts the device into driver mode
when it discovers it. Warn and continue instead, so probe completes, drvdata
is set, and a sleeping keyboard merely yields read timeouts until it wakes.

## Testing

Built and installed via DKMS on 6.8.0-136-generic, verified the running
module's `srcversion` matched the newly built one, then reproduced the
timeout above. With the patch applied:

- all 5 interfaces on `1532:02c9` bound to `razerkbd`
- `device_type` read as an unprivileged `plugdev` user returned
  `Razer BlackWidow V4 Low Profile HyperSpeed (Wireless)`
- `firmware_version` and `device_serial` also read back correctly once the
  keyboard woke
- no Oops/BUG/NULL-pointer entries in the kernel log

## Related findings (not addressed here)

While tracing the above I noticed three adjacent issues. **None of them are
changed by this PR** — this patch stays limited to the one line I could
actually reproduce and test. Recording them here so the analysis isn't lost;
happy to open separate issues or PRs for any of them if maintainers want.

**1. The daemon has the same advisory-command-treated-as-fatal pattern.**
In `openrazer_daemon/hardware/device_base.py`, `set_device_mode(0x03, 0x00)`
is called from `__init__`; the resulting `TimeoutError: [Errno 110]` escapes
the constructor and aborts device registration, so a sleeping keyboard is
dropped by the daemon even though the driver bound it correctly
(`DeviceManager().devices` comes back empty). `misc/battery_notifier.py` dies
the same way. Restarting the daemon once the keyboard is awake recovers it.
This means the kernel fix alone does not fully fix a cold wireless boot.
*Observed on hardware alongside the reproduction above.*

**2. `razeraccessory` has the same NULL-drvdata window this patch closes.**
`razeraccessory_driver.c` creates its attributes at ~L2592, but
`dev_set_drvdata(&hdev->dev, dev)` is at L2773, and there is a
`return err;` at L2767 in between. The fix there is *not* the one used here:
that comment says the device "needs to be in Driver mode just to function",
so downgrading the error to a warning would leave a non-functional device
silently bound. Reordering `dev_set_drvdata()` above the attribute creation
would be the appropriate change.

**3. The probe failure path can leave attributes over freed memory.**
In all four drivers, `dev_set_drvdata(&hdev->dev, dev)` runs before the
`hid_parse()` / `hid_hw_start()` checks, and both jump to an `exit_free:`
label that is byte-identical across the drivers:

```c
exit_free:
    kfree(dev);
    return retval;
```

It frees `dev` but never removes the attributes — `device_remove_file()` is
only called from `*_disconnect()`, which the driver core does not invoke when
probe fails. The `0440 plugdev` files therefore survive a failed probe with
`drvdata` pointing at freed memory. Removing the attributes on the failure
path (or clearing `drvdata` before `kfree`) would close it.

*Caveat: unlike the timeout above, findings 2 and 3 are from reading the code
— I have not reproduced either, and a `hid_parse()` failure is far rarer than
a sleeping wireless keyboard. Worth a look, but I did not want to bundle an
untested four-driver change with a fix I could verify.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
