### PR TITLE
daemon: don't let device timeouts abort registration, resume and enumeration

### DIFF
--- a/daemon/openrazer_daemon/dbus_services/dbus_methods/all.py
+++ b/daemon/openrazer_daemon/dbus_services/dbus_methods/all.py
@@ -97,11 +97,19 @@ def get_keyboard_layout(self):
 
     driver_path = self.get_driver_path('kbd_layout')
 
-    with open(driver_path, 'r') as driver_file:
-        try:
+    try:
+        with open(driver_path, 'r') as driver_file:
             return layout_ids[driver_file.read().strip()]
-        except KeyError:
-            return "unknown"
+    except KeyError:
+        return "unknown"
+    except OSError as err:
+        # Reading this queries the device, so a wireless device that is asleep
+        # answers with ETIMEDOUT. pylib calls getKeyboardLayout() while building
+        # RazerDevice, so letting the error out breaks enumeration of every
+        # device. The layout is unknown in that case, which this method already
+        # has a defined return value for.
+        self.logger.warning('getting keyboard layout: %s', err)
+        return "unknown"
 
 
 # Functions to define a hardware class

--- a/daemon/openrazer_daemon/hardware/device_base.py
+++ b/daemon/openrazer_daemon/hardware/device_base.py
@@ -333,7 +333,16 @@ class RazerDevice(DBusService):
 
         if self.DRIVER_MODE:
             self.logger.info('Setting device to "driver" mode. Daemon will handle special functionality')
-            self.set_device_mode(0x03, 0x00)  # Driver mode
+            try:
+                self.set_device_mode(0x03, 0x00)  # Driver mode
+            except OSError as err:
+                # Wireless devices that are asleep when their dongle enumerates
+                # cannot answer this, and the write fails with ETIMEDOUT. Letting
+                # that escape __init__ aborts device registration entirely, so the
+                # device is dropped even though the driver bound it correctly.
+                # Driver mode is re-applied on resume, so warn and carry on.
+                self.logger.warning('Failed to set "driver" mode (%s). Continuing; '
+                                    'special functionality may be unavailable until resume.', err)
 
         self.restore_dpi_poll_rate()
         self.restore_brightness()
@@ -1179,7 +1188,15 @@ class RazerDevice(DBusService):
         # suspend.
         if self.DRIVER_MODE:
             self.logger.info('Setting device back to "driver" mode.')
-            self.set_device_mode(0x03, 0x00)  # Driver mode
+            try:
+                self.set_device_mode(0x03, 0x00)  # Driver mode
+            except OSError as err:
+                # A device that is asleep at unlock time cannot answer. This must
+                # not abort the rest of the resume: disable_notify and
+                # disable_persistence are set True above and are only cleared at
+                # the end of this method, so an exception here would leave the
+                # device with notifications and persistence disabled for good.
+                self.logger.warning('Failed to restore "driver" mode (%s). Continuing resume.', err)
 
         self.restore_brightness()
         self._resume_device()
@@ -1218,13 +1235,20 @@ class RazerDevice(DBusService):
             if 'get_dpi_xy' in self.METHODS:
                 dpi_func = getattr(self, "getDPI", None)
                 if dpi_func is not None:
-                    self.dpi = dpi_func()
+                    try:
+                        self.dpi = dpi_func()
+                    except OSError:
+                        # A sleeping wireless device cannot answer. Keep the stored
+                        # value rather than aborting close() and leaking resources.
+                        self.logger.exception("Failed to read DPI while closing!")
 
             if self.DRIVER_MODE:
                 # Set back to device mode
                 try:
                     self.set_device_mode(0x00, 0x00)  # Device mode
-                except FileNotFoundError:
+                except OSError:
+                    # FileNotFoundError (device already gone) and ETIMEDOUT
+                    # (device asleep) are both expected here.
                     pass
 
             self._close()

--- a/daemon/openrazer_daemon/misc/battery_notifier.py
+++ b/daemon/openrazer_daemon/misc/battery_notifier.py
@@ -59,7 +59,20 @@ class BatteryNotifier(threading.Thread):
         now = datetime.datetime.now()
 
         if (now - self._last_notify_time).seconds > self.frequency:
-            battery_level = self._get_battery_func()
+            try:
+                battery_level = self._get_battery_func()
+            except OSError as err:
+                # Reading charge_level from a sleeping wireless device fails with
+                # ETIMEDOUT. run() has no exception handling around this call, so
+                # letting it escape kills the notifier thread for the rest of the
+                # daemon's lifetime. Skip this round and retry on the next tick;
+                # _last_notify_time is deliberately not updated.
+                self._logger.debug("Failed to read battery level (%s), will retry.", err)
+                # Same throttle as the bogus-value path below, so a device that
+                # stays asleep is not polled in a tight loop.
+                time.sleep(10)
+                return
+
             battery_percent = round(battery_level)
 
             # Sometimes due to various issues we don't get the percentage correctly.


### PR DESCRIPTION
## Problem

