### PR TITLE
Add logo toggle for Razer Blade Pro Early 2020

### DIFF
--- a/daemon/openrazer_daemon/hardware/keyboards.py
+++ b/daemon/openrazer_daemon/hardware/keyboards.py
@@ -1823,7 +1823,7 @@ class RazerBladeProEarly2020(_RippleKeyboard):
     USB_PID = 0x0256
     HAS_MATRIX = True
     MATRIX_DIMS = [6, 16]
-    METHODS = ['get_device_type_keyboard', 'set_wave_effect', 'set_static_effect', 'set_spectrum_effect',
+    METHODS = ['get_device_type_keyboard', 'get_logo_active', 'set_logo_active', 'set_wave_effect', 'set_static_effect', 'set_spectrum_effect',
                'set_reactive_effect', 'set_none_effect', 'set_custom_effect', 'set_key_row',
                'set_ripple_effect', 'set_ripple_effect_random_colour']
 

--- a/driver/razerkbd_driver.c
+++ b/driver/razerkbd_driver.c
@@ -5753,6 +5753,7 @@ static int razer_kbd_probe(struct hid_device *hdev, const struct hid_device_id *
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_static);          // Static effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_effect_custom);          // Custom effect
             CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_matrix_custom_frame);           // Set LED matrix
+            CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_logo_led_state);                // Enable/Disable the logo
             break;
 
         case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:
@@ -6300,6 +6301,7 @@ static void razer_kbd_disconnect(struct hid_device *hdev)
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_static);          // Static effect
             device_remove_file(&hdev->dev, &dev_attr_matrix_effect_custom);          // Custom effect
             device_remove_file(&hdev->dev, &dev_attr_matrix_custom_frame);           // Set LED matrix
+            device_remove_file(&hdev->dev, &dev_attr_logo_led_state);                // Enable/Disable the logo
             break;
 
         case USB_DEVICE_ID_RAZER_BLACKWIDOW_CHROMA:

--- a/pylib/openrazer/_fake_driver/razerbladeproearly2020.cfg
+++ b/pylib/openrazer/_fake_driver/razerbladeproearly2020.cfg
@@ -8,6 +8,7 @@ files = rw,device_mode,0x0000
         r,device_type,%(name)s
         r,firmware_version,v1.0
         r,kbd_layout,01
+        rw,logo_led_state,0
         rw,matrix_brightness,0
         w,matrix_custom_frame
         w,matrix_effect_custom


### PR DESCRIPTION
The Razer Blade Pro Early 2020 (`1532:0256`) does not expose `logo_led_state`, so the lid logo cannot be controlled through OpenRazer.

Expose the existing logo state interface for this device and add the corresponding daemon methods.

Tested on a Razer Blade Pro 17 Early 2020 (`RZ09-0329`, 4K 120 Hz). The lid logo switches on and off correctly.

Supersedes #2895, which was closed when its branch was deleted.