A wireless device whose dongle enumerates while the device itself is asleep
cannot answer commands, so reads and writes of its sysfs attributes fail with
`ETIMEDOUT`. Several call sites let that escape into code paths that were never
written to fail, with consequences well out of proportion to a transient
timeout.

**1. Device registration is aborted entirely.**
`RazerDevice.__init__()` calls `set_device_mode(0x03, 0x00)` to enter driver
mode. The exception escapes the constructor, so the device is dropped even
though the kernel driver bound it correctly:

```
File "openrazer_daemon/hardware/device_base.py", line 336, in __init__
  self.set_device_mode(0x03, 0x00)  # Driver mode
File "openrazer_daemon/hardware/device_base.py", line 1047, in set_device_mode
  with open(device_mode_path, 'wb') as mode_file:
TimeoutError: [Errno 110] Connection timed out
```

`DeviceManager().devices` then comes back empty, and only a daemon restart with
the device awake recovers it.

**2. Resume leaves the device permanently degraded.**
The screensaver-resume path sets `disable_notify` and `disable_persistence` to
`True` on entry and only clears them at the end. An exception from
`set_device_mode()` between the two leaves both disabled for the rest of the
session.

**3. `close()` leaks resources.**
It reads DPI before shutting down; an exception there skips `_close()` and
leaves `_is_closed` unset. The `set_device_mode()` call below it caught only
`FileNotFoundError`, letting `ETIMEDOUT` through.

**4. The battery notifier thread dies for good.**
`BatteryNotifier.notify_battery()` reads `charge_level` from its worker thread.
`run()` has no exception handling around it, so one timeout ends battery
notifications for the daemon's whole lifetime.

**5. Enumeration of every device fails, not just the sleeping one.**
`get_keyboard_layout()` reads `kbd_layout`, which queries the device. `pylib`
calls `getKeyboardLayout()` eagerly while constructing `RazerDevice`, so the
timeout propagates out of `DeviceManager().devices` and no device can be listed:

```
File "openrazer_daemon/dbus_services/dbus_methods/all.py", line 102, in get_keyboard_layout
  return layout_ids[driver_file.read().strip()]
TimeoutError: [Errno 110] Connection timed out
```

The method already maps an unrecognised layout id to `"unknown"` and documents
that as a valid return value, so it now returns the same when the device cannot
be reached, and logs why.

## Fix

Setting driver mode is advisory — it is re-applied on resume — and a battery
reading can simply be retried. Handle `OSError` at each site and carry on.
`OSError` also subsumes the `FileNotFoundError` that `close()` already caught,
so a device that has genuinely gone away is still handled there.

The battery path deliberately does not update `_last_notify_time` and reuses the
same 10 s throttle as the existing bogus-value branch, so a device that stays
asleep is not polled in a tight loop.

## Testing

Reproduced on a BlackWidow V4 Low Profile HyperSpeed (`1532:02c9`), kernel
6.8.0-136-generic, by powering the keyboard off with the dongle still connected
and restarting the daemon.

Before: `device count: 0`, with the traceback above.

After: registration completes and the new warning is logged —

```
razer.device0 | WARNING | Failed to set "driver" mode ([Errno 110] Connection
timed out). Continuing; special functionality may be unavailable until resume.
```

The device object then survives and becomes fully usable as soon as the keyboard
wakes, with no daemon restart needed.

## Notes

Reading `firmware_version` from a sleeping device still raises, which is correct
— but `pylib` used to call `getFirmware()` eagerly in `RazerDevice.__init__()`,
so that timeout broke enumeration for every device. That is already fixed on
master by 847d96fc ("pylib: Make getFirmware() call lazy"); this PR needs it to
be present for enumeration to survive a sleeping device.

Related: the kernel-side half of this, where the same advisory command aborted
`razer_kbd_probe()` and left plugdev-readable sysfs attributes over NULL
drvdata, is #2866.

### Known follow-up, not addressed here

With these fixes a device that is asleep at daemon start now registers, but it
does so under a *generated* serial, because `get_serial()` exhausts its five
retries and falls back:

```
/org/razer/device/UNKNOWN_153202C9_0000     (instead of IO2529F82500955)
```

`_serial` is then cached for the lifetime of the object, so per-device config
sections (`[Device:XXXX]`) and persisted effects silently do not match. There is
already a `TODO` on this in `device_base.py`:

```python
# TODO raise exception if serial can't be got and handle during device add
```

Restarting the daemon once the device is awake restores the correct serial. I
have deliberately left this alone: deferring device-add until a valid serial is
available reshapes the DBus object-path lifecycle, which is a much larger change
than this PR, and I would not want to bundle it with fixes I can reproduce and
verify. Worth noting that these fixes change the failure from "device dropped
entirely" to "device present but misidentified" — better, but not yet correct.

Two further observations from testing, both pre-existing and neither touched
here: after a sleep/wake cycle the driver can match a late reply to the wrong
request (`Response doesn't match request`, with the serial visible in the
params), which yields empty serials and bogus values such as firmware `v0.0`;
and `restore_brightness()`/`restore_dpi_poll_rate()` log full tracebacks via
`logger.exception()` for errors they handle, which reads alarmingly in the
journal for what is a handled timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